### PR TITLE
Textoutline improvements

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Essential.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Essential.kt
@@ -165,34 +165,26 @@ fun InfoAlbumAndArtistEssential(
             ) {
                 BasicText(
                     text = cleanPrefix(title ?: ""),
-                    style = TextStyle(
+                    style = typography.l.bold.merge(TextStyle(
                         textAlign = TextAlign.Center,
                         color = if (albumId == null)
                                  if (showthumbnail) colorPalette.textDisabled else if (colorPaletteMode == ColorPaletteMode.Light) colorPalette.textDisabled.copy(0.5f).compositeOver(Color.Black) else colorPalette.textDisabled.copy(0.35f).compositeOver(Color.White)
-                                else colorPalette.text,
-                        fontStyle = typography.l.bold.fontStyle,
-                        fontWeight = typography.l.bold.fontWeight,
-                        fontSize = typography.l.bold.fontSize,
-                        fontFamily = typography.l.bold.fontFamily
-                    ),
+                                else colorPalette.text
+                    )),
                     maxLines = 1,
                     modifier = modifierTitle
                 )
                 BasicText(
                     text = cleanPrefix(title ?: ""),
-                    style = TextStyle(
+                    style = typography.l.bold.merge(TextStyle(
                         drawStyle = Stroke(width = 1.5f, join = StrokeJoin.Round),
                         textAlign = TextAlign.Center,
                         color = if (!textoutline) Color.Transparent
                         else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
                             0.5f
                         )
-                        else Color.Black,
-                        fontStyle = typography.l.bold.fontStyle,
-                        fontWeight = typography.l.bold.fontWeight,
-                        fontSize = typography.l.bold.fontSize,
-                        fontFamily = typography.l.bold.fontFamily
-                    ),
+                        else Color.Black
+                    )),
                     maxLines = 1,
                     modifier = modifierTitle
                 )

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Essential.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Essential.kt
@@ -183,7 +183,10 @@ fun InfoAlbumAndArtistEssential(
                     style = TextStyle(
                         drawStyle = Stroke(width = 1.5f, join = StrokeJoin.Round),
                         textAlign = TextAlign.Center,
-                        color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(0.5f)
+                        color = if (!textoutline) Color.Transparent
+                        else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
+                            0.5f
+                        )
                         else Color.Black,
                         fontStyle = typography.l.bold.fontStyle,
                         fontWeight = typography.l.bold.fontWeight,
@@ -289,7 +292,10 @@ fun InfoAlbumAndArtistEssential(
                 style = TextStyle(
                     drawStyle = Stroke(width = 1.5f, join = StrokeJoin.Round),
                     textAlign = TextAlign.Center,
-                    color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(0.5f)
+                    color = if (!textoutline) Color.Transparent
+                    else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
+                        0.5f
+                    )
                     else Color.Black,
                     fontStyle = typography.m.bold.fontStyle,
                     fontSize = typography.m.bold.fontSize,

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
@@ -191,7 +191,10 @@ fun InfoAlbumAndArtistModern(
                     text = cleanPrefix(title ?: ""),
                     style = TextStyle(
                         drawStyle = Stroke(width = 1.5f, join = StrokeJoin.Round),
-                        color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(0.5f)
+                        color = if (!textoutline) Color.Transparent
+                        else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
+                            0.5f
+                        )
                         else Color.Black,
                         fontStyle = typography.l.bold.fontStyle,
                         fontWeight = typography.l.bold.fontWeight,
@@ -322,7 +325,10 @@ fun InfoAlbumAndArtistModern(
                 text = artist ?: "",
                 style = TextStyle(
                     drawStyle = Stroke(width = 1.5f, join = StrokeJoin.Round),
-                    color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(0.5f)
+                    color = if (!textoutline) Color.Transparent
+                    else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
+                        0.5f
+                    )
                     else Color.Black,
                     fontStyle = typography.m.bold.fontStyle,
                     fontSize = typography.m.bold.fontSize,

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
@@ -175,32 +175,24 @@ fun InfoAlbumAndArtistModern(
             ){
                 BasicText(
                     text = cleanPrefix(title ?: ""),
-                    style = TextStyle(
+                    style = typography.l.bold.merge(TextStyle(
                         color = if (albumId == null)
                             if (showthumbnail) colorPalette.textDisabled else if (colorPaletteMode == ColorPaletteMode.Light) colorPalette.textDisabled.copy(0.35f).compositeOver(Color.Black) else colorPalette.textDisabled.copy(0.35f).compositeOver(Color.White)
-                        else colorPalette.text,
-                        fontStyle = typography.l.bold.fontStyle,
-                        fontWeight = typography.l.bold.fontWeight,
-                        fontSize = typography.l.bold.fontSize,
-                        fontFamily = typography.l.bold.fontFamily
-                    ),
+                        else colorPalette.text
+                    )),
                     maxLines = 1,
                     modifier = modifierTitle
                 )
                 BasicText(
                     text = cleanPrefix(title ?: ""),
-                    style = TextStyle(
+                    style = typography.l.bold.merge(TextStyle(
                         drawStyle = Stroke(width = 1.5f, join = StrokeJoin.Round),
                         color = if (!textoutline) Color.Transparent
                         else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
                             0.5f
                         )
-                        else Color.Black,
-                        fontStyle = typography.l.bold.fontStyle,
-                        fontWeight = typography.l.bold.fontWeight,
-                        fontSize = typography.l.bold.fontSize,
-                        fontFamily = typography.l.bold.fontFamily
-                    ),
+                        else Color.Black
+                    )),
                     maxLines = 1,
                     modifier = modifierTitle
                 )
@@ -308,33 +300,25 @@ fun InfoAlbumAndArtistModern(
         ) {
             BasicText(
                 text = artist ?: "",
-                style = TextStyle(
+                style = typography.m.bold.merge(TextStyle(
                     color = if (albumId == null)
                         if (showthumbnail) colorPalette.textDisabled else if (colorPaletteMode == ColorPaletteMode.Light) colorPalette.textDisabled.copy(0.35f).compositeOver(Color.Black) else colorPalette.textDisabled.copy(0.35f).compositeOver(Color.White)
-                    else colorPalette.text,
-                    fontStyle = typography.m.bold.fontStyle,
-                    fontSize = typography.m.bold.fontSize,
-                    fontWeight = typography.m.bold.fontWeight,
-                    fontFamily = typography.m.bold.fontFamily
-                ),
+                    else colorPalette.text
+                )),
                 maxLines = 1,
                 modifier = modifierArtist
 
             )
             BasicText(
                 text = artist ?: "",
-                style = TextStyle(
+                style = typography.m.bold.merge(TextStyle(
                     drawStyle = Stroke(width = 1.5f, join = StrokeJoin.Round),
                     color = if (!textoutline) Color.Transparent
                     else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
                         0.5f
                     )
-                    else Color.Black,
-                    fontStyle = typography.m.bold.fontStyle,
-                    fontSize = typography.m.bold.fontSize,
-                    fontWeight = typography.m.bold.fontWeight,
-                    fontFamily = typography.m.bold.fontFamily
-                ),
+                    else Color.Black
+                )),
                 maxLines = 1,
                 modifier = modifierArtist
 

--- a/app/src/main/kotlin/it/fast4x/rimusic/utils/GetSeekBarType.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/utils/GetSeekBarType.kt
@@ -305,7 +305,10 @@ fun GetSeekBar(
                 text = formatAsDuration(scrubbingPosition ?: position),
                 style = typography.xxs.semiBold.merge(TextStyle(
                     drawStyle = Stroke(width = 1.0f, join = StrokeJoin.Round),
-                    color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(0.5f)
+                    color = if (!textoutline) Color.Transparent
+                    else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
+                        0.5f
+                    )
                     else Color.Black)),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
@@ -352,7 +355,10 @@ fun GetSeekBar(
                         text = "-${formatAsDuration(timeRemaining.toLong())}",
                         style = typography.xxs.semiBold.merge(TextStyle(
                             drawStyle = Stroke(width = 1.0f, join = StrokeJoin.Round),
-                            color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(0.5f)
+                            color = if (!textoutline) Color.Transparent
+                            else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
+                                0.5f
+                            )
                             else Color.Black)),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
@@ -419,7 +425,8 @@ fun GetSeekBar(
                     style = typography.xxs.semiBold.merge(
                         TextStyle(
                             drawStyle = Stroke(width = 1.0f, join = StrokeJoin.Round),
-                            color = if (!textoutline) Color.Transparent else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
+                            color = if (!textoutline) Color.Transparent
+                            else if (colorPaletteMode == ColorPaletteMode.Light || (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme()))) Color.White.copy(
                                 0.5f
                             )
                             else Color.Black


### PR DESCRIPTION
Changes:

- TextStyle.merge is now used more.
- Code Format improvements

I think that for example this should also work for [this](https://github.com/twistios/RiMusic/blob/45d9846420343b35a776bc4bf38bdb7fd34ec05e/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/home/HomeDiscovery.kt#L364-L368) section or similar.

I can add the change also at these places.

The original idea of this branch was to add more text outlines, this is also the reason for the name. I have not yet done it, but would also like to add this stuff to this pull-request once it is done.