### PR TITLE
fixed horizontal alignment when only one next song is shown

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
@@ -1176,6 +1176,7 @@ fun PlayerModern(
                             Row(
                                   modifier = Modifier
                                       .padding(vertical = 7.5.dp)
+                                      .weight(if (showtwosongs) 0.15f else 0.07f)
                               ){
                                   Icon(
                                       painter = painterResource(id = R.drawable.chevron_forward),
@@ -1288,6 +1289,13 @@ fun PlayerModern(
                                     }
                                 }
                             }
+                            if (!showtwosongs) {
+                                Row(
+                                    modifier = modifier
+                                        .weight(0.07f)
+                                ){}
+                            }
+
                             if (showtwosongs) {
                                 Row(
                                     horizontalArrangement = Arrangement.Center,


### PR DESCRIPTION
Before and after
![GridArt_20240707_222524248.jpg](https://github.com/fast4x/RiMusic/assets/45353488/5a016a30-ebba-4168-9f53-85a09bff9575)

