### PR TITLE
fixed showthumbnail bug with modern controls and fixed modern disabled button size

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/enums/ThumbnailType.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/enums/ThumbnailType.kt
@@ -1,0 +1,6 @@
+package it.fast4x.rimusic.enums
+
+enum class ThumbnailType {
+    Essential,
+    Modern;
+}

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Controls.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Controls.kt
@@ -260,6 +260,7 @@ fun Controls(
         false
     )
     var playerControlsType by rememberPreference(playerControlsTypeKey, PlayerControlsType.Modern)
+    var playerPlayButtonType by rememberPreference(playerPlayButtonTypeKey, PlayerPlayButtonType.Default)
     Box(
         modifier = Modifier
             .animateContentSize()
@@ -321,7 +322,7 @@ fun Controls(
                     likedAt = likedAt,
                     mediaId = mediaId
                 )
-                if (!transparentBackgroundActionBarPlayer || playerControlsType == PlayerControlsType.Modern)
+                if (!transparentBackgroundActionBarPlayer || (playerControlsType == PlayerControlsType.Modern && playerPlayButtonType != PlayerPlayButtonType.Disabled))
                     Spacer(
                         modifier = Modifier
                             .height(10.dp)

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
@@ -1727,6 +1727,7 @@ fun PlayerModern(
                     modifier = Modifier
                         .weight(1.2f)
                 ) {
+                   if (showthumbnail)
                     if ((!isShowingLyrics) || (isShowingLyrics && showlyricsthumbnail))
                     thumbnailContent(
                         modifier = Modifier
@@ -1736,7 +1737,7 @@ fun PlayerModern(
                                 vertical = 4.dp,
                             )
                     )
-                    Box(
+                   Box(
                         modifier = Modifier
                             .pointerInput(Unit) {
                                 detectHorizontalDragGestures(

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Thumbnail.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Thumbnail.kt
@@ -55,7 +55,7 @@ import it.fast4x.rimusic.Database
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.ClickLyricsText
-import it.fast4x.rimusic.enums.PlayerControlsType
+import it.fast4x.rimusic.enums.ThumbnailType
 import it.fast4x.rimusic.enums.TransitionEffect
 import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.service.LoginRequiredException
@@ -81,7 +81,6 @@ import it.fast4x.rimusic.utils.dropShadow
 import it.fast4x.rimusic.utils.fadingEdge
 import it.fast4x.rimusic.utils.intent
 import it.fast4x.rimusic.utils.isLandscape
-import it.fast4x.rimusic.utils.playerControlsTypeKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.resize
 import it.fast4x.rimusic.utils.thumbnail
@@ -89,6 +88,7 @@ import java.net.UnknownHostException
 import java.nio.channels.UnresolvedAddressException
 import it.fast4x.rimusic.utils.showthumbnailKey
 import it.fast4x.rimusic.utils.showlyricsthumbnailKey
+import it.fast4x.rimusic.utils.thumbnailTypeKey
 
 @ExperimentalAnimationApi
 @UnstableApi
@@ -199,11 +199,11 @@ fun Thumbnail(
         contentAlignment = Alignment.Center, label = ""
     ) { currentWindow ->
 
-        val playerControlsType by rememberPreference(playerControlsTypeKey, PlayerControlsType.Modern)
+        val thumbnailType by rememberPreference(thumbnailTypeKey, ThumbnailType.Modern)
         var modifierUiType by remember { mutableStateOf(modifier) }
         if (showthumbnail)
             if ((!isShowingLyrics) || (isShowingLyrics && showlyricsthumbnail))
-              if (playerControlsType == PlayerControlsType.Modern)
+              if (thumbnailType == ThumbnailType.Modern)
                 modifierUiType = modifier
                  .padding(vertical = 8.dp)
                  .aspectRatio(1f)

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
@@ -484,9 +484,9 @@ fun ControlsModern(
                   painter = painterResource(R.drawable.play_skip_back),
                   contentDescription = null,
                   modifier = Modifier
-                      .offset(x = (5.5).dp, y = (5.5).dp)
+                      .offset(x = (8).dp, y = (8).dp)
                       .blur(7.dp)
-                      .size(46.dp),
+                      .size(38.dp),
                   tint = Color.Black
               )
               Image(
@@ -495,7 +495,7 @@ fun ControlsModern(
                   colorFilter = ColorFilter.tint(colorPalette.accent),
                   modifier = Modifier
                       .padding(10.dp)
-                      .size(36.dp)
+                      .size(34.dp)
                       .rotate(rotationAngle)
                       .combinedClickable(
                           onClick = {
@@ -518,8 +518,8 @@ fun ControlsModern(
                   contentDescription = null,
                   modifier = Modifier
                       .offset(x = (0).dp, y = (0).dp)
-                      .blur(10.dp)
-                      .size(75.dp),
+                      .blur(7.dp)
+                      .size(54.dp),
                   tint = Color.Black
               )
               Image(
@@ -528,7 +528,7 @@ fun ControlsModern(
                   colorFilter = ColorFilter.tint(colorPalette.accent),  //ColorFilter.tint(colorPalette.collapsedPlayerProgressBar),
                   modifier = Modifier
                       .rotate(rotationAngle)
-                      .size(60.dp)
+                      .size(44.dp)
                       .align(Alignment.Center)
                       .combinedClickable(
                           onClick = {
@@ -556,9 +556,9 @@ fun ControlsModern(
                   painter = painterResource(R.drawable.play_skip_forward),
                   contentDescription = null,
                   modifier = Modifier
-                      .offset(x = (5.5).dp, y = (5.5).dp)
+                      .offset(x = (8).dp, y = (8).dp)
                       .blur(7.dp)
-                      .size(46.dp),
+                      .size(38.dp),
                   tint = Color.Black
               )
               Image(
@@ -567,7 +567,7 @@ fun ControlsModern(
                   colorFilter = ColorFilter.tint(colorPalette.accent),  //ColorFilter.tint(colorPalette.collapsedPlayerProgressBar),
                   modifier = Modifier
                       .padding(10.dp)
-                      .size(36.dp)
+                      .size(34.dp)
                       .rotate(rotationAngle)
                       .combinedClickable(
                           onClick = {

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
@@ -485,7 +485,7 @@ fun ControlsModern(
                   contentDescription = null,
                   modifier = Modifier
                       .offset(x = (8).dp, y = (8).dp)
-                      .blur(7.dp)
+                      .blur(4.dp)
                       .size(38.dp),
                   tint = Color.Black
               )
@@ -557,7 +557,7 @@ fun ControlsModern(
                   contentDescription = null,
                   modifier = Modifier
                       .offset(x = (8).dp, y = (8).dp)
-                      .blur(7.dp)
+                      .blur(4.dp)
                       .size(38.dp),
                   tint = Color.Black
               )

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
@@ -59,6 +59,7 @@ import it.fast4x.rimusic.enums.PlayerTimelineSize
 import it.fast4x.rimusic.enums.PlayerTimelineType
 import it.fast4x.rimusic.enums.PlayerVisualizerType
 import it.fast4x.rimusic.enums.ThumbnailRoundness
+import it.fast4x.rimusic.enums.ThumbnailType
 import it.fast4x.rimusic.ui.components.themed.HeaderIconButton
 import it.fast4x.rimusic.ui.components.themed.HeaderWithIcon
 import it.fast4x.rimusic.ui.components.themed.IconButton
@@ -118,6 +119,7 @@ import it.fast4x.rimusic.utils.transparentbarKey
 import it.fast4x.rimusic.utils.blackgradientKey
 import it.fast4x.rimusic.utils.bottomgradientKey
 import it.fast4x.rimusic.utils.textoutlineKey
+import it.fast4x.rimusic.utils.thumbnailTypeKey
 
 
 @ExperimentalAnimationApi
@@ -244,6 +246,7 @@ fun AppearanceSettings() {
         true
     )
     var actionspacedevenly by rememberPreference(actionspacedevenlyKey, false)
+    var thumbnailType by rememberPreference(thumbnailTypeKey, ThumbnailType.Modern)
 
     Column(
         modifier = Modifier
@@ -451,6 +454,25 @@ fun AppearanceSettings() {
                         PlayerTimelineSize.Expanded -> stringResource(R.string.expanded)
                     }
                 }
+            )
+        if (showthumbnail)
+          if (filter.isNullOrBlank() || stringResource(R.string.thumbnailtype).contains(
+                filterCharSequence,
+                true
+            )
+          )
+            EnumValueSelectorSettingsEntry(
+                title = stringResource(R.string.thumbnailtype),
+                selectedValue = thumbnailType,
+                onValueSelected = {
+                    thumbnailType = it
+                },
+                valueText = {
+                    when (it) {
+                        ThumbnailType.Modern -> stringResource(R.string.pcontrols_modern)
+                        ThumbnailType.Essential -> stringResource(R.string.pcontrols_essential)
+                    }
+                },
             )
 
         if (showthumbnail)

--- a/app/src/main/kotlin/it/fast4x/rimusic/utils/Preferences.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/utils/Preferences.kt
@@ -203,6 +203,7 @@ const val expandedplayertoggleKey = "expandedplayertoggle"
 const val blackgradientKey = "blackgradient"
 const val bottomgradientKey = "bottomgradient"
 const val textoutlineKey = "textoutline"
+const val thumbnailTypeKey = "thumbnailType"
 /**** CUSTOM THEME **** */
 
 const val parentalControlEnabledKey = "parentalControlEnabled"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -619,6 +619,7 @@
     <string name="glow">Glow</string>
     <string name="bottomgradient">Show Bottom Gradient</string>
     <string name="textoutline">Enable Text Outline</string>
+    <string name="thumbnailtype">Thumbnail Type</string>
 
 
 </resources>


### PR DESCRIPTION
1) now shadow also disappears when the  thumbnail is hidden

https://github.com/fast4x/RiMusic/assets/45353488/6f2cdab3-2f80-4c4d-9d2e-0ad7174c16b9

2) In the above video you can see that I've reduced button sizes. Previous ones were too big and were taking too much space in the expanded player.

3) separated essential/modern thumbnail from controls

https://github.com/fast4x/RiMusic/assets/45353488/ce4e590e-d205-485d-b45b-eaae06fa89ed

