### PR TITLE
Fix ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION extras

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/service/PlayerService.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/service/PlayerService.kt
@@ -1080,6 +1080,7 @@ class PlayerService : InvincibleService(),
         sendBroadcast(
             Intent(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION).apply {
                 putExtra(AudioEffect.EXTRA_AUDIO_SESSION, player.audioSessionId)
+                putExtra(AudioEffect.EXTRA_PACKAGE_NAME, packageName)
             }
         )
     }


### PR DESCRIPTION
As stated in the documentation, the EXTRA_PACKAGE_NAME extra is mandatory (and required by audio effects such as ViPER4Android and Wavelet).

More info: https://developer.android.com/reference/android/media/audiofx/AudioEffect#ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION