### PR TITLE
Removed background progress bar in the full player and fixed time in songs if is more than 1 hour

### DIFF
--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Player.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Player.kt
@@ -1026,19 +1026,6 @@ fun Player(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = containerModifier
                     .padding(top = 10.dp)
-                    .drawBehind {
-                        if (showPlayerBackgroundProgress) {
-                            drawRect(
-                                color = colorPalette.favoritesOverlay,
-                                topLeft = Offset.Zero,
-                                size = Size(
-                                    width = positionAndDuration.first.toFloat() /
-                                            positionAndDuration.second.absoluteValue * size.width,
-                                    height = size.maxDimension
-                                )
-                            )
-                        }
-                    }
                     /*
                     .pointerInput(Unit) {
                         detectHorizontalDragGestures(

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/utils/Utils.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/utils/Utils.kt
@@ -203,14 +203,12 @@ fun Uri?.thumbnail(size: Int): Uri? {
 }
 
 fun formatAsDuration(millis: Long) = DateUtils.formatElapsedTime(millis / 1000).removePrefix("0")
-fun durationToMillis(duration: String) = Duration.between(
-    LocalTime.MIN,
-    LocalTime.parse(
-        if (duration.length == 4) "0$duration"
-        else if (duration.length < 4) "00:00"
-        else duration
-    )
-).toMillis()
+fun durationToMillis(duration: String): Long {
+    val parts = duration.split(":")
+    val hours = parts[0].toLong()
+    val minutes = parts[1].toLong()
+    return hours * 3600000 + minutes * 60000
+}
 
 fun durationTextToMillis(duration: String): Long {
     return try {


### PR DESCRIPTION
# Background progress bar
I don't think that the background progress bar in the full player is necessary. Personally I don't think that anyone would use it. There is already progress bar in the player. But I really like the progress bar in the mini player.

# Time of songs
If time of songs was greater than 1 hour for example 71:54 it returns 0 milliseconds. Fixed it