### PR TITLE
changes in outline colors and removal of redundant expanded player button for some conditions

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
@@ -426,9 +426,11 @@ fun PlayerModern(
     var actionspacedevenly by rememberPreference(actionspacedevenlyKey, false)
     var expandedplayer by rememberPreference(expandedplayerKey, false)
 
-    if (expandedlyrics && !isLandscape)
-        if (isShowingLyrics || isShowingVisualizer) expandedplayer = true
+    if (expandedlyrics && !isLandscape) {
+        if ((isShowingLyrics && !showlyricsthumbnail) || (isShowingVisualizer && !showvisthumbnail)) expandedplayer = true
         else expandedplayer = false
+    }
+    if (showlyricsthumbnail) expandedplayer = false
 
     LaunchedEffect(mediaItem.mediaId) {
         withContext(Dispatchers.IO) {
@@ -1238,7 +1240,7 @@ fun PlayerModern(
                                                     join = StrokeJoin.Round
                                                 ),
                                                 color = if (!textoutline) Color.Transparent
-                                                else if (colorPaletteMode == ColorPaletteMode.Light) Color.White.copy(
+                                                else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
                                                     0.65f
                                                 )
                                                 else Color.Black,
@@ -1273,7 +1275,7 @@ fun PlayerModern(
                                                     join = StrokeJoin.Round
                                                 ),
                                                 color = if (!textoutline) Color.Transparent
-                                                else if (colorPaletteMode == ColorPaletteMode.Light) Color.White.copy(
+                                                else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
                                                     0.65f
                                                 )
                                                 else Color.Black,
@@ -1340,7 +1342,7 @@ fun PlayerModern(
                                                         join = StrokeJoin.Round
                                                     ),
                                                     color = if (!textoutline) Color.Transparent
-                                                    else if (colorPaletteMode == ColorPaletteMode.Light) Color.White.copy(
+                                                    else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
                                                         0.65f
                                                     )
                                                     else Color.Black,
@@ -1375,7 +1377,7 @@ fun PlayerModern(
                                                         join = StrokeJoin.Round
                                                     ),
                                                     color = if (!textoutline) Color.Transparent
-                                                    else if (colorPaletteMode == ColorPaletteMode.Light) Color.White.copy(
+                                                    else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
                                                         0.65f
                                                     )
                                                     else Color.Black,
@@ -1481,7 +1483,7 @@ fun PlayerModern(
                                     .size(24.dp),
                             )
                         if (!isLandscape)
-                         if (expandedplayertoggle && (!showlyricsthumbnail || !showvisthumbnail) && !expandedlyrics)
+                         if (expandedplayertoggle && (!showlyricsthumbnail) && !expandedlyrics)
                             IconButton(
                                 icon = R.drawable.minmax,
                                 color = if (expandedplayer) colorPalette.accent else Color.Gray,

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Essential.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Essential.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -181,7 +182,7 @@ fun InfoAlbumAndArtistEssential(
                     style = TextStyle(
                         drawStyle = Stroke(width = 1.5f, join = StrokeJoin.Round),
                         textAlign = TextAlign.Center,
-                        color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light) Color.White.copy(0.5f)
+                        color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(0.5f)
                         else Color.Black,
                         fontStyle = typography.l.bold.fontStyle,
                         fontWeight = typography.l.bold.fontWeight,
@@ -287,7 +288,7 @@ fun InfoAlbumAndArtistEssential(
                 style = TextStyle(
                     drawStyle = Stroke(width = 1.5f, join = StrokeJoin.Round),
                     textAlign = TextAlign.Center,
-                    color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light) Color.White.copy(0.5f)
+                    color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(0.5f)
                     else Color.Black,
                     fontStyle = typography.m.bold.fontStyle,
                     fontSize = typography.m.bold.fontSize,

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
@@ -79,6 +79,7 @@ import it.fast4x.rimusic.ui.screens.player.bounceClick
 import it.fast4x.rimusic.utils.cleanPrefix
 import it.fast4x.rimusic.utils.dropShadow
 import it.fast4x.rimusic.utils.textoutlineKey
+import androidx.compose.foundation.isSystemInDarkTheme
 
 
 @androidx.annotation.OptIn(UnstableApi::class)
@@ -185,7 +186,7 @@ fun InfoAlbumAndArtistModern(
                     text = cleanPrefix(title ?: ""),
                     style = TextStyle(
                         drawStyle = Stroke(width = 1.5f, join = StrokeJoin.Round),
-                        color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light) Color.White.copy(0.5f)
+                        color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(0.5f)
                         else Color.Black,
                         fontStyle = typography.l.bold.fontStyle,
                         fontWeight = typography.l.bold.fontWeight,
@@ -316,7 +317,7 @@ fun InfoAlbumAndArtistModern(
                 text = artist ?: "",
                 style = TextStyle(
                     drawStyle = Stroke(width = 1.5f, join = StrokeJoin.Round),
-                    color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light) Color.White.copy(0.5f)
+                    color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(0.5f)
                     else Color.Black,
                     fontStyle = typography.m.bold.fontStyle,
                     fontSize = typography.m.bold.fontSize,

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
@@ -333,29 +333,38 @@ fun SearchResultScreen(
                                 emptyItemsText = emptyItemsText,
                                 headerContent = headerContent,
                                 itemContent = { video ->
-                                    VideoItem(
-                                        video = video,
-                                        thumbnailWidthDp = thumbnailWidthDp,
-                                        thumbnailHeightDp = thumbnailHeightDp,
-                                        modifier = Modifier
-                                            .combinedClickable(
-                                                onLongClick = {
-                                                    menuState.display {
-                                                        NonQueuedMediaItemMenu(
-                                                            navController = navController,
-                                                            mediaItem = video.asMediaItem,
-                                                            onDismiss = menuState::hide
+                                    SwipeablePlaylistItem(
+                                        mediaItem = video.asMediaItem,
+                                        onSwipeToLeft = {
+                                            binder?.player?.addNext(video.asMediaItem)
+                                        }
+                                    ) {
+                                        VideoItem(
+                                            video = video,
+                                            thumbnailWidthDp = thumbnailWidthDp,
+                                            thumbnailHeightDp = thumbnailHeightDp,
+                                            modifier = Modifier
+                                                .combinedClickable(
+                                                    onLongClick = {
+                                                        menuState.display {
+                                                            NonQueuedMediaItemMenu(
+                                                                navController = navController,
+                                                                mediaItem = video.asMediaItem,
+                                                                onDismiss = menuState::hide
+                                                            )
+                                                        };
+                                                        hapticFeedback.performHapticFeedback(
+                                                            HapticFeedbackType.LongPress
                                                         )
-                                                    };
-                                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                },
-                                                onClick = {
-                                                    binder?.stopRadio()
-                                                    binder?.player?.forcePlay(video.asMediaItem)
-                                                    binder?.setupRadio(video.info?.endpoint)
-                                                }
-                                            )
-                                    )
+                                                    },
+                                                    onClick = {
+                                                        binder?.stopRadio()
+                                                        binder?.player?.forcePlay(video.asMediaItem)
+                                                        binder?.setupRadio(video.info?.endpoint)
+                                                    }
+                                                )
+                                        )
+                                    }
                                 },
                                 itemPlaceholderContent = {
                                     VideoItemPlaceholder(

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
@@ -396,7 +396,7 @@ fun AppearanceSettings() {
         if (playerBackgroundColors != PlayerBackgroundColors.BlurredCoverColor)
             showthumbnail = true
         if (!visualizerEnabled) showvisthumbnail = false
-        if (showlyricsthumbnail || showvisthumbnail) expandedlyrics = false
+        if (showlyricsthumbnail) expandedlyrics = false
         if (filter.isNullOrBlank() || stringResource(R.string.show_player_top_actions_bar).contains(
                 filterCharSequence,
                 true
@@ -530,7 +530,7 @@ fun AppearanceSettings() {
                         }
                     )
         }
-        if (!showlyricsthumbnail && !showvisthumbnail && !isLandscape)
+        if (!showlyricsthumbnail && !isLandscape)
             if (filter.isNullOrBlank() || stringResource(R.string.expandedlyrics).contains(
                     filterCharSequence,
                     true

--- a/app/src/main/kotlin/it/fast4x/rimusic/utils/GetSeekBarType.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/utils/GetSeekBarType.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -298,7 +299,7 @@ fun GetSeekBar(
                 text = formatAsDuration(scrubbingPosition ?: position),
                 style = typography.xxs.semiBold.merge(TextStyle(
                     drawStyle = Stroke(width = 1.0f, join = StrokeJoin.Round),
-                    color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light) Color.White.copy(0.5f)
+                    color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(0.5f)
                     else Color.Black)),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
@@ -345,7 +346,7 @@ fun GetSeekBar(
                         text = "-${formatAsDuration(timeRemaining.toLong())}",
                         style = typography.xxs.semiBold.merge(TextStyle(
                             drawStyle = Stroke(width = 1.0f, join = StrokeJoin.Round),
-                            color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light) Color.White.copy(0.5f)
+                            color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(0.5f)
                             else Color.Black)),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
@@ -412,7 +413,7 @@ fun GetSeekBar(
                     style = typography.xxs.semiBold.merge(
                         TextStyle(
                             drawStyle = Stroke(width = 1.0f, join = StrokeJoin.Round),
-                            color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light) Color.White.copy(
+                            color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
                                 0.5f
                             )
                             else Color.Black


### PR DESCRIPTION
1) Added swipe for video results too
2) fixed outline color. Now if theme mode is system and system is in dark mode then it will follow light theme outline pattern. fixes #2648
3) removed 'useless' expanded player button when "show thumbnail for lyrics" is enabled fixes #2658 
4) fixed gradient inconsistencies when "show thumbnail for lyrics" is on fixes #2657