### PR TITLE
added check if currentVisualizer is too large

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/extensions/nextvisualizer/NextVisualizer.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/extensions/nextvisualizer/NextVisualizer.kt
@@ -156,8 +156,8 @@ fun NextVisualizer() {
 
             val visualizersList = getVisualizers()
             var currentVisualizer by rememberPreference(currentVisualizerKey, 0)
-            if (currentVisualizer < 0) currentVisualizer = 0
-            else if (currentVisualizer > visualizersList.lastIndex) currentVisualizer = 0
+            if (currentVisualizer < 0 || currentVisualizer > visualizersList.lastIndex)
+                currentVisualizer = 0
 
             Box(
                 modifier = Modifier.fillMaxSize()

--- a/app/src/main/kotlin/it/fast4x/rimusic/extensions/nextvisualizer/NextVisualizer.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/extensions/nextvisualizer/NextVisualizer.kt
@@ -157,6 +157,7 @@ fun NextVisualizer() {
             val visualizersList = getVisualizers()
             var currentVisualizer by rememberPreference(currentVisualizerKey, 0)
             if (currentVisualizer < 0) currentVisualizer = 0
+            else if (currentVisualizer > visualizersList.lastIndex) currentVisualizer = 0
 
             Box(
                 modifier = Modifier.fillMaxSize()


### PR DESCRIPTION
Without this, there would be a problem if the number of visualizers is reduced one day.