### PR TITLE
added haptic feedback to some important bottom sheets

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumDetailsModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumDetailsModern.kt
@@ -51,8 +51,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.style.TextAlign
@@ -259,6 +261,7 @@ fun AlbumDetailsModern(
     var nowPlayingItem by remember {
         mutableStateOf(-1)
     }
+    val hapticFeedback = LocalHapticFeedback.current
 
     /*
     val painter = rememberAsyncImagePainter(
@@ -1015,7 +1018,8 @@ fun AlbumDetailsModern(
                                                 onDismiss = menuState::hide,
                                                 mediaItem = song.asMediaItem,
                                             )
-                                        }
+                                        };
+                                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                     },
                                     onClick = {
                                         if (!selectItems) {

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
@@ -41,7 +41,9 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.font.FontWeight
@@ -188,6 +190,7 @@ fun ArtistOverviewModern(
     val listMediaItems = remember { mutableListOf<MediaItem>() }
 
     val artist by persist<Artist?>("artist/$browseId/artist")
+    val hapticFeedback = LocalHapticFeedback.current
 
     LayoutWithAdaptiveThumbnail(thumbnailContent = thumbnailContent) {
         Box(
@@ -560,7 +563,8 @@ fun ArtistOverviewModern(
                                                     onDismiss = menuState::hide,
                                                     mediaItem = song.asMediaItem,
                                                 )
-                                            }
+                                            };
+                                            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                         },
                                         onClick = {
                                             binder?.stopRadio()

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
@@ -27,7 +27,9 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.unit.dp
@@ -142,6 +144,7 @@ fun ArtistScreen(
     var changeShape by remember {
         mutableStateOf(false)
     }
+    val hapticFeedback = LocalHapticFeedback.current
 
     LaunchedEffect(Unit) {
         Database
@@ -537,7 +540,8 @@ fun ArtistScreen(
                                                             onDismiss = menuState::hide,
                                                             mediaItem = song.asMediaItem,
                                                         )
-                                                    }
+                                                    };
+                                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                                 },
                                                 onClick = {
                                                     binder?.stopRadio()

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -64,8 +64,10 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -314,7 +316,7 @@ fun HomeSongsModern(
         BuiltInPlaylist.OnDevice to stringResource(R.string.on_device)
 
     val excludeSongWithDurationLimit by rememberPreference(excludeSongsWithDurationLimitKey, DurationInMinutes.Disabled)
-
+    val hapticFeedback = LocalHapticFeedback.current
 
     when (builtInPlaylist) {
         BuiltInPlaylist.All -> {
@@ -1202,7 +1204,8 @@ fun HomeSongsModern(
                                                         },
                                                         thumbnailSizeDp = thumbnailSizeDp
                                                     )
-                                                }
+                                                };
+                                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                             },
                                             onClick = {
                                                 currentFolderPath += folder.name + "/"
@@ -1266,7 +1269,8 @@ fun HomeSongsModern(
                                                 song = song,
                                                 onDismiss = menuState::hide
                                             )
-                                        }
+                                        };
+                                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                     },
                                     onClick = {
                                         if (!selectItems) {
@@ -1423,7 +1427,8 @@ fun HomeSongsModern(
                                             onDismiss = menuState::hide,
                                             onHideFromDatabase = { isHiding = true }
                                         )
-                                    }
+                                    };
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                 },
                                 onClick = {
                                     searching = false

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
@@ -55,8 +55,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ExperimentalTextApi
@@ -323,6 +325,7 @@ fun QuickPicksModern(
     val enableCreateMonthlyPlaylists by rememberPreference(enableCreateMonthlyPlaylistsKey, true)
     if (enableCreateMonthlyPlaylists)
         CheckMonthlyPlaylist()
+    val hapticFeedback = LocalHapticFeedback.current
 
     PullToRefreshBox(
         refreshing = refreshing,
@@ -518,7 +521,8 @@ fun QuickPicksModern(
                                                         }
 
                                                     )
-                                                }
+                                                };
+                                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                             },
                                             onClick = {
                                                 val mediaItem = song.asMediaItem
@@ -610,6 +614,7 @@ fun QuickPicksModern(
 
                                                         )
                                                 }
+                                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                             },
                                             onClick = {
                                                 val mediaItem = song.asMediaItem

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
@@ -64,8 +64,10 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
@@ -582,6 +584,7 @@ fun LocalPlaylistSongs(
 
     val playlistNotMonthlyType = playlistPreview?.playlist?.name?.startsWith(MONTHLY_PREFIX,0,true) == false
     val playlistNotPipedType = playlistPreview?.playlist?.name?.startsWith(PIPED_PREFIX,0,true) == false
+    val hapticFeedback = LocalHapticFeedback.current
 
 
     Box(
@@ -1532,7 +1535,8 @@ fun LocalPlaylistSongs(
                                                 song = song,
                                                 onDismiss = menuState::hide
                                             )
-                                        }
+                                        };
+                                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                     },
                                     onClick = {
                                         if (!selectItems) {

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerEssential.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerEssential.kt
@@ -62,9 +62,11 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -194,6 +196,7 @@ fun PlayerEssential(
         animationSpec = tween(durationMillis = 200), label = ""
     )
     val disableClosingPlayerSwipingDown by rememberPreference(disableClosingPlayerSwipingDownKey, true)
+    val hapticFeedback = LocalHapticFeedback.current
 
     SwipeToDismissBox(
         modifier = Modifier
@@ -249,7 +252,8 @@ fun PlayerEssential(
             modifier = Modifier
                 .combinedClickable (
                     onLongClick = {
-                        navController?.navigate(NavRoutes.queue.name)
+                        navController?.navigate(NavRoutes.queue.name);
+                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                     },
                     onClick = {
                         //if (showPlayer != null)

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/QueueModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/QueueModern.kt
@@ -64,8 +64,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ExperimentalTextApi
@@ -333,7 +335,7 @@ fun QueueModern(
         }
 
         val isSwipeToActionEnabled by rememberPreference(isSwipeToActionEnabledKey, true)
-
+        val hapticFeedback = LocalHapticFeedback.current
 
         Column {
             Box(
@@ -494,6 +496,7 @@ fun QueueModern(
 
                                                     )
                                                 }
+                                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                             },
                                             onClick = {
                                                 if (!selectQueueItems) {

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongListModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongListModern.kt
@@ -50,8 +50,10 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -161,6 +163,7 @@ fun PlaylistSongListModern(
     var playlistPage by persist<Innertube.PlaylistOrAlbumPage?>("playlist/$browseId/playlistPage")
 
     var filter: String? by rememberSaveable { mutableStateOf(null) }
+    val hapticFeedback = LocalHapticFeedback.current
 
     LaunchedEffect(Unit, filter) {
         if (playlistPage != null && playlistPage?.songsPage?.continuation == null) return@LaunchedEffect
@@ -778,7 +781,8 @@ fun PlaylistSongListModern(
                                             onDismiss = menuState::hide,
                                             mediaItem = song.asMediaItem,
                                         )
-                                    }
+                                    };
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                 },
                                 onClick = {
                                     searching = false


### PR DESCRIPTION
added haptic feedback to long click bottom sheet at quick picks, songs, playlists, albums, artists and long tap to open queue from mini player

fixes #2602