### PR TITLE
Adds textoutline for "totalPlayTimes"

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
@@ -225,6 +225,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.times
 import androidx.compose.ui.util.lerp
@@ -2554,12 +2555,35 @@ fun PlayerModern(
                             contentDescription = "Background Image",
                             contentScale = ContentScale.Fit
                         )
-                        BasicText(
-                            text = " ${formatAsTime(totalPlayTimes)}",
-                            style = typography.xxs.semiBold,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+
+                        Box {
+                            BasicText(
+                                text = " ${formatAsTime(totalPlayTimes)}",
+                                style = typography.xxs.semiBold.merge(TextStyle(
+                                    textAlign = TextAlign.Center,
+                                    color = colorPalette.text,
+                                )),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            BasicText(
+                                text = " ${formatAsTime(totalPlayTimes)}",
+                                style = typography.xxs.semiBold.merge(TextStyle(
+                                    textAlign = TextAlign.Center,
+                                    drawStyle = Stroke(
+                                        width = 1f,
+                                        join = StrokeJoin.Round
+                                    ),
+                                    color = if (!textoutline) Color.Transparent
+                                    else if (colorPaletteMode == ColorPaletteMode.Light ||
+                                        (colorPaletteMode == ColorPaletteMode.System && (!isSystemInDarkTheme())))
+                                        Color.White.copy(0.5f)
+                                    else Color.Black,
+                                )),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
                     }
 
 


### PR DESCRIPTION
See examples.

<details><summary>Beggin</summary>
<p>

![beggin_with_outline](https://github.com/user-attachments/assets/0b18596d-747e-4b89-a0f2-24fa181f08c6)

![beggin_no_outline](https://github.com/user-attachments/assets/7e47506e-50e7-454b-bb56-ec017250fc6a)

</p>
</details> 

<details><summary>Comfortably Numb</summary>
<p>

![comfortably_numb_with_outline](https://github.com/user-attachments/assets/9b78078e-6ca6-46ad-b22e-b0249c061b6f)

![comfortably_numb_no_outline](https://github.com/user-attachments/assets/521896ce-65b4-443e-9210-7152c8262c63)

</p>
</details> 

This is an example where my recent ideas would have helped. I also found out that merge works reliably with good results while the idea with inferring (and therefore ability not to state all fields) without merge  did NOT actually work.
