### PR TITLE
fixed modern control shadows and padding in expanded player mode

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Controls.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Controls.kt
@@ -330,7 +330,7 @@ fun Controls(
                     likedAt = likedAt,
                     mediaId = mediaId
                 )
-                if ((!transparentBackgroundActionBarPlayer) && (playerPlayButtonType != PlayerPlayButtonType.Disabled)) {
+                if (((playerControlsType == PlayerControlsType.Modern) || (!transparentBackgroundActionBarPlayer)) && (playerPlayButtonType != PlayerPlayButtonType.Disabled)) {
                     Spacer(
                         modifier = Modifier
                             .height(10.dp)

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
@@ -83,6 +83,7 @@ import it.fast4x.rimusic.utils.textoutlineKey
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.draw.clip
+import it.fast4x.rimusic.utils.doubleShadowDrop
 
 
 @androidx.annotation.OptIn(UnstableApi::class)
@@ -364,6 +365,7 @@ fun ControlsModern(
           onClick = {},
           modifier = Modifier
               .size(55.dp)
+              .doubleShadowDrop(RoundedCornerShape(8.dp), 4.dp, 8.dp)
               .clip(RoundedCornerShape(8.dp))
               .combinedClickable(
                   indication = ripple(bounded = true),
@@ -451,6 +453,7 @@ fun ControlsModern(
               backgroundColor = colorPalette.background2.copy(0.95f),
               onClick = {},
               modifier = Modifier
+                  .doubleShadowDrop(RoundedCornerShape(8.dp), 4.dp, 8.dp)
                   .clip(RoundedCornerShape(8.dp))
                   .combinedClickable(
                       indication = ripple(bounded = true),
@@ -530,6 +533,7 @@ fun ControlsModern(
         onClick = {},
         modifier = Modifier
             .size(55.dp)
+            .doubleShadowDrop(RoundedCornerShape(8.dp), 4.dp, 8.dp)
             .clip(RoundedCornerShape(8.dp))
             .combinedClickable(
                 indication = ripple(bounded = true),


### PR DESCRIPTION
1) My previous pull request removed button shadows by mistake so I added it back. Now shadows and ripple bounded by shape both are working

https://github.com/fast4x/RiMusic/assets/45353488/d549a6a3-0b60-4152-8642-8edb320b28d3

It's perfect now

2) fixed modern controls padding for expanded player