### PR TITLE
Added expanded player to landscape mode & added back button in lyrics (not working)

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Controls.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Controls.kt
@@ -1,6 +1,7 @@
 package it.fast4x.rimusic.ui.screens.player
 
 import android.annotation.SuppressLint
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Animatable
@@ -126,6 +127,7 @@ import kotlinx.coroutines.launch
 import it.fast4x.rimusic.utils.expandedplayerKey
 import it.fast4x.rimusic.utils.isLandscape
 import it.fast4x.rimusic.utils.showlyricsthumbnailKey
+import it.fast4x.rimusic.utils.showthumbnailKey
 import it.fast4x.rimusic.utils.transparentBackgroundPlayerActionBarKey
 
 
@@ -268,6 +270,8 @@ fun Controls(
     )
     var playerControlsType by rememberPreference(playerControlsTypeKey, PlayerControlsType.Modern)
     var playerPlayButtonType by rememberPreference(playerPlayButtonTypeKey, PlayerPlayButtonType.Default)
+    var showthumbnail by rememberPreference(showthumbnailKey, true)
+    val expandedlandscape = expandedplayer && !showthumbnail
 
     Box(
         modifier = Modifier
@@ -433,6 +437,7 @@ fun Controls(
     if (isLandscape)
         Column(
             horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.Bottom,
             modifier = modifier
                 .fillMaxWidth()
                 .padding(horizontal = playerTimelineSize.size.dp)
@@ -470,7 +475,7 @@ fun Controls(
 
             Spacer(
                 modifier = Modifier
-                    .height(25.dp)
+                    .height(if (expandedlandscape) 10.dp else 25.dp)
             )
 
             if (!playerSwapControlsWithTimeline) {
@@ -482,7 +487,9 @@ fun Controls(
                 )
                 Spacer(
                     modifier = Modifier
-                        .weight(0.4f)
+                        .animateContentSize()
+                        .conditional(!expandedlandscape) { weight(0.4f) }
+                        .conditional(expandedlandscape) { height(15.dp) }
                 )
                 GetControls(
                     binder = binder,
@@ -493,7 +500,9 @@ fun Controls(
                 )
                 Spacer(
                     modifier = Modifier
-                        .weight(0.5f)
+                        .animateContentSize()
+                        .conditional(!expandedlandscape) { weight(0.5f) }
+                        .conditional(expandedlandscape) { height(15.dp) }
                 )
             } else {
                 GetControls(
@@ -505,7 +514,9 @@ fun Controls(
                 )
                 Spacer(
                     modifier = Modifier
-                        .weight(0.5f)
+                        .animateContentSize()
+                        .conditional(!expandedlandscape) { weight(0.5f) }
+                        .conditional(expandedlandscape) { height(15.dp) }
                 )
                 GetSeekBar(
                     position = position,
@@ -515,7 +526,9 @@ fun Controls(
                 )
                 Spacer(
                     modifier = Modifier
-                        .weight(0.4f)
+                        .animateContentSize()
+                        .conditional(!expandedlandscape) { weight(0.4f) }
+                        .conditional(expandedlandscape) { height(15.dp) }
                 )
             }
         }
@@ -542,6 +555,14 @@ fun Modifier.bounceClick() = composed {
                 }
             }
         }
+}
+
+fun Modifier.conditional(condition : Boolean, modifier : Modifier.() -> Modifier) : Modifier {
+    return if (condition) {
+        then(modifier(Modifier))
+    } else {
+        this
+    }
 }
 
 

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Lyrics.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Lyrics.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -146,6 +147,7 @@ import kotlin.time.Duration.Companion.seconds
 import it.fast4x.rimusic.enums.LyricsBackground
 import it.fast4x.rimusic.utils.cleanPrefix
 import it.fast4x.rimusic.utils.lyricsBackgroundKey
+import it.fast4x.rimusic.utils.isShowingLyricsKey
 
 
 @UnstableApi
@@ -1619,13 +1621,28 @@ fun Lyrics(
                 }
             }
             /*********/
-
+            var isShowingLyrics by rememberSaveable {
+                mutableStateOf(false)
+            }
 
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomStart)
                     .fillMaxWidth(if (trailingContent == null) 0.30f else 0.22f)
             ) {
+                /*if (isLandscape && !showlyricsthumbnail)
+                    IconButton(
+                        icon = R.drawable.chevron_back,
+                        color = colorPalette.accent,
+                        enabled = true,
+                        onClick = {
+                            isShowingLyrics = false
+                        },
+                        modifier = Modifier
+                            .padding(all = 8.dp)
+                            .align(Alignment.BottomStart)
+                            .size(30.dp)
+                    )*/
                 if (showlyricsthumbnail)
                     IconButton(
                         icon = R.drawable.minmax,

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
@@ -1482,7 +1482,7 @@ fun PlayerModern(
                                 modifier = Modifier
                                     .size(24.dp),
                             )
-                        if (!isLandscape)
+                        if (!isLandscape || !showthumbnail)
                          if (expandedplayertoggle && (!showlyricsthumbnail) && !expandedlyrics)
                             IconButton(
                                 icon = R.drawable.minmax,

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
@@ -1092,18 +1092,21 @@ fun AppearanceSettings() {
                 isChecked = showButtonPlayerLyrics,
                 onCheckedChange = { showButtonPlayerLyrics = it }
             )
-        if (!showlyricsthumbnail and !expandedlyrics and !isLandscape)
-        if (filter.isNullOrBlank() || stringResource(R.string.expandedplayer).contains(
-                filterCharSequence,
-                true
-            )
-        )
-            SwitchSettingEntry(
-                title = stringResource(R.string.expandedplayer),
-                text = "",
-                isChecked = expandedplayertoggle,
-                onCheckedChange = { expandedplayertoggle = it }
-            )
+        if (!isLandscape || !showthumbnail) {
+            if (!showlyricsthumbnail and !expandedlyrics) {
+                if (filter.isNullOrBlank() || stringResource(R.string.expandedplayer).contains(
+                        filterCharSequence,
+                        true
+                    )
+                )
+                    SwitchSettingEntry(
+                        title = stringResource(R.string.expandedplayer),
+                        text = "",
+                        isChecked = expandedplayertoggle,
+                        onCheckedChange = { expandedplayertoggle = it }
+                    )
+            }
+        }
 
         if (filter.isNullOrBlank() || stringResource(R.string.action_bar_show_sleep_timer_button).contains(
                 filterCharSequence,


### PR DESCRIPTION
1) I used RiMusic in my PC and saw that the controls are taking so much space so I decided to add expanded player here too. It works only when thumbnail is disabled

https://github.com/fast4x/RiMusic/assets/45353488/aabfa857-c1f9-421c-b3e3-0300d74a6d6e

2) Added back button in landscape lyrics but it's not working. Disabled the code. Look for the code from 1633 to 1645 in Lyrics.kt