### PR TITLE
Better layout in website footer

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -6,7 +6,7 @@ select {
   position: fixed;
   width: 100vw;
   height: 100vh;
-  background-color: #0B0D19;
+  background-color: #0b0d19;
   z-index: 2;
   display: flex;
   align-items: center;
@@ -24,7 +24,7 @@ select {
   animation: l15 1s infinite linear;
 }
 .loader::before,
-.loader::after {    
+.loader::after {
   content: "";
   grid-area: 1/1;
   margin: 2px;
@@ -36,118 +36,133 @@ select {
   margin: 8px;
   animation-duration: 3s;
 }
-@keyframes l15{ 
-  100%{transform: rotate(1turn)}
+@keyframes l15 {
+  100% {
+    transform: rotate(1turn);
+  }
 }
-#languageSelect{
-  padding:0 5px 0 5px
+#languageSelect {
+  padding: 0 5px 0 5px;
 }
-.footer-links > li > a{
-    white-space: nowrap
+.footer-links > li > a {
+  white-space: nowrap;
 }
 @media (max-width: 740px) {
-    .footer-links {   
-        flex-direction: column;
-        text-align: right
-    }
-    .footer-links > li {
-        margin: 2px !important  
-    }
+  .footer-links {
+    flex-direction: column;
+    text-align: right;
+  }
+  .footer-links > li {
+    margin: 2px !important;
+  }
 }
 @media (max-width: 640px) {
-    .footer-links {   
-        text-align: center;
-    }
-} 
+  .footer-links {
+    text-align: center;
+  }
+}
 @media (max-width: 840px) {
   @media (min-width: 641px) {
     .feature-extended-body {
       width: 45%;
     }
     .container > div:nth-child(even) {
-      img.device-mockup{
-        left: calc(0vw - (95px - 12vw) *2) !important
+      img.device-mockup {
+        left: calc(0vw - (95px - 12vw) * 2) !important;
       }
     }
     .container > div:nth-child(odd) {
-      img.device-mockup{
-        right: calc(0vw - (95px - 12vw) *2) !important
+      img.device-mockup {
+        right: calc(0vw - (95px - 12vw) * 2) !important;
       }
     }
   }
   .feature-extended-image {
     margin-right: 12% !important;
     margin-left: 12% !important;
-  }  
+  }
 }
 .feature-extended-body p {
-    color: #36517c;
+  color: #36517c;
 }
 .hero-bg,
 .site-footer {
-  background-color: #181d36 !important
+  background-color: #181d36 !important;
 }
 .hero-paragraph,
 .site-footer a,
 .site-footer p {
-  color: #ABBAD0 !important
+  color: #abbad0 !important;
 }
 #toggledark {
-  --color: #ABBAD0;
+  --color: #abbad0;
   --moon: 0.4;
-  --sun: 0.95
+  --sun: 0.95;
 }
 .focustoggle:hover {
-  --color: #4fc17c!important;
-  cursor: pointer
+  --color: #4fc17c !important;
+  cursor: pointer;
 }
 body,
-.body-wrap  {
-  transition: background-color 250ms ;
+.body-wrap {
+  transition: background-color 250ms;
 }
 body.dark {
   background-color: #0d1117;
   #toggledark {
     --sun: 0.4 !important;
     --moon: 0.95 !important
+  ;
   }
-  #languageSelect > option{
-    color:#15182b
+  #languageSelect > option {
+    color: #15182b;
   }
   .hero-paragraph,
   .site-footer a,
   .site-footer p {
-    color: #ABBAD0 important;
+    color: #abbad0 important;
   }
   .feature-extended p {
-    color: #ABBAD0;
+    color: #abbad0;
   }
   .hero-bg,
   .site-footer {
-    background-color: #0B0D19 !important;
+    background-color: #0b0d19 !important;
   }
   .body-wrap {
     background-color: #15182b;
   }
-  .mockup-bg>img {
-    opacity: 0.35
+  .mockup-bg > img {
+    opacity: 0.35;
   }
   .boxed-container {
-    box-shadow: 0 0 40px rgba(255, 255, 255, 0.15)
+    box-shadow: 0 0 40px rgba(255, 255, 255, 0.15);
   }
   .feature-extended h3 {
-      color: rgb(79, 193, 124)
+    color: rgb(79, 193, 124);
   }
 }
-.container-sm a img{
-  opacity: 0.7
+.container-sm a img {
+  opacity: 0.7;
 }
-a > img:hover{
-  opacity: 1
+a > img:hover {
+  opacity: 1;
 }
-.device-mockup{
-  border-radius:10px
+.device-mockup {
+  border-radius: 10px;
 }
-.hero-inner .device-mockup{
-  border-radius:12px
+.hero-inner .device-mockup {
+  border-radius: 12px;
+}
+
+.footer-copyright {
+  width: fit-content;
+  text-align: center;
+  flex: unset;
+}
+@media (max-width: 641px) {
+  .footer-copyright {
+    text-align: center;
+    flex: 50%;
+  }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -303,7 +303,7 @@
                 <li>
                   <select
                     id="languageSelect"
-                    onchange="multilingual.updateLanguage(this.value)"
+                    onchange="multilingual.updateLanguage(this)"
                   >
                     <option value="bn">বাংলা</option>
                     <option value="zh-rCN">简体中文</option>

--- a/docs/js/loadingScreen.js
+++ b/docs/js/loadingScreen.js
@@ -4,16 +4,25 @@ class LoadingScreen {
     loadingScreen.style.opacity = "0";
     setTimeout(() => {
       loadingScreen.style.display = "none";
-    }, 400)
+    }, 400);
   }
 }
 // Dark Mode
-if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {       
+const preference = localStorage.getItem("dark");
+if (preference == "true") {
+  document.body.classList.add("dark");
+} else if (
+  preference !== "false" &&
+  window.matchMedia &&
+  window.matchMedia("(prefers-color-scheme: dark)").matches
+) {
   document.body.classList.add("dark");
 }
 function toggleDark() {
+  const dark = document.body.classList.contains("dark");
   document.body.classList.toggle("dark");
+  localStorage.setItem("dark", !dark);
 }
-function detecttouch(){
-  document.getElementById("toggledark").classList.remove("focustoggle")
+function detecttouch() {
+  document.getElementById("toggledark").classList.remove("focustoggle");
 }

--- a/docs/js/multilingual.js
+++ b/docs/js/multilingual.js
@@ -81,7 +81,12 @@ class Multilingual {
       }
     });
   }
-  updateLanguage(lang) {
+  updateLanguage(el) {
+    const lang = el.value;
+
+    // Calculate width for the new language that is selected
+    this._calculateWidth(el);
+
     localStorage.setItem("language", lang);
     window.location.reload();
   }
@@ -89,9 +94,25 @@ class Multilingual {
     for (const option of el.children) {
       if (option.value == this.language) {
         option.selected = true;
-        return;
+        break;
       }
     }
+    this._calculateWidth(el);
+  }
+  _calculateWidth(el) {
+    const option = el.options[el.selectedIndex].textContent;
+
+    // Calculate width of the text
+    const tempSpan = document.createElement("span");
+    tempSpan.textContent = option;
+    tempSpan.style.visibility = "hidden";
+    tempSpan.style.fontSize = "14px";
+    const spanEl = document.body.appendChild(tempSpan);
+
+    const textWidth = tempSpan.getBoundingClientRect().width;
+    el.style.width = `${Math.round(textWidth)}px`;
+
+    spanEl.remove();
   }
   setAttribute(el) {
     el.setAttribute("lang", this.language);


### PR DESCRIPTION
First, I fixed issue with that the language selector used too much unnecessary space.

### Before:
![before](https://github.com/user-attachments/assets/87266bfe-eb08-4acc-b303-3d701f0d1f42)

### After:
![after](https://github.com/user-attachments/assets/c6029246-2af4-4aae-adea-96cc51974f23)

---

And second, I fixed that the copyright text used too much unnecessary space, and the links then needed to be on a separate line.

### Before:
![before2](https://github.com/user-attachments/assets/3e0ffa35-cb85-44a5-a960-87b5aca76c01)

### After:
![after2](https://github.com/user-attachments/assets/fbc015a7-b8cd-4ca2-b60d-34cf2becc1d3)

---

And third, I made it so the website remembers if user manually selected light mode / dark mode