### PR TITLE
Fixed escape character

### DIFF
--- a/docs/js/multilingual.js
+++ b/docs/js/multilingual.js
@@ -3,13 +3,20 @@ class Multilingual {
   defaultValues = {};
   selectedValues = {};
   constructor(supported) {
-    const user = (navigator.language || navigator.userLanguage).split("-")[0]
+    const user = (navigator.language || navigator.userLanguage).split("-")[0];
     if (supported.includes(user)) {
-      this.language = localStorage.getItem("language") || user || "en"
+      this.language = localStorage.getItem("language") || user || "en";
+    } else {
+      this.language = localStorage.getItem("language") || "en";
     }
-    else {
-      this.language = localStorage.getItem("language") || "en"
-    }
+  }
+  _decode(string) {
+    return string
+      .replace(/\\n/g, "\n")
+      .replaceAll("\\'", "'")
+      .replaceAll('\\"', '"')
+      .replaceAll("\\\\", "\\")
+      .replaceAll("\\t", "\t");
   }
   async loadStrings() {
     const defaultValuesResponse = await fetch("res/values/strings.xml");
@@ -32,7 +39,7 @@ class Multilingual {
     const stringsDefault = xmlDocDefault.getElementsByTagName("string");
     for (const string of stringsDefault) {
       const name = string.getAttribute("name");
-      const value = string.textContent.replace(/\\n/g, "\n");
+      const value = this._decode(string.textContent);
       this.defaultValues[name] = value;
     }
 
@@ -46,7 +53,7 @@ class Multilingual {
 
     for (const string of stringsSelected) {
       const name = string.getAttribute("name");
-      const value = string.textContent.replace(/\\n/g, "\n");
+      const value = this._decode(string.textContent);
       this.selectedValues[name] = value;
     }
   }
@@ -87,6 +94,6 @@ class Multilingual {
     }
   }
   setAttribute(el) {
-    el.setAttribute("lang", this.language)
+    el.setAttribute("lang", this.language);
   }
 }


### PR DESCRIPTION
The escape character from the .xml file was shown in the website:
![image](https://github.com/fast4x/RiMusic/assets/72742578/6cbb2a8a-e1ba-4db1-a035-b382d6826bd7)

This is fixed in this PR.

Also you should probably add the translated languages from crowding to the `<select>` and the `new Multilingual()` so users can select the language and the script can auto-select the language based of the users browser language.