### PR TITLE
Reorder problems in queue and local playlist fixed

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
@@ -1494,7 +1494,7 @@ fun LocalPlaylistSongs(
                                 .width(44.dp)
                                 .height(24.dp)
                                 .align(Alignment.TopEnd)
-                                .offset(x = -0.dp)
+                                .offset(x = 0.dp)
                                 .zIndex(10f)
                         )
                     }

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -1490,9 +1491,10 @@ fun LocalPlaylistSongs(
                                     reorderingState = reorderingState,
                                     index = index
                                 )
-                                .size(24.dp)
+                                .width(44.dp)
+                                .height(24.dp)
                                 .align(Alignment.TopEnd)
-                                .offset(x = -15.dp)
+                                .offset(x = -0.dp)
                                 .zIndex(10f)
                         )
                     }
@@ -1712,10 +1714,4 @@ fun LocalPlaylistSongs(
 
     }
 }
-
-
-
-
-
-
 

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Queue.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Queue.kt
@@ -502,7 +502,8 @@ fun Queue(
                                                         reorderingState = reorderingState,
                                                         index = window.firstPeriodIndex
                                                     )
-                                                    .size(18.dp)
+                                                    .width(37.dp)
+                                                    .height(20.dp)
                                             )
                                         }
                                     },

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Queue.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Queue.kt
@@ -502,7 +502,7 @@ fun Queue(
                                                         reorderingState = reorderingState,
                                                         index = window.firstPeriodIndex
                                                     )
-                                                    .width(37.dp)
+                                                    .width(36.dp)
                                                     .height(20.dp)
                                             )
                                         }

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/QueueModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/QueueModern.kt
@@ -434,9 +434,10 @@ fun QueueModern(
                                             reorderingState = reorderingState,
                                             index = window.firstPeriodIndex
                                         )
-                                        .size(24.dp)
+                                        .width(44.dp)
+                                        .height(24.dp)
                                         .align(Alignment.TopEnd)
-                                        .offset(x = -15.dp)
+                                        .offset(x = 0.dp)
                                         .zIndex(5f)
                                 )
                             }

--- a/app/src/main/res/drawable/reorder.xml
+++ b/app/src/main/res/drawable/reorder.xml
@@ -1,17 +1,17 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
+    android:width="44dp"
     android:height="24dp"
     android:viewportWidth="512"
     android:viewportHeight="512">
   <path
-      android:pathData="M118,304L394,304"
+      android:pathData="M118,304L280,304"
       android:strokeLineJoin="round"
       android:strokeWidth="44"
       android:fillColor="#00000000"
       android:strokeColor="#000"
       android:strokeLineCap="round"/>
   <path
-      android:pathData="M118,208L394,208"
+      android:pathData="M118,208L280,208"
       android:strokeLineJoin="round"
       android:strokeWidth="44"
       android:fillColor="#00000000"

--- a/app/src/main/res/drawable/reorder.xml
+++ b/app/src/main/res/drawable/reorder.xml
@@ -4,14 +4,14 @@
     android:viewportWidth="512"
     android:viewportHeight="512">
   <path
-      android:pathData="M118,304L280,304"
+      android:pathData="M128,304L280,304"
       android:strokeLineJoin="round"
       android:strokeWidth="44"
       android:fillColor="#00000000"
       android:strokeColor="#000"
       android:strokeLineCap="round"/>
   <path
-      android:pathData="M118,208L280,208"
+      android:pathData="M128,208L280,208"
       android:strokeLineJoin="round"
       android:strokeWidth="44"
       android:fillColor="#00000000"


### PR DESCRIPTION
I have noticed that the items in the queue can no longer be moved.

**Problem:** 
The offset specified in the screens only causes the icon to be moved. The click area remains on the outer edge of the screen and is therefore not tappable with screen edge gesture navigation (or generally difficult to reach).

**Solution:**
Offset set in icon, offset removed where icon is called up
The icon is now slightly wider and can hopefully now be operated with ‘stubby fingers’

I could not find a call to the non-modern queue in the app. I was therefore unable to test the layout. Is it possible that this screen is no longer needed?