### PR TITLE
fixed difference in thumbnail size between essential and modern

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/enums/PlayerThumbnailSize.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/enums/PlayerThumbnailSize.kt
@@ -9,10 +9,10 @@ enum class PlayerThumbnailSize {
 
     val size: Int
         get() = when (this) {
-            Small -> 80
-            Medium -> 45
-            Big -> 20
-            Biggest -> 10
+            Small -> 90
+            Medium -> 55
+            Big -> 30
+            Biggest -> 20
             Expanded -> 0
         }
 

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Thumbnail.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Thumbnail.kt
@@ -204,7 +204,7 @@ fun Thumbnail(
             if ((!isShowingLyrics) || (isShowingLyrics && showlyricsthumbnail))
               if (playerControlsType == PlayerControlsType.Modern)
                 modifierUiType = modifier
-                 .padding(vertical = 8.dp)
+                 //.padding(vertical = 8.dp)
                  .aspectRatio(1f)
                  //.size(thumbnailSizeDp)
                  .fillMaxSize()
@@ -216,7 +216,7 @@ fun Thumbnail(
               else modifierUiType = modifier
                  .aspectRatio(1f)
                  //.size(thumbnailSizeDp)
-                 .padding(14.dp)
+                 //.padding(14.dp)
                  .fillMaxSize()
                  .clip(LocalAppearance.current.thumbnailShape)
 


### PR DESCRIPTION
I tried to fix those bugs again but couldn't do it. At least I was able to fix different thumbnail sizes between essential and modern controls.

It doesn't touch your piped coding files so should be fine to merge.