### PR TITLE
Updated background progress bar settings fixed time in songs if is more than 1 hour

### DIFF
--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/MainActivity.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/MainActivity.kt
@@ -157,7 +157,7 @@ import it.vfsfitvnm.vimusic.utils.showButtonPlayerMenuKey
 import it.vfsfitvnm.vimusic.utils.showButtonPlayerShuffleKey
 import it.vfsfitvnm.vimusic.utils.showButtonPlayerSleepTimerKey
 import it.vfsfitvnm.vimusic.utils.showLikeButtonBackgroundPlayerKey
-import it.vfsfitvnm.vimusic.utils.showPlayerBackgroundProgressKey
+import it.vfsfitvnm.vimusic.utils.backgroundProgressKey
 import it.vfsfitvnm.vimusic.utils.showSearchTabKey
 import it.vfsfitvnm.vimusic.utils.showTotalTimeQueueKey
 import it.vfsfitvnm.vimusic.utils.thumbnailRoundnessKey
@@ -408,7 +408,7 @@ class MainActivity : AppCompatActivity(), PersistMapOwner {
                             navigationBarPositionKey,
                             navigationBarTypeKey,
                             showTotalTimeQueueKey,
-                            showPlayerBackgroundProgressKey -> {
+                            backgroundProgressKey -> {
                                 this@MainActivity.recreate()
                             }
 

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/enums/BackgroundProgress.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/enums/BackgroundProgress.kt
@@ -1,0 +1,7 @@
+package it.vfsfitvnm.vimusic.enums;
+
+enum class BackgroundProgress {
+    Player,
+    MiniPlayer,
+    Both
+}

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Player.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Player.kt
@@ -85,6 +85,7 @@ import it.vfsfitvnm.innertube.models.NavigationEndpoint
 import it.vfsfitvnm.vimusic.Database
 import it.vfsfitvnm.vimusic.LocalPlayerServiceBinder
 import it.vfsfitvnm.vimusic.R
+import it.vfsfitvnm.vimusic.enums.BackgroundProgress
 import it.vfsfitvnm.vimusic.enums.ColorPaletteName
 import it.vfsfitvnm.vimusic.enums.PlayerThumbnailSize
 import it.vfsfitvnm.vimusic.enums.PlayerVisualizerType
@@ -151,7 +152,7 @@ import it.vfsfitvnm.vimusic.utils.showButtonPlayerLyricsKey
 import it.vfsfitvnm.vimusic.utils.showButtonPlayerMenuKey
 import it.vfsfitvnm.vimusic.utils.showButtonPlayerShuffleKey
 import it.vfsfitvnm.vimusic.utils.showButtonPlayerSleepTimerKey
-import it.vfsfitvnm.vimusic.utils.showPlayerBackgroundProgressKey
+import it.vfsfitvnm.vimusic.utils.backgroundProgressKey
 import it.vfsfitvnm.vimusic.utils.showTotalTimeQueueKey
 import it.vfsfitvnm.vimusic.utils.shuffleQueue
 import it.vfsfitvnm.vimusic.utils.thumbnail
@@ -383,7 +384,7 @@ fun Player(
     val showButtonPlayerMenu by rememberPreference(showButtonPlayerMenuKey, false)
     val disableClosingPlayerSwipingDown by rememberPreference(disableClosingPlayerSwipingDownKey, true)
     val showTotalTimeQueue by rememberPreference(showTotalTimeQueueKey, true)
-    val showPlayerBackgroundProgress by rememberPreference(showPlayerBackgroundProgressKey, true)
+    val backgroundProgress by rememberPreference(backgroundProgressKey, BackgroundProgress.MiniPlayer)
     /*
     val playlistPreviews by remember {
         Database.playlistPreviews(PlaylistSortBy.Name, SortOrder.Ascending)
@@ -589,7 +590,7 @@ fun Player(
                     .fillMaxSize()
                     .padding(horizontalBottomPaddingValues)
                     .drawBehind {
-                        if (showPlayerBackgroundProgress) {
+                        if (backgroundProgress == BackgroundProgress.Both || backgroundProgress == BackgroundProgress.MiniPlayer) {
                             drawRect(
                                 color = colorPalette.favoritesOverlay,
                                 topLeft = Offset.Zero,
@@ -1026,6 +1027,19 @@ fun Player(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = containerModifier
                     .padding(top = 10.dp)
+                    .drawBehind {
+                        if (backgroundProgress == BackgroundProgress.Both || backgroundProgress == BackgroundProgress.Player) {
+                            drawRect(
+                                color = colorPalette.favoritesOverlay,
+                                topLeft = Offset.Zero,
+                                size = Size(
+                                    width = positionAndDuration.first.toFloat() /
+                                            positionAndDuration.second.absoluteValue * size.width,
+                                    height = size.maxDimension
+                                )
+                            )
+                        }
+                    }
                     /*
                     .pointerInput(Unit) {
                         detectHorizontalDragGestures(

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Player.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/player/Player.kt
@@ -1026,19 +1026,6 @@ fun Player(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = containerModifier
                     .padding(top = 10.dp)
-                    .drawBehind {
-                        if (showPlayerBackgroundProgress) {
-                            drawRect(
-                                color = colorPalette.favoritesOverlay,
-                                topLeft = Offset.Zero,
-                                size = Size(
-                                    width = positionAndDuration.first.toFloat() /
-                                            positionAndDuration.second.absoluteValue * size.width,
-                                    height = size.maxDimension
-                                )
-                            )
-                        }
-                    }
                     /*
                     .pointerInput(Unit) {
                         detectHorizontalDragGestures(

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/ui/screens/settings/AppearanceSettings.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.UnstableApi
 import it.vfsfitvnm.vimusic.LocalPlayerAwareWindowInsets
 import it.vfsfitvnm.vimusic.R
+import it.vfsfitvnm.vimusic.enums.BackgroundProgress
 import it.vfsfitvnm.vimusic.enums.ColorPaletteMode
 import it.vfsfitvnm.vimusic.enums.ColorPaletteName
 import it.vfsfitvnm.vimusic.enums.FontType
@@ -108,7 +109,7 @@ import it.vfsfitvnm.vimusic.utils.showFavoritesPlaylistKey
 import it.vfsfitvnm.vimusic.utils.showLikeButtonBackgroundPlayerKey
 import it.vfsfitvnm.vimusic.utils.showMyTopPlaylistKey
 import it.vfsfitvnm.vimusic.utils.showOnDevicePlaylistKey
-import it.vfsfitvnm.vimusic.utils.showPlayerBackgroundProgressKey
+import it.vfsfitvnm.vimusic.utils.backgroundProgressKey
 import it.vfsfitvnm.vimusic.utils.showPlaylistsKey
 import it.vfsfitvnm.vimusic.utils.showTotalTimeQueueKey
 import it.vfsfitvnm.vimusic.utils.thumbnailRoundnessKey
@@ -164,7 +165,7 @@ fun AppearanceSettings() {
     var showPlaylists by rememberPreference(showPlaylistsKey, true)
     var isGradientBackgroundEnabled by rememberPreference(isGradientBackgroundEnabledKey, false)
     var showTotalTimeQueue by rememberPreference(showTotalTimeQueueKey, true)
-    var showPlayerBackgroundProgress by rememberPreference(showPlayerBackgroundProgressKey, true)
+    var backgroundProgress by rememberPreference(backgroundProgressKey, BackgroundProgress.MiniPlayer)
 
     val (colorPalette, typography, thumbnailShape) = LocalAppearance.current
     var searching by rememberSaveable { mutableStateOf(false) }
@@ -353,12 +354,20 @@ fun AppearanceSettings() {
                 onCheckedChange = { isGradientBackgroundEnabled = it }
             )
 
-        if (filter.isNullOrBlank() || stringResource(R.string.show_background_progress_bar).contains(filterCharSequence,true))
-            SwitchSettingEntry(
-                title = stringResource(R.string.show_background_progress_bar),
-                text = "",
-                isChecked = showPlayerBackgroundProgress,
-                onCheckedChange = { showPlayerBackgroundProgress = it }
+        if (filter.isNullOrBlank() || stringResource(R.string.background_progress_bar).contains(filterCharSequence,true))
+            EnumValueSelectorSettingsEntry(
+                title = stringResource(R.string.background_progress_bar),
+                selectedValue = backgroundProgress,
+                onValueSelected = {
+                    backgroundProgress = it
+                },
+                valueText = {
+                    when (it) {
+                        BackgroundProgress.Player -> stringResource(R.string.player)
+                        BackgroundProgress.MiniPlayer -> stringResource(R.string.minimized_player)
+                        BackgroundProgress.Both -> stringResource(R.string.both)
+                    }
+                },
             )
 
         if (filter.isNullOrBlank() || stringResource(R.string.show_total_time_of_queue).contains(filterCharSequence,true))

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/utils/Preferences.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/utils/Preferences.kt
@@ -111,7 +111,7 @@ const val isGradientBackgroundEnabledKey = "isGradientBackgroundEnabled"
 const val playbackSpeedKey = "playbackSpeed"
 const val playbackPitchKey = "playbackPitch"
 const val showTotalTimeQueueKey = "showTotalTimeQueue"
-const val showPlayerBackgroundProgressKey = "showPlayerBackgroundProgress"
+const val backgroundProgressKey = "backgroundProgress"
 
 inline fun <reified T : Enum<T>> SharedPreferences.getEnum(
     key: String,

--- a/app/src/main/kotlin/it/vfsfitvnm/vimusic/utils/Utils.kt
+++ b/app/src/main/kotlin/it/vfsfitvnm/vimusic/utils/Utils.kt
@@ -203,14 +203,12 @@ fun Uri?.thumbnail(size: Int): Uri? {
 }
 
 fun formatAsDuration(millis: Long) = DateUtils.formatElapsedTime(millis / 1000).removePrefix("0")
-fun durationToMillis(duration: String) = Duration.between(
-    LocalTime.MIN,
-    LocalTime.parse(
-        if (duration.length == 4) "0$duration"
-        else if (duration.length < 4) "00:00"
-        else duration
-    )
-).toMillis()
+fun durationToMillis(duration: String): Long {
+    val parts = duration.split(":")
+    val hours = parts[0].toLong()
+    val minutes = parts[1].toLong()
+    return hours * 3600000 + minutes * 60000
+}
 
 fun durationTextToMillis(duration: String): Long {
     return try {

--- a/app/src/main/res/values-af/strings.xml
+++ b/app/src/main/res/values-af/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-ba/strings.xml
+++ b/app/src/main/res/values-ba/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -419,4 +419,7 @@ CC-BY-SA 3.0</string>
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -418,4 +418,7 @@
     <string name="grant_permission">Grant permission</string>
     <string name="open_permission_settings">Open permission settings</string>
     <string name="show_background_progress_bar">Show background progress bar</string>
+    <string name="background_progress_bar">Background progress bar</string>
+    <string name="minimized_player">Minimized player</string>
+    <string name="both">Both</string>
 </resources>


### PR DESCRIPTION
# Background progress bar
Changed it the way you wanted.

# Time of songs
If time of songs was greater than 1 hour for example 71:54 it returns 0 milliseconds. Fixed it

