### PR TITLE
Better showing of pinned playlists in Add to playlist

### DIFF
--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/components/themed/AlbumsItemMenu.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/components/themed/AlbumsItemMenu.kt
@@ -67,6 +67,7 @@ import it.vfsfitvnm.vimusic.service.isLocal
 import it.vfsfitvnm.vimusic.transaction
 import it.vfsfitvnm.vimusic.ui.items.AlbumItem
 import it.vfsfitvnm.vimusic.ui.items.SongItem
+import it.vfsfitvnm.vimusic.ui.screens.home.PINNED_PREFIX
 import it.vfsfitvnm.vimusic.ui.styling.Dimensions
 import it.vfsfitvnm.vimusic.ui.styling.LocalAppearance
 import it.vfsfitvnm.vimusic.ui.styling.px
@@ -105,7 +106,7 @@ fun AlbumsItemMenu(
     onAddToPlaylist: ((PlaylistPreview) -> Unit)? = null,
 
 ) {
-    val (colorPalette) = LocalAppearance.current
+    val (colorPalette, typography) = LocalAppearance.current
     val density = LocalDensity.current
 
     var isViewingPlaylists by remember {
@@ -133,6 +134,14 @@ fun AlbumsItemMenu(
             val playlistPreviews by remember {
                 Database.playlistPreviews(sortBy, sortOrder)
             }.collectAsState(initial = emptyList(), context = Dispatchers.IO)
+
+            val pinnedPlaylists = playlistPreviews.filter {
+                it.playlist.name.startsWith(PINNED_PREFIX, 0, true)
+            }
+
+            val unpinnedPlaylists = playlistPreviews.filter {
+                !it.playlist.name.startsWith(PINNED_PREFIX, 0, true)
+            }
 
             var isCreatingNewPlaylist by rememberSaveable {
                 mutableStateOf(false)
@@ -188,17 +197,47 @@ fun AlbumsItemMenu(
                     }
                 }
 
-                onAddToPlaylist?.let { onAddToPlaylist ->
-                    playlistPreviews.forEach { playlistPreview ->
-                        MenuEntry(
-                            icon = R.drawable.add_in_playlist,
-                            text = playlistPreview.playlist.name,
-                            secondaryText = "${playlistPreview.songCount} " + stringResource(R.string.songs),
-                            onClick = {
-                                onDismiss()
-                                onAddToPlaylist(PlaylistPreview(playlistPreview.playlist, playlistPreview.songCount))
-                            }
-                        )
+                if (pinnedPlaylists.isNotEmpty()) {
+                    BasicText(
+                        text = stringResource(R.string.pinned_playlists),
+                        style = typography.m.semiBold,
+                        modifier = modifier.padding(start = 20.dp, top = 5.dp)
+                    )
+
+                    onAddToPlaylist?.let { onAddToPlaylist ->
+                        pinnedPlaylists.forEach { playlistPreview ->
+                            MenuEntry(
+                                icon = R.drawable.add_in_playlist,
+                                text = playlistPreview.playlist.name.substringAfter(PINNED_PREFIX),
+                                secondaryText = "${playlistPreview.songCount} " + stringResource(R.string.songs),
+                                onClick = {
+                                    onDismiss()
+                                    onAddToPlaylist(PlaylistPreview(playlistPreview.playlist, playlistPreview.songCount))
+                                }
+                            )
+                        }
+                    }
+                }
+
+                if (unpinnedPlaylists.isNotEmpty()) {
+                    BasicText(
+                        text = stringResource(R.string.playlists),
+                        style = typography.m.semiBold,
+                        modifier = modifier.padding(start = 20.dp, top = 5.dp)
+                    )
+
+                    onAddToPlaylist?.let { onAddToPlaylist ->
+                        unpinnedPlaylists.forEach { playlistPreview ->
+                            MenuEntry(
+                                icon = R.drawable.add_in_playlist,
+                                text = playlistPreview.playlist.name.substringAfter(PINNED_PREFIX),
+                                secondaryText = "${playlistPreview.songCount} " + stringResource(R.string.songs),
+                                onClick = {
+                                    onDismiss()
+                                    onAddToPlaylist(PlaylistPreview(playlistPreview.playlist, playlistPreview.songCount))
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/components/themed/MediaItemMenu.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/components/themed/MediaItemMenu.kt
@@ -81,6 +81,7 @@ import it.vfsfitvnm.vimusic.ui.items.ArtistItem
 import it.vfsfitvnm.vimusic.ui.items.SongItem
 import it.vfsfitvnm.vimusic.ui.screens.albumRoute
 import it.vfsfitvnm.vimusic.ui.screens.artistRoute
+import it.vfsfitvnm.vimusic.ui.screens.home.PINNED_PREFIX
 import it.vfsfitvnm.vimusic.ui.styling.Dimensions
 import it.vfsfitvnm.vimusic.ui.styling.LocalAppearance
 import it.vfsfitvnm.vimusic.ui.styling.favoritesIcon
@@ -381,7 +382,7 @@ fun MediaItemMenu(
     onRemoveFromQuickPicks: (() -> Unit)? = null,
     onShare: () -> Unit
 ) {
-    val (colorPalette) = LocalAppearance.current
+    val (colorPalette, typography) = LocalAppearance.current
     val density = LocalDensity.current
 
     val binder = LocalPlayerServiceBinder.current
@@ -503,6 +504,14 @@ fun MediaItemMenu(
                 Database.playlistPreviews(sortBy, sortOrder)
             }.collectAsState(initial = emptyList(), context = Dispatchers.IO)
 
+            val pinnedPlaylists = playlistPreviews.filter {
+                it.playlist.name.startsWith(PINNED_PREFIX, 0, true)
+            }
+
+            val unpinnedPlaylists = playlistPreviews.filter {
+                !it.playlist.name.startsWith(PINNED_PREFIX, 0, true)
+            }
+
             var isCreatingNewPlaylist by rememberSaveable {
                 mutableStateOf(false)
             }
@@ -563,17 +572,47 @@ fun MediaItemMenu(
                     }
                 }
 
-                onAddToPlaylist?.let { onAddToPlaylist ->
-                    playlistPreviews.forEach { playlistPreview ->
-                        MenuEntry(
-                            icon = R.drawable.add_in_playlist,
-                            text = playlistPreview.playlist.name,
-                            secondaryText = "${playlistPreview.songCount} " + stringResource(R.string.songs),
-                            onClick = {
-                                onDismiss()
-                                onAddToPlaylist(playlistPreview.playlist, playlistPreview.songCount)
-                            }
-                        )
+                if (pinnedPlaylists.isNotEmpty()) {
+                    BasicText(
+                        text = stringResource(R.string.pinned_playlists),
+                        style = typography.m.semiBold,
+                        modifier = modifier.padding(start = 20.dp, top = 5.dp)
+                    )
+
+                    onAddToPlaylist?.let { onAddToPlaylist ->
+                        pinnedPlaylists.forEach { playlistPreview ->
+                            MenuEntry(
+                                icon = R.drawable.add_in_playlist,
+                                text = playlistPreview.playlist.name.substringAfter(PINNED_PREFIX),
+                                secondaryText = "${playlistPreview.songCount} " + stringResource(R.string.songs),
+                                onClick = {
+                                    onDismiss()
+                                    onAddToPlaylist(playlistPreview.playlist, playlistPreview.songCount)
+                                }
+                            )
+                        }
+                    }
+                }
+
+                if (unpinnedPlaylists.isNotEmpty()) {
+                    BasicText(
+                        text = stringResource(R.string.playlists),
+                        style = typography.m.semiBold,
+                        modifier = modifier.padding(start = 20.dp, top = 5.dp)
+                    )
+
+                    onAddToPlaylist?.let { onAddToPlaylist ->
+                        unpinnedPlaylists.forEach { playlistPreview ->
+                            MenuEntry(
+                                icon = R.drawable.add_in_playlist,
+                                text = playlistPreview.playlist.name,
+                                secondaryText = "${playlistPreview.songCount} " + stringResource(R.string.songs),
+                                onClick = {
+                                    onDismiss()
+                                    onAddToPlaylist(playlistPreview.playlist, playlistPreview.songCount)
+                                }
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/components/themed/PlaylistsItemMenu.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/components/themed/PlaylistsItemMenu.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -45,6 +46,7 @@ import it.vfsfitvnm.vimusic.models.PlaylistPreview
 import it.vfsfitvnm.vimusic.query
 import it.vfsfitvnm.vimusic.transaction
 import it.vfsfitvnm.vimusic.ui.items.PlaylistItem
+import it.vfsfitvnm.vimusic.ui.screens.home.PINNED_PREFIX
 import it.vfsfitvnm.vimusic.ui.styling.Dimensions
 import it.vfsfitvnm.vimusic.ui.styling.LocalAppearance
 import it.vfsfitvnm.vimusic.ui.styling.px
@@ -52,6 +54,7 @@ import it.vfsfitvnm.vimusic.utils.addNext
 import it.vfsfitvnm.vimusic.utils.playlistSortByKey
 import it.vfsfitvnm.vimusic.utils.playlistSortOrderKey
 import it.vfsfitvnm.vimusic.utils.rememberPreference
+import it.vfsfitvnm.vimusic.utils.semiBold
 import kotlinx.coroutines.Dispatchers
 
 @ExperimentalTextApi
@@ -78,7 +81,7 @@ fun PlaylistsItemMenu(
     onExport: (() -> Unit)? = null,
     onImport: (() -> Unit)? = null
     ) {
-    val (colorPalette) = LocalAppearance.current
+    val (colorPalette, typography) = LocalAppearance.current
     val density = LocalDensity.current
 
     var isViewingPlaylists by remember {
@@ -109,6 +112,14 @@ fun PlaylistsItemMenu(
             val playlistPreviews by remember {
                 Database.playlistPreviews(sortBy, sortOrder)
             }.collectAsState(initial = emptyList(), context = Dispatchers.IO)
+
+            val pinnedPlaylists = playlistPreviews.filter {
+                it.playlist.name.startsWith(PINNED_PREFIX, 0, true)
+            }
+
+            val unpinnedPlaylists = playlistPreviews.filter {
+                !it.playlist.name.startsWith(PINNED_PREFIX, 0, true)
+            }
 
             var isCreatingNewPlaylist by rememberSaveable {
                 mutableStateOf(false)
@@ -164,17 +175,47 @@ fun PlaylistsItemMenu(
                     }
                 }
 
-                onAddToPlaylist?.let { onAddToPlaylist ->
-                    playlistPreviews.forEach { playlistPreview ->
-                        MenuEntry(
-                            icon = R.drawable.add_in_playlist,
-                            text = playlistPreview.playlist.name,
-                            secondaryText = "${playlistPreview.songCount} " + stringResource(R.string.songs),
-                            onClick = {
-                                onDismiss()
-                                onAddToPlaylist(PlaylistPreview(playlistPreview.playlist, playlistPreview.songCount))
-                            }
-                        )
+                if (pinnedPlaylists.isNotEmpty()) {
+                    BasicText(
+                        text = stringResource(R.string.pinned_playlists),
+                        style = typography.m.semiBold,
+                        modifier = modifier.padding(start = 20.dp, top = 5.dp)
+                    )
+
+                    onAddToPlaylist?.let { onAddToPlaylist ->
+                        pinnedPlaylists.forEach { playlistPreview ->
+                            MenuEntry(
+                                icon = R.drawable.add_in_playlist,
+                                text = playlistPreview.playlist.name.substringAfter(PINNED_PREFIX),
+                                secondaryText = "${playlistPreview.songCount} " + stringResource(R.string.songs),
+                                onClick = {
+                                    onDismiss()
+                                    onAddToPlaylist(PlaylistPreview(playlistPreview.playlist, playlistPreview.songCount))
+                                }
+                            )
+                        }
+                    }
+                }
+
+                if (unpinnedPlaylists.isNotEmpty()) {
+                    BasicText(
+                        text = stringResource(R.string.playlists),
+                        style = typography.m.semiBold,
+                        modifier = modifier.padding(start = 20.dp, top = 5.dp)
+                    )
+
+                    onAddToPlaylist?.let { onAddToPlaylist ->
+                        unpinnedPlaylists.forEach { playlistPreview ->
+                            MenuEntry(
+                                icon = R.drawable.add_in_playlist,
+                                text = playlistPreview.playlist.name,
+                                secondaryText = "${playlistPreview.songCount} " + stringResource(R.string.songs),
+                                onClick = {
+                                    onDismiss()
+                                    onAddToPlaylist(PlaylistPreview(playlistPreview.playlist, playlistPreview.songCount))
+                                }
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When you have pinned playlists and you want to add song, playlist or an album to a playlist in the add to playlist section it is showing the pinned playlists normally with the "pinned:" prefix. So I made it so that it separates pinned playlists and unpinned playlists and removes the "pinned:" prefix for the pinned playlists. If there is no pinned or unpinned playlist, their title is not shown.

## Screenshots
![2024-03-17_10-13-25](https://github.com/fast4x/RiMusic/assets/72742578/24b6e71a-a0fc-4e40-8c79-776c14d2e33a)
When there is no pinned playlist:
![2024-03-17_10-21-38](https://github.com/fast4x/RiMusic/assets/72742578/8e7490c2-f2ac-4d20-8276-e0024cdb3821)
