### PR TITLE
Updated versions & junit

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 [versions]
 compose-compiler = "1.5.11"
 junit = "4.13.2"
-agp = "8.4.2"
+agp = "8.5.0"
 kotlin = "1.9.23"
 kotlin-ksp = "1.9.23-1.0.20"
 kotlin-coroutine = "1.8.1"
@@ -38,7 +38,7 @@ math3 = "3.6.1"
 
 [libraries]
 gradle = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
-junit = { group = "junit", name = "junit", version = "junit" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-coroutines = {group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlin-coroutine"}
 kotlin-datetime = {group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlin-datetime"}
 compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "compose" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Oct 22 13:15:10 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/innertube/build.gradle.kts
+++ b/innertube/build.gradle.kts
@@ -19,5 +19,5 @@ dependencies {
     implementation(libs.ktor.client.serialization)
     implementation(libs.ktor.serialization.json)
 
-    //testImplementation(libs.junit)
+    testImplementation(libs.junit)
 }

--- a/kugou/build.gradle.kts
+++ b/kugou/build.gradle.kts
@@ -18,5 +18,5 @@ dependencies {
     implementation(libs.ktor.client.serialization)
     implementation(libs.ktor.serialization.json)
 
-    //testImplementation(libs.junit)
+    testImplementation(libs.junit)
 }


### PR DESCRIPTION
-updated agp to 8.5.0
-updated gradle to 8.7
-fixed junit dependancy
-made it such that the "build"-button in Android Studio works correctly (wasn't because junit was not working correctly and not added to build i.e testImplementation was commented)