### PR TITLE
fix: android auto voice action not working

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -71,8 +71,13 @@
             </intent-filter>
 
             <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
When searching for a song with the Android Auto voice command “Play [song]”, Android Auto indicates that there is a problem.

Putting “MEDIA_PLAY_FROM_SEARCH” in its own intent filter solves the problem.

I'm not sure of the impact on the rest of the application, which is why I've put it on draft pull request for now.