### PR TITLE
Fixed disable horizontal swipe and show embedded name

### DIFF
--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/models/OnDeviceBlacklistPath.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/models/OnDeviceBlacklistPath.kt
@@ -3,10 +3,7 @@ package it.vfsfitvnm.vimusic.models
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-@Entity("OnDeviceBlacklist")
 data class OnDeviceBlacklistPath(
-    @PrimaryKey(autoGenerate = true)
-    val id: Int? = null,
     val path: String
 ) {
     fun test(relativePath: String): Boolean {

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/ondevice/DeviceListSongs.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/ondevice/DeviceListSongs.kt
@@ -654,7 +654,6 @@ fun Context.musicFilesAsFlow(sortBy: OnDeviceSongSortBy, order: SortOrder, conte
                             val exclude = blacklist.contains(relativePath)
 
                             if (!exclude) {
-                                println(relativePath)
                                 val albumUri = ContentUris.withAppendedId(albumUriBase, albumId)
                                 val durationText =
                                     duration.milliseconds.toComponents { minutes, seconds, _ ->

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/ondevice/DeviceListSongs.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/ondevice/DeviceListSongs.kt
@@ -6,6 +6,7 @@ import android.app.Activity
 import android.content.ContentUris
 import android.content.Context
 import android.content.pm.PackageManager
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
@@ -642,16 +643,22 @@ fun Context.musicFilesAsFlow(sortBy: OnDeviceSongSortBy, order: SortOrder, conte
                     val albumIdIdx = cursor.getColumnIndex(MediaStore.Audio.Media.ALBUM_ID)
                     val relativePathIdx = cursor.getColumnIndex(MediaStore.Audio.Media.RELATIVE_PATH)
                     val blacklist = OnDeviceBlacklist(context = context)
+                    val metadataRetriever = MediaMetadataRetriever()
+
 
                     buildList {
                         while (cursor.moveToNext()) {
                             val id = cursor.getLong(idIdx)
-                            val name = cursor.getString(nameIdx)
+                            val songUri = ContentUris.withAppendedId(collection, id)
+                            metadataRetriever.setDataSource(context, songUri)
+                            val trackName = metadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE)
+                            val name = cursor.getString(nameIdx).substringBeforeLast(".")
                             val duration = cursor.getInt(durationIdx)
                             val artist = cursor.getString(artistIdx)
                             val albumId = cursor.getLong(albumIdIdx)
                             val relativePath = cursor.getString(relativePathIdx)
                             val exclude = blacklist.contains(relativePath)
+                            println(trackName)
 
                             if (!exclude) {
                                 val albumUri = ContentUris.withAppendedId(albumUriBase, albumId)
@@ -662,7 +669,7 @@ fun Context.musicFilesAsFlow(sortBy: OnDeviceSongSortBy, order: SortOrder, conte
                                 add(
                                     Song(
                                         id = "$LOCAL_KEY_PREFIX$id",
-                                        title = name.substringBeforeLast("."),
+                                        title = trackName ?: name,
                                         artistsText = artist,
                                         durationText = durationText,
                                         thumbnailUrl = albumUri.toString()

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Player.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Player.kt
@@ -765,12 +765,16 @@ fun Player(
                                 when (direction) {
                                     0 -> {
                                         //right swipe code here
-                                        binder.player.seekToPreviousMediaItem()
+                                        if (!disablePlayerHorizontalSwipe) {
+                                            binder.player.seekToPreviousMediaItem()
+                                        }
                                         //Log.d("mediaItem","Swipe to RIGHT")
                                     }
                                     1 -> {
                                         // left swipe code here
-                                        binder.player.forceSeekToNext()
+                                        if (!disablePlayerHorizontalSwipe) {
+                                            binder.player.forceSeekToNext()
+                                        }
                                         //Log.d("mediaItem","Swipe to LEFT")
                                     }
 


### PR DESCRIPTION
Just fixed disabling horizontal swipe in the player and implemented shoring embedded name in the on device songs. If no embedded name is found, the file name is displayed as before.