### PR TITLE
adds radio songs if mediacount < 50

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/service/PlayerService.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/service/PlayerService.kt
@@ -914,7 +914,7 @@ class PlayerService : InvincibleService(),
 
     private fun maybeProcessRadio() {
         radio?.let { radio ->
-            if (player.mediaItemCount - player.currentMediaItemIndex <= 3) {
+            if ((player.mediaItemCount < 50) || player.mediaItemCount - player.currentMediaItemIndex <= 3) {
                 coroutineScope.launch(Dispatchers.Main) {
                     player.addMediaItems(radio.process())
                 }


### PR DESCRIPTION
since you can remove favorites and playlist songs from queue, songs can go below 50 easily. This code will add new songs in radio if songs are less than 50 in queue