### PR TITLE
"Expanded lyrics" also works for visualizer now

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
@@ -1083,8 +1083,6 @@ fun Player(
                 isShowingEqualizer = isShowingEqualizer,
                 onShowEqualizer = { isShowingEqualizer = it },
                 showthumbnail = showthumbnail,
-                expandedplayer = expandedplayer,
-                onexpandedplayer = { expandedplayer = it },
                 onMaximize = { lyricsBottomSheetState.expandSoft() },
                 onDoubleTap = {
                     val currentMediaItem = binder.player.currentMediaItem

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
@@ -397,7 +397,9 @@ fun PlayerModern(
     var actionspacedevenly by rememberPreference(actionspacedevenlyKey, false)
     var expandedplayer by rememberPreference(expandedplayerKey, false)
 
-    if ((expandedlyrics) && (!isShowingLyrics)) expandedplayer = false
+    if (expandedlyrics && !isLandscape)
+        if (isShowingLyrics || isShowingEqualizer) expandedplayer = true
+        else expandedplayer = false
 
     LaunchedEffect(mediaItem.mediaId) {
         withContext(Dispatchers.IO) {
@@ -896,7 +898,6 @@ fun PlayerModern(
                     indication = null,
                     onClick = {
                        if(thumbnailTapEnabled){
-                          if (expandedlyrics) expandedplayer = !expandedplayer
                           if (isShowingEqualizer) isShowingEqualizer = !isShowingEqualizer
                           isShowingLyrics = !isShowingLyrics
                         }
@@ -987,8 +988,6 @@ fun PlayerModern(
             isShowingEqualizer = isShowingEqualizer,
             onShowEqualizer = { isShowingEqualizer = it },
             showthumbnail = showthumbnail,
-            expandedplayer = expandedplayer,
-            onexpandedplayer = { expandedplayer = it },
             onMaximize = {
                 showFullLyrics = true
             },
@@ -1363,7 +1362,6 @@ fun PlayerModern(
                                 color = if (isShowingLyrics)  colorPalette.accent else Color.Gray,
                                 enabled = true,
                                 onClick = {
-                                    if (expandedlyrics) expandedplayer = !expandedplayer
                                     if (isShowingEqualizer) isShowingEqualizer = !isShowingEqualizer
                                     isShowingLyrics = !isShowingLyrics
                                 },
@@ -1371,7 +1369,7 @@ fun PlayerModern(
                                     .size(24.dp),
                             )
                         if (!isLandscape)
-                         if (expandedplayertoggle && !showlyricsthumbnail && !expandedlyrics)
+                         if (expandedplayertoggle && (!showlyricsthumbnail || !showvisthumbnail) && !expandedlyrics)
                             IconButton(
                                 icon = R.drawable.minmax,
                                 color = if (expandedplayer) colorPalette.accent else Color.Gray,
@@ -1806,7 +1804,6 @@ fun PlayerModern(
                                 isDisplayed = isShowingLyrics,
                                 onDismiss = {
                                     if (thumbnailTapEnabled) {
-                                        if (expandedlyrics) expandedplayer = !expandedplayer
                                         isShowingLyrics = false
                                     }
                                 },

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Thumbnail.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Thumbnail.kt
@@ -89,8 +89,6 @@ fun Thumbnail(
     onMaximize: () -> Unit,
     onDoubleTap: () -> Unit,
     showthumbnail: Boolean,
-    expandedplayer: Boolean,
-    onexpandedplayer: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
@@ -251,7 +249,6 @@ fun Thumbnail(
                                         onLongPress = { onShowStatsForNerds(true) },
                                         onTap = if (thumbnailTapEnabledKey) {
                                             {
-                                                if(expandedlyrics) onexpandedplayer(true)
                                                 onShowLyrics(true)
                                                 onShowEqualizer(false)
                                             }
@@ -276,7 +273,6 @@ fun Thumbnail(
                                 onLongPress = { onShowStatsForNerds(true) },
                                 onTap = if (thumbnailTapEnabledKey) {
                                     {
-                                        if(expandedlyrics) onexpandedplayer(true)
                                         onShowLyrics(true)
                                         onShowEqualizer(false)
                                     }

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Essential.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Essential.kt
@@ -388,12 +388,7 @@ fun ControlsEssential(
                     ColorPaletteName.Dynamic, ColorPaletteName.Default,
                     ColorPaletteName.MaterialYou, ColorPaletteName.Customized -> {
                         when (playerPlayButtonType) {
-                            PlayerPlayButtonType.CircularRibbed -> {
-                                if (isGradientBackgroundEnabled) colorPalette.background2
-                                else colorPalette.background1
-                            }
-
-                            PlayerPlayButtonType.Disabled -> Color.Transparent
+                            PlayerPlayButtonType.CircularRibbed, PlayerPlayButtonType.Disabled -> Color.Transparent
                             else -> {
                                 if (isGradientBackgroundEnabled) colorPalette.background1
                                 else colorPalette.background2

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.ContentScale
 import it.fast4x.rimusic.utils.textoutlineKey
 
 
@@ -364,31 +365,81 @@ fun ControlsModern(
           )
       }
 
-      CustomElevatedButton(
-          backgroundColor = colorPalette.background2.copy(0.95f),
-          onClick = {},
-          modifier = Modifier
-              .combinedClickable(
-                  indication = ripple(bounded = true),
-                  interactionSource = remember { MutableInteractionSource() },
-                  onClick = {
-                      if (shouldBePlaying) {
-                          binder.player.pause()
-                      } else {
-                          if (binder.player.playbackState == Player.STATE_IDLE) {
-                              binder.player.prepare()
-                          }
-                          binder.player.play()
-                      }
-                      if (effectRotationEnabled) isRotated = !isRotated
-                  },
-                  onLongClick = onShowSpeedPlayerDialog
+      if (playerPlayButtonType == PlayerPlayButtonType.CircularRibbed){
+          Box(
+             contentAlignment = Alignment.Center
+          ) {
+              Icon(
+                  painter = painterResource(R.drawable.a13shape),
+                  contentDescription = null,
+                  modifier = Modifier
+                      .offset(x = (0).dp, y = (0).dp)
+                      .blur(7.dp)
+                      .size(115.dp),
+                  tint = Color.Black.copy(0.85f)
               )
-              .width(playerPlayButtonType.width.dp)
-              .height(playerPlayButtonType.height.dp)
+              Image(
+                  painter = painterResource(R.drawable.a13shape),
+                  colorFilter = ColorFilter.tint(colorPalette.background2.copy(0.95f)),
+                  modifier = Modifier
+                      .rotate(rotationAngle)
+                      .combinedClickable(
+                          indication = ripple(bounded = true),
+                          interactionSource = remember { MutableInteractionSource() },
+                          onClick = {
+                              if (shouldBePlaying) {
+                                  binder.player.pause()
+                              } else {
+                                  if (binder.player.playbackState == Player.STATE_IDLE) {
+                                      binder.player.prepare()
+                                  }
+                                  binder.player.play()
+                              }
+                              if (effectRotationEnabled) isRotated = !isRotated
+                          },
+                          onLongClick = onShowSpeedPlayerDialog
+                      )
+                      .size(100.dp),
+                  contentDescription = "Background Image",
+                  contentScale = ContentScale.Fit
+              )
+              Image(
+                  painter = painterResource(if (shouldBePlaying) R.drawable.pause else R.drawable.play),
+                  contentDescription = null,
+                  colorFilter = ColorFilter.tint(colorPalette.text),  //ColorFilter.tint(colorPalette.collapsedPlayerProgressBar),
+                  modifier = Modifier
+                      .rotate(rotationAngle)
+                      .align(Alignment.Center)
+                      .size(30.dp)
+              )
+          }
+      }
+      else {
+          CustomElevatedButton(
+              backgroundColor = colorPalette.background2.copy(0.95f),
+              onClick = {},
+              modifier = Modifier
+                  .combinedClickable(
+                      indication = ripple(bounded = true),
+                      interactionSource = remember { MutableInteractionSource() },
+                      onClick = {
+                          if (shouldBePlaying) {
+                              binder.player.pause()
+                          } else {
+                              if (binder.player.playbackState == Player.STATE_IDLE) {
+                                  binder.player.prepare()
+                              }
+                              binder.player.play()
+                          }
+                          if (effectRotationEnabled) isRotated = !isRotated
+                      },
+                      onLongClick = onShowSpeedPlayerDialog
+                  )
+                  .width(playerPlayButtonType.width.dp)
+                  .height(playerPlayButtonType.height.dp)
 
-      ) {
-          /*
+          ) {
+              /*
         if (playerPlayButtonType == PlayerPlayButtonType.CircularRibbed)
             Image(
                 painter = painterResource(R.drawable.a13shape),
@@ -407,35 +458,36 @@ fun ControlsModern(
             )
          */
 
-          Image(
-              painter = painterResource(if (shouldBePlaying) R.drawable.pause else R.drawable.play),
-              contentDescription = null,
-              colorFilter = ColorFilter.tint(colorPalette.text),  //ColorFilter.tint(colorPalette.collapsedPlayerProgressBar),
-              modifier = Modifier
-                  .rotate(rotationAngle)
-                  .align(Alignment.Center)
-                  .size(30.dp)
-          )
-
-          val fmtSpeed = "%.1fx".format(playbackSpeed).replace(",", ".")
-          if (fmtSpeed != "1.0x")
-              Box(
+              Image(
+                  painter = painterResource(if (shouldBePlaying) R.drawable.pause else R.drawable.play),
+                  contentDescription = null,
+                  colorFilter = ColorFilter.tint(colorPalette.text),  //ColorFilter.tint(colorPalette.collapsedPlayerProgressBar),
                   modifier = Modifier
-                      .align(Alignment.BottomCenter)
+                      .rotate(rotationAngle)
+                      .align(Alignment.Center)
+                      .size(30.dp)
+              )
 
-              ) {
-                  BasicText(
-                      text = fmtSpeed,
-                      style = TextStyle(
-                          color = colorPalette.text,
-                          fontStyle = typography.xxxs.semiBold.fontStyle,
-                          fontSize = typography.xxxs.semiBold.fontSize
-                      ),
-                      maxLines = 1,
+              val fmtSpeed = "%.1fx".format(playbackSpeed).replace(",", ".")
+              if (fmtSpeed != "1.0x")
+                  Box(
                       modifier = Modifier
-                          .padding(bottom = if (playerPlayButtonType != PlayerPlayButtonType.CircularRibbed) 5.dp else 15.dp)
-                  )
-              }
+                          .align(Alignment.BottomCenter)
+
+                  ) {
+                      BasicText(
+                          text = fmtSpeed,
+                          style = TextStyle(
+                              color = colorPalette.text,
+                              fontStyle = typography.xxxs.semiBold.fontStyle,
+                              fontSize = typography.xxxs.semiBold.fontSize
+                          ),
+                          maxLines = 1,
+                          modifier = Modifier
+                              .padding(bottom = if (playerPlayButtonType != PlayerPlayButtonType.CircularRibbed) 5.dp else 15.dp)
+                      )
+                  }
+          }
       }
 
     CustomElevatedButton(

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
@@ -388,7 +388,7 @@ fun AppearanceSettings() {
         if (playerBackgroundColors != PlayerBackgroundColors.BlurredCoverColor)
             showthumbnail = true
         if (!visualizerEnabled) showvisthumbnail = false
-        if (showlyricsthumbnail) expandedlyrics = false
+        if (showlyricsthumbnail || showvisthumbnail) expandedlyrics = false
         if (filter.isNullOrBlank() || stringResource(R.string.show_player_top_actions_bar).contains(
                 filterCharSequence,
                 true
@@ -510,7 +510,7 @@ fun AppearanceSettings() {
                         }
                     )
         }
-        if (!showlyricsthumbnail)
+        if (!showlyricsthumbnail && !showvisthumbnail && !isLandscape)
             if (filter.isNullOrBlank() || stringResource(R.string.expandedlyrics).contains(
                     filterCharSequence,
                     true


### PR DESCRIPTION
1) "Expanded lyrics" also works for visualizer now.

Code Cleanup : Removed complicated codes and added simple codes to achieve the same result

2) Changed Wavy Circle. Fixes #2558
Before and After
![GridArt_20240701_143054397.jpg](https://github.com/fast4x/RiMusic/assets/45353488/1d5370d3-b817-483f-b649-ac6804d1cb95)

