### PR TITLE
Improvements in Landscape Layout 2

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/enums/PrevNextSongs.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/enums/PrevNextSongs.kt
@@ -1,0 +1,7 @@
+package it.fast4x.rimusic.enums
+
+enum class PrevNextSongs {
+    Hide,
+    onesong,
+    twosongs;
+}

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Controls.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Controls.kt
@@ -68,6 +68,7 @@ import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.ButtonState
 import it.fast4x.rimusic.enums.ColorPaletteName
+import it.fast4x.rimusic.enums.LandscapeLayout
 import it.fast4x.rimusic.enums.NavRoutes
 import it.fast4x.rimusic.enums.PauseBetweenSongs
 import it.fast4x.rimusic.enums.PlayerControlsType
@@ -126,6 +127,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import it.fast4x.rimusic.utils.expandedplayerKey
 import it.fast4x.rimusic.utils.isLandscape
+import it.fast4x.rimusic.utils.landscapeLayoutKey
 import it.fast4x.rimusic.utils.showlyricsthumbnailKey
 import it.fast4x.rimusic.utils.showthumbnailKey
 import it.fast4x.rimusic.utils.transparentBackgroundPlayerActionBarKey
@@ -271,7 +273,8 @@ fun Controls(
     var playerControlsType by rememberPreference(playerControlsTypeKey, PlayerControlsType.Modern)
     var playerPlayButtonType by rememberPreference(playerPlayButtonTypeKey, PlayerPlayButtonType.Default)
     var showthumbnail by rememberPreference(showthumbnailKey, true)
-    val expandedlandscape = expandedplayer && !showthumbnail
+    var landscapeLayout by rememberPreference(landscapeLayoutKey, LandscapeLayout.Layout1)
+    val expandedlandscape = (landscapeLayout == LandscapeLayout.Layout2) || (expandedplayer && !showthumbnail)
 
     Box(
         modifier = Modifier

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
@@ -214,6 +214,7 @@ import it.fast4x.rimusic.enums.ClickLyricsText
 import it.fast4x.rimusic.enums.LandscapeLayout
 import it.fast4x.rimusic.enums.PlayerPlayButtonType
 import it.fast4x.rimusic.enums.PlayerTimelineType
+import it.fast4x.rimusic.enums.PrevNextSongs
 import it.fast4x.rimusic.enums.ThumbnailRoundness
 import it.fast4x.rimusic.enums.ThumbnailType
 import it.fast4x.rimusic.utils.actionspacedevenlyKey
@@ -239,6 +240,7 @@ import it.fast4x.rimusic.utils.landscapeLayoutKey
 import it.fast4x.rimusic.utils.lastPlayerPlayButtonTypeKey
 import it.fast4x.rimusic.utils.playerPlayButtonTypeKey
 import it.fast4x.rimusic.utils.playerTimelineTypeKey
+import it.fast4x.rimusic.utils.prevNextSongsKey
 import it.fast4x.rimusic.utils.resize
 import it.fast4x.rimusic.utils.showalbumcoverKey
 import it.fast4x.rimusic.utils.showtwosongsKey
@@ -1663,17 +1665,30 @@ fun PlayerModern(
         val player = binder?.player ?: return
         val clickLyricsText by rememberPreference(clickLyricsTextKey, ClickLyricsText.FullScreen)
         var extraspace by rememberPreference(extraspaceKey, false)
+        val nextMediaItemIndex = binder.player.nextMediaItemIndex
+        val prevMediaItemIndex = binder.player.previousMediaItemIndex
         val nextMediaItem = if (binder.player.hasNextMediaItem())
             binder.player.getMediaItemAt(binder.player.nextMediaItemIndex)
         else MediaItem.EMPTY
+        val nextNextMediaItem = try {
+            binder.player.getMediaItemAt(nextMediaItemIndex + 1)
+        } catch (e: Exception) {
+            MediaItem.EMPTY
+        }
         val prevMediaItem = if (binder.player.hasPreviousMediaItem())
             binder.player.getMediaItemAt(binder.player.previousMediaItemIndex)
         else MediaItem.EMPTY
+        val prevPrevMediaItem = try {
+            binder.player.getMediaItemAt(prevMediaItemIndex - 1)
+        } catch (e: Exception) {
+            MediaItem.EMPTY
+        }
         var thumbnailRoundness by rememberPreference(thumbnailRoundnessKey, ThumbnailRoundness.Heavy)
         var hideprevnext by rememberPreference(hideprevnextKey, false)
         var playerTimelineType by rememberPreference(playerTimelineTypeKey, PlayerTimelineType.Default)
         var playerPlayButtonType by rememberPreference(playerPlayButtonTypeKey,PlayerPlayButtonType.Rectangular)
         val thumbnailType by rememberPreference(thumbnailTypeKey, ThumbnailType.Modern)
+        var prevNextSongs by rememberPreference(prevNextSongsKey, PrevNextSongs.twosongs)
 
         if (isLandscape) {
             Row(
@@ -1820,7 +1835,65 @@ fun PlayerModern(
                          ) {
                              if (showthumbnail) {
                                  if ((!isShowingLyrics && !isShowingVisualizer) || (isShowingVisualizer && showvisthumbnail) || (isShowingLyrics && showlyricsthumbnail)) {
-                                     if (!hideprevnext) {
+                                     if (prevNextSongs != PrevNextSongs.Hide) {
+                                         if (prevNextSongs == PrevNextSongs.twosongs) {
+                                             AsyncImage(
+                                                 model = prevPrevMediaItem.mediaMetadata.artworkUri.toString()
+                                                     .resize(1200, 1200),
+                                                 contentDescription = null,
+                                                 contentScale = ContentScale.Fit,
+                                                 modifier = Modifier
+                                                     .padding(
+                                                         all = playerThumbnailSize.size.dp + 60.dp
+                                                     )
+                                                     .padding(start = playerPlayButtonType.height.dp - 60.dp)
+                                                     .conditional(playerTimelineType == PlayerTimelineType.FakeAudioBar) {
+                                                         padding(
+                                                             start = 40.dp
+                                                         )
+                                                     }
+                                                     .offset(
+                                                         -((thumbnailSizeDp / 2) - 2 * (playerThumbnailSize.size.dp)),
+                                                         0.dp
+                                                     )
+                                                     .conditional(thumbnailType == ThumbnailType.Modern) {
+                                                         doubleShadowDrop(
+                                                             thumbnailRoundness.shape(),
+                                                             4.dp,
+                                                             8.dp
+                                                         )
+                                                     }
+                                                     .clip(thumbnailRoundness.shape())
+                                             )
+                                             AsyncImage(
+                                                 model = nextNextMediaItem.mediaMetadata.artworkUri.toString()
+                                                     .resize(1200, 1200),
+                                                 contentDescription = null,
+                                                 contentScale = ContentScale.Fit,
+                                                 modifier = Modifier
+                                                     .padding(
+                                                         all = playerThumbnailSize.size.dp + 60.dp
+                                                     )
+                                                     .padding(start = playerPlayButtonType.height.dp - 60.dp)
+                                                     .conditional(playerTimelineType == PlayerTimelineType.FakeAudioBar) {
+                                                         padding(
+                                                             start = 40.dp
+                                                         )
+                                                     }
+                                                     .offset(
+                                                         ((thumbnailSizeDp / 2) - 2 * (playerThumbnailSize.size.dp)),
+                                                         0.dp
+                                                     )
+                                                     .conditional(thumbnailType == ThumbnailType.Modern) {
+                                                         doubleShadowDrop(
+                                                             thumbnailRoundness.shape(),
+                                                             4.dp,
+                                                             8.dp
+                                                         )
+                                                     }
+                                                     .clip(thumbnailRoundness.shape())
+                                             )
+                                         }
                                          AsyncImage(
                                              model = prevMediaItem.mediaMetadata.artworkUri.toString()
                                                  .resize(1200, 1200),
@@ -1832,7 +1905,8 @@ fun PlayerModern(
                                                  )
                                                  .padding(start = playerPlayButtonType.height.dp - 60.dp)
                                                  .conditional(playerTimelineType == PlayerTimelineType.FakeAudioBar) {padding(start = 40.dp)}
-                                                 .offset(-((thumbnailSizeDp/2) - 2*(playerThumbnailSize.size.dp)),0.dp)
+                                                 .conditional(prevNextSongs == PrevNextSongs.onesong) {offset(-((thumbnailSizeDp/2) - 2*(playerThumbnailSize.size.dp)),0.dp)}
+                                                 .conditional(prevNextSongs == PrevNextSongs.twosongs) {offset(-((thumbnailSizeDp/3) - 2*(playerThumbnailSize.size.dp)),0.dp)}
                                                  .conditional(thumbnailType == ThumbnailType.Modern) {doubleShadowDrop(thumbnailRoundness.shape(), 4.dp, 8.dp)}
                                                  .clip(thumbnailRoundness.shape())
                                          )
@@ -1847,7 +1921,8 @@ fun PlayerModern(
                                                  )
                                                  .padding(end = playerPlayButtonType.height.dp - 60.dp)
                                                  .conditional(playerTimelineType == PlayerTimelineType.FakeAudioBar) {padding(end = 40.dp)}
-                                                 .offset((thumbnailSizeDp/2) - 2*(playerThumbnailSize.size.dp),0.dp)
+                                                 .conditional(prevNextSongs == PrevNextSongs.onesong) {offset(((thumbnailSizeDp/2) - 2*(playerThumbnailSize.size.dp)),0.dp)}
+                                                 .conditional(prevNextSongs == PrevNextSongs.twosongs) {offset(((thumbnailSizeDp/3) - 2*(playerThumbnailSize.size.dp)),0.dp)}
                                                  .conditional(thumbnailType == ThumbnailType.Modern) {doubleShadowDrop(thumbnailRoundness.shape(), 4.dp, 8.dp)}
                                                  .clip(thumbnailRoundness.shape())
                                          )

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
@@ -212,7 +212,10 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.times
 import it.fast4x.rimusic.enums.ClickLyricsText
 import it.fast4x.rimusic.enums.LandscapeLayout
+import it.fast4x.rimusic.enums.PlayerPlayButtonType
+import it.fast4x.rimusic.enums.PlayerTimelineType
 import it.fast4x.rimusic.enums.ThumbnailRoundness
+import it.fast4x.rimusic.enums.ThumbnailType
 import it.fast4x.rimusic.utils.actionspacedevenlyKey
 import it.fast4x.rimusic.utils.expandedplayerKey
 import it.fast4x.rimusic.utils.expandedplayertoggleKey
@@ -228,15 +231,20 @@ import it.fast4x.rimusic.utils.textoutlineKey
 import kotlin.Float.Companion.POSITIVE_INFINITY
 import it.fast4x.rimusic.utils.clickLyricsTextKey
 import it.fast4x.rimusic.utils.disableScrollingTextKey
+import it.fast4x.rimusic.utils.doubleShadowDrop
 import it.fast4x.rimusic.utils.expandedlyricsKey
 import it.fast4x.rimusic.utils.extraspaceKey
 import it.fast4x.rimusic.utils.hideprevnextKey
 import it.fast4x.rimusic.utils.landscapeLayoutKey
+import it.fast4x.rimusic.utils.lastPlayerPlayButtonTypeKey
+import it.fast4x.rimusic.utils.playerPlayButtonTypeKey
+import it.fast4x.rimusic.utils.playerTimelineTypeKey
 import it.fast4x.rimusic.utils.resize
 import it.fast4x.rimusic.utils.showalbumcoverKey
 import it.fast4x.rimusic.utils.showtwosongsKey
 import it.fast4x.rimusic.utils.showvisthumbnailKey
 import it.fast4x.rimusic.utils.thumbnailRoundnessKey
+import it.fast4x.rimusic.utils.thumbnailTypeKey
 
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
@@ -1663,6 +1671,9 @@ fun PlayerModern(
         else MediaItem.EMPTY
         var thumbnailRoundness by rememberPreference(thumbnailRoundnessKey, ThumbnailRoundness.Heavy)
         var hideprevnext by rememberPreference(hideprevnextKey, false)
+        var playerTimelineType by rememberPreference(playerTimelineTypeKey, PlayerTimelineType.Default)
+        var playerPlayButtonType by rememberPreference(playerPlayButtonTypeKey,PlayerPlayButtonType.Rectangular)
+        val thumbnailType by rememberPreference(thumbnailTypeKey, ThumbnailType.Modern)
 
         if (isLandscape) {
             Row(
@@ -1802,7 +1813,7 @@ fun PlayerModern(
                          Box(
                              contentAlignment = Alignment.Center,
                              modifier = Modifier
-                                 .fillMaxHeight(0.6f)
+                                 .weight(1f)
                              /*modifier = Modifier
                             .weight(1f)*/
                              //.padding(vertical = 10.dp)
@@ -1819,7 +1830,10 @@ fun PlayerModern(
                                                  .padding(
                                                      all = playerThumbnailSize.size.dp + 40.dp
                                                  )
+                                                 .padding(start = playerPlayButtonType.height.dp - 60.dp)
+                                                 .conditional(playerTimelineType == PlayerTimelineType.FakeAudioBar) {padding(start = 40.dp)}
                                                  .offset(-((thumbnailSizeDp/2) - 2*(playerThumbnailSize.size.dp)),0.dp)
+                                                 .conditional(thumbnailType == ThumbnailType.Modern) {doubleShadowDrop(thumbnailRoundness.shape(), 4.dp, 8.dp)}
                                                  .clip(thumbnailRoundness.shape())
                                          )
                                          AsyncImage(
@@ -1831,7 +1845,10 @@ fun PlayerModern(
                                                  .padding(
                                                      all = playerThumbnailSize.size.dp + 40.dp
                                                  )
+                                                 .padding(end = playerPlayButtonType.height.dp - 60.dp)
+                                                 .conditional(playerTimelineType == PlayerTimelineType.FakeAudioBar) {padding(end = 40.dp)}
                                                  .offset((thumbnailSizeDp/2) - 2*(playerThumbnailSize.size.dp),0.dp)
+                                                 .conditional(thumbnailType == ThumbnailType.Modern) {doubleShadowDrop(thumbnailRoundness.shape(), 4.dp, 8.dp)}
                                                  .clip(thumbnailRoundness.shape())
                                          )
                                      }
@@ -1880,8 +1897,8 @@ fun PlayerModern(
                     controlsContent(
                         modifier = Modifier
                             .padding(vertical = 8.dp)
-                            .fillMaxHeight()
-                            .weight(1f)
+                            .conditional(landscapeLayout == LandscapeLayout.Layout1) {fillMaxHeight()}
+                            .conditional(landscapeLayout == LandscapeLayout.Layout1) {weight(1f)}
                     )
 
                     actionsBarContent(

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
@@ -237,7 +237,6 @@ import it.fast4x.rimusic.utils.expandedlyricsKey
 import it.fast4x.rimusic.utils.extraspaceKey
 import it.fast4x.rimusic.utils.hideprevnextKey
 import it.fast4x.rimusic.utils.landscapeLayoutKey
-import it.fast4x.rimusic.utils.lastPlayerPlayButtonTypeKey
 import it.fast4x.rimusic.utils.playerPlayButtonTypeKey
 import it.fast4x.rimusic.utils.playerTimelineTypeKey
 import it.fast4x.rimusic.utils.prevNextSongsKey

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
@@ -59,6 +59,7 @@ import it.fast4x.rimusic.enums.PlayerThumbnailSize
 import it.fast4x.rimusic.enums.PlayerTimelineSize
 import it.fast4x.rimusic.enums.PlayerTimelineType
 import it.fast4x.rimusic.enums.PlayerVisualizerType
+import it.fast4x.rimusic.enums.PrevNextSongs
 import it.fast4x.rimusic.enums.ThumbnailRoundness
 import it.fast4x.rimusic.enums.ThumbnailType
 import it.fast4x.rimusic.ui.components.themed.HeaderIconButton
@@ -130,6 +131,7 @@ import it.fast4x.rimusic.utils.textoutlineKey
 import it.fast4x.rimusic.utils.thumbnailTypeKey
 import it.fast4x.rimusic.utils.thumbnailpauseKey
 import it.fast4x.rimusic.utils.landscapeLayoutKey
+import it.fast4x.rimusic.utils.prevNextSongsKey
 
 
 @ExperimentalAnimationApi
@@ -264,7 +266,7 @@ fun AppearanceSettings() {
     var showtwosongs by rememberPreference(showtwosongsKey, true)
     var showalbumcover by rememberPreference(showalbumcoverKey, true)
     var landscapeLayout by rememberPreference(landscapeLayoutKey,LandscapeLayout.Layout1)
-    var hideprevnext by rememberPreference(hideprevnextKey, false)
+    var prevNextSongs by rememberPreference(prevNextSongsKey, PrevNextSongs.twosongs)
 
     Column(
         modifier = Modifier
@@ -422,17 +424,19 @@ fun AppearanceSettings() {
                     }
                 )
             if (landscapeLayout == LandscapeLayout.Layout2 && showthumbnail) {
-                if (filter.isNullOrBlank() || stringResource(R.string.hideprevnext).contains(
-                        filterCharSequence,
-                        true
-                    )
+                EnumValueSelectorSettingsEntry(
+                    title = stringResource(R.string.hideprevnext),
+                    titleSecondary = "",
+                    selectedValue = prevNextSongs,
+                    onValueSelected = { prevNextSongs = it },
+                    valueText = {
+                        when (it) {
+                            PrevNextSongs.Hide -> stringResource(R.string.hide)
+                            PrevNextSongs.onesong -> stringResource(R.string.onesong)
+                            PrevNextSongs.twosongs -> stringResource(R.string.twosongs)
+                        }
+                    }
                 )
-                    SwitchSettingEntry(
-                        title = stringResource(R.string.hideprevnext),
-                        text = "",
-                        isChecked = hideprevnext,
-                        onCheckedChange = { hideprevnext = it }
-                    )
             }
         }
         

--- a/app/src/main/kotlin/it/fast4x/rimusic/utils/Preferences.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/utils/Preferences.kt
@@ -220,6 +220,7 @@ const val showalbumcoverKey = "showalbumcover"
 const val lyricsBackgroundKey = "lyricsBackground"
 const val landscapeLayoutKey = "landscapeLayout"
 const val hideprevnextKey = "hideprevnext"
+const val prevNextSongsKey = "prevNextSongs"
 /**** CUSTOM THEME **** */
 
 const val parentalControlEnabledKey = "parentalControlEnabled"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -644,5 +644,7 @@
     <string name="landscapelayout">Landscape Layout</string>
     <string name="layout">Layout</string>
     <string name="layoutinfo">Layout 2 is Recommended only for Big Screens</string>
-    <string name="hideprevnext">Hide Previous and Next Songs</string>
+    <string name="hideprevnext">Queue Songs in Player</string>
+    <string name="onesong">One Song</string>
+    <string name="twosongs">Two Songs</string>
 </resources>


### PR DESCRIPTION
1) Now thumbnail will take only the space left after artists, albums and controls.
 changing controls will also adjust thumbnails size
2) added shadow to side thumbnails for modern thumbnail
3)

https://github.com/fast4x/RiMusic/assets/45353488/e7def4fd-692a-4487-af6b-5e974edd281e





