### PR TITLE
made showthumbnail compulsory for playerBackgroundColors != PlayerBackgroundColors.BlurredCoverColor

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
@@ -380,6 +380,9 @@ fun AppearanceSettings() {
         //SettingsGroupSpacer()
         SettingsEntryGroupText(title = stringResource(R.string.player))
 
+        if (playerBackgroundColors != PlayerBackgroundColors.BlurredCoverColor)
+            showthumbnail = true
+
         if (filter.isNullOrBlank() || stringResource(R.string.show_player_top_actions_bar).contains(
                 filterCharSequence,
                 true
@@ -391,7 +394,7 @@ fun AppearanceSettings() {
                 isChecked = showTopActionsBar,
                 onCheckedChange = { showTopActionsBar = it }
             )
-
+        if (playerBackgroundColors == PlayerBackgroundColors.BlurredCoverColor)
         if (filter.isNullOrBlank() || stringResource(R.string.show_thumbnail).contains(
                 filterCharSequence,
                 true


### PR DESCRIPTION
I can already see many people creating issues because they don't have thumbnail in their player. Last week someone created an issue saying that expanded player is not working. I had to disable expanded player for people who are using this app the old way.

So I made `showthumbnail = true`  compulsory for non-cover backgrounds. as soon as they switch to some other background other than 'PlayerBackgroundColors.BlurredCoverColor' showthumbnail will become true and then I've hidden this option for non-cover backgrounds so they can't change it unless they change the background back to `BlurredCoverColor`.

Believe me, this will save us two a lot of headache.