### PR TITLE
Updated StatsForNerds displaying in player

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
@@ -2223,13 +2223,15 @@ fun PlayerModern(
                                 )
 
                     }
-                    if (!showthumbnail) {
-                        StatsForNerds(
-                            mediaId = mediaItem.mediaId,
-                            isDisplayed = statsfornerds,
-                            onDismiss = {}
-                        )
-                    }
+
+                    // does not seem to get activated so commented
+//                    if (!showthumbnail) {
+//                        StatsForNerds(
+//                            mediaId = mediaItem.mediaId,
+//                            isDisplayed = statsfornerds,
+//                            onDismiss = {}
+//                        )
+//                    }
                     actionsBarContent()
                 }
             }
@@ -2730,13 +2732,13 @@ fun PlayerModern(
                     }
                 }
 
-                if (!showthumbnail) {
-                    StatsForNerds(
-                        mediaId = mediaItem.mediaId,
-                        isDisplayed = statsfornerds,
-                        onDismiss = {}
-                    )
-                }
+
+                StatsForNerds(
+                    mediaId = mediaItem.mediaId,
+                    isDisplayed = statsfornerds,
+                    onDismiss = {}
+                )
+
                 actionsBarContent()
               }
             }

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/StatsForNerds.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/StatsForNerds.kt
@@ -89,7 +89,7 @@ fun StatsForNerds(
         var format by remember {
             mutableStateOf<Format?>(null)
         }
-        var showthumbnail by rememberPreference(showthumbnailKey, false)
+//        var showthumbnail by rememberPreference(showthumbnailKey, false)
         val transparentBackgroundActionBarPlayer by rememberPreference(
             transparentBackgroundPlayerActionBarKey,
             false
@@ -185,298 +185,297 @@ fun StatsForNerds(
             }
         }
 
-    if (showthumbnail) {
-        Box(
+//    if (showthumbnail && playerType==PlayerType.Essential) {
+//        Box(
+//            modifier = modifier
+//                .pointerInput(Unit) {
+//                    detectTapGestures(
+//                        onTap = {
+//                            onDismiss()
+//                        }
+//                    )
+//                }
+//                .background(colorPalette.overlay)
+//                .fillMaxSize()
+//        ) {
+//            Row(
+//                horizontalArrangement = Arrangement.spacedBy(16.dp),
+//                modifier = Modifier
+//                    .align(Alignment.Center)
+//                    .padding(all = 16.dp)
+//            ) {
+//                Column(horizontalAlignment = Alignment.End) {
+//                    BasicText(
+//                        text = stringResource(R.string.id),
+//                        style = typography.xs.medium.color(colorPalette.onOverlay)
+//                    )
+//                    if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
+//                        BasicText(
+//                            text = stringResource(R.string.itag),
+//                            style = typography.xs.medium.color(colorPalette.onOverlay)
+//                        )
+//                        BasicText(
+//                            text = stringResource(R.string.quality),
+//                            style = typography.xs.medium.color(colorPalette.onOverlay)
+//                        )
+//                    }
+//                    BasicText(
+//                        text = stringResource(R.string.bitrate),
+//                        style = typography.xs.medium.color(colorPalette.onOverlay)
+//                    )
+//                    BasicText(
+//                        text = stringResource(R.string.size),
+//                        style = typography.xs.medium.color(colorPalette.onOverlay)
+//                    )
+//
+//                    if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == true)
+//                        BasicText(
+//                            text = stringResource(R.string.cached),
+//                            style = typography.xs.medium.color(colorPalette.onOverlay)
+//                        )
+//
+//                    if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
+//                        BasicText(
+//                            text = if (cachedBytes > downloadCachedBytes) stringResource(R.string.cached)
+//                            else stringResource(R.string.downloaded),
+//                            style = typography.xs.medium.color(colorPalette.onOverlay)
+//                        )
+//
+//                        BasicText(
+//                            text = stringResource(R.string.loudness),
+//                            style = typography.xs.medium.color(colorPalette.onOverlay)
+//                        )
+//                    }
+//                }
+//
+//                Column {
+//                    BasicText(
+//                        text = mediaId,
+//                        maxLines = 1,
+//                        style = typography.xs.medium.color(colorPalette.onOverlay)
+//                    )
+//
+//                    if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
+//                        BasicText(
+//                            text = format?.itag?.toString()
+//                                ?: stringResource(R.string.audio_quality_format_unknown),
+//                            maxLines = 1,
+//                            style = typography.xs.medium.color(colorPalette.onOverlay)
+//                        )
+//                        BasicText(
+//                            text = getQuality(format!!),
+//                            maxLines = 1,
+//                            style = typography.xs.medium.color(colorPalette.onOverlay)
+//                        )
+//                    }
+//                    BasicText(
+//                        text = format?.bitrate?.let { "${it / 1000} kbps" } ?: stringResource(R.string.audio_quality_format_unknown),
+//                        maxLines = 1,
+//                        style = typography.xs.medium.color(colorPalette.onOverlay)
+//                    )
+//                    BasicText(
+//                        text = format?.contentLength
+//                            ?.let { Formatter.formatShortFileSize(context, it) } ?: stringResource(R.string.audio_quality_format_unknown),
+//                        maxLines = 1,
+//                        style = typography.xs.medium.color(colorPalette.onOverlay)
+//                    )
+//                    if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == true) {
+//                        BasicText(
+//                            text = "100%",
+//                            maxLines = 1,
+//                            style = typography.xs.medium.color(colorPalette.onOverlay)
+//                        )
+//                    }
+//                    if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
+//                        BasicText(
+//                            text = buildString {
+//                                if (cachedBytes > downloadCachedBytes)
+//                                    append(Formatter.formatShortFileSize(context, cachedBytes))
+//                                else append(
+//                                    Formatter.formatShortFileSize(
+//                                        context,
+//                                        downloadCachedBytes
+//                                    )
+//                                )
+//
+//                                format?.contentLength?.let {
+//                                    if (cachedBytes > downloadCachedBytes)
+//                                        append(" (${(cachedBytes.toFloat() / it * 100).roundToInt()}%)")
+//                                    else append(" (${(downloadCachedBytes.toFloat() / it * 100).roundToInt()}%)")
+//                                }
+//                            },
+//                            maxLines = 1,
+//                            style = typography.xs.medium.color(colorPalette.onOverlay)
+//                        )
+//                        BasicText(
+//                            text = format?.loudnessDb?.let { "%.2f dB".format(it) }
+//                                ?: stringResource(R.string.audio_quality_format_unknown),
+//                            maxLines = 1,
+//                            style = typography.xs.medium.color(colorPalette.onOverlay)
+//                        )
+//                    }
+//                }
+//            }
+//        }
+//    }
+
+    Column(
+        modifier = modifier
+            .pointerInput(Unit) {detectTapGestures(onLongPress = {statsfornerdsfull = !statsfornerdsfull})}
+    ) {
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
             modifier = modifier
-                .pointerInput(Unit) {
-                    detectTapGestures(
-                        onTap = {
-                            onDismiss()
-                        }
-                    )
-                }
-                .background(colorPalette.overlay)
-                .fillMaxSize()
+                .background(colorPalette.background2.copy(alpha = if ((transparentBackgroundActionBarPlayer) || ((playerBackgroundColors == PlayerBackgroundColors.CoverColorGradient) || (playerBackgroundColors == PlayerBackgroundColors.ThemeColorGradient)) && blackgradient) 0.0f else 0.7f))
+                .padding(vertical = 5.dp)
+                .fillMaxWidth(if (isLandscape) 0.8f else 1f)
         ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .padding(all = 16.dp)
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = modifier.weight(1f)
             ) {
-                Column(horizontalAlignment = Alignment.End) {
+                if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
                     BasicText(
-                        text = stringResource(R.string.id),
-                        style = typography.xs.medium.color(colorPalette.onOverlay)
-                    )
-                    if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
-                        BasicText(
-                            text = stringResource(R.string.itag),
-                            style = typography.xs.medium.color(colorPalette.onOverlay)
-                        )
-                        BasicText(
-                            text = stringResource(R.string.quality),
-                            style = typography.xs.medium.color(colorPalette.onOverlay)
-                        )
-                    }
-                    BasicText(
-                        text = stringResource(R.string.bitrate),
-                        style = typography.xs.medium.color(colorPalette.onOverlay)
-                    )
-                    BasicText(
-                        text = stringResource(R.string.size),
-                        style = typography.xs.medium.color(colorPalette.onOverlay)
-                    )
-
-                    if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == true)
-                        BasicText(
-                            text = stringResource(R.string.cached),
-                            style = typography.xs.medium.color(colorPalette.onOverlay)
-                        )
-
-                    if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
-                        BasicText(
-                            text = if (cachedBytes > downloadCachedBytes) stringResource(R.string.cached)
-                            else stringResource(R.string.downloaded),
-                            style = typography.xs.medium.color(colorPalette.onOverlay)
-                        )
-
-                        BasicText(
-                            text = stringResource(R.string.loudness),
-                            style = typography.xs.medium.color(colorPalette.onOverlay)
-                        )
-                    }
-                }
-
-                Column {
-                    BasicText(
-                        text = mediaId,
+                        text = stringResource(R.string.quality) + " : " + getQuality(format!!),
                         maxLines = 1,
-                        style = typography.xs.medium.color(colorPalette.onOverlay)
+                        style = typography.xs.medium.color(colorPalette.text)
                     )
-
-                    if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
-                        BasicText(
-                            text = format?.itag?.toString()
-                                ?: stringResource(R.string.audio_quality_format_unknown),
-                            maxLines = 1,
-                            style = typography.xs.medium.color(colorPalette.onOverlay)
-                        )
-                        BasicText(
-                            text = getQuality(format!!),
-                            maxLines = 1,
-                            style = typography.xs.medium.color(colorPalette.onOverlay)
-                        )
-                    }
-                    BasicText(
-                        text = format?.bitrate?.let { "${it / 1000} kbps" } ?: stringResource(R.string.audio_quality_format_unknown),
-                        maxLines = 1,
-                        style = typography.xs.medium.color(colorPalette.onOverlay)
-                    )
-                    BasicText(
-                        text = format?.contentLength
-                            ?.let { Formatter.formatShortFileSize(context, it) } ?: stringResource(R.string.audio_quality_format_unknown),
-                        maxLines = 1,
-                        style = typography.xs.medium.color(colorPalette.onOverlay)
-                    )
-                    if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == true) {
-                        BasicText(
-                            text = "100%",
-                            maxLines = 1,
-                            style = typography.xs.medium.color(colorPalette.onOverlay)
-                        )
-                    }
-                    if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
-                        BasicText(
-                            text = buildString {
-                                if (cachedBytes > downloadCachedBytes)
-                                    append(Formatter.formatShortFileSize(context, cachedBytes))
-                                else append(
-                                    Formatter.formatShortFileSize(
-                                        context,
-                                        downloadCachedBytes
-                                    )
-                                )
-
-                                format?.contentLength?.let {
-                                    if (cachedBytes > downloadCachedBytes)
-                                        append(" (${(cachedBytes.toFloat() / it * 100).roundToInt()}%)")
-                                    else append(" (${(downloadCachedBytes.toFloat() / it * 100).roundToInt()}%)")
-                                }
-                            },
-                            maxLines = 1,
-                            style = typography.xs.medium.color(colorPalette.onOverlay)
-                        )
-                        BasicText(
-                            text = format?.loudnessDb?.let { "%.2f dB".format(it) }
-                                ?: stringResource(R.string.audio_quality_format_unknown),
-                            maxLines = 1,
-                            style = typography.xs.medium.color(colorPalette.onOverlay)
-                        )
-                    }
                 }
             }
-        }
-    } else {
-            Column(
-                modifier = modifier
-                    .pointerInput(Unit) {detectTapGestures(onLongPress = {statsfornerdsfull = !statsfornerdsfull})}
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = modifier.weight(1f)
             ) {
-
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center,
-                    modifier = modifier
-                        .background(colorPalette.background2.copy(alpha = if ((transparentBackgroundActionBarPlayer) || ((playerBackgroundColors == PlayerBackgroundColors.CoverColorGradient) || (playerBackgroundColors == PlayerBackgroundColors.ThemeColorGradient)) && blackgradient) 0.0f else 0.7f))
-                        .padding(vertical = 5.dp)
-                        .fillMaxWidth(if (isLandscape) 0.8f else 1f)
-                ) {
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier = modifier.weight(1f)
-                    ) {
-                        if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
-                            BasicText(
-                                text = stringResource(R.string.quality) + " : " + getQuality(format!!),
-                                maxLines = 1,
-                                style = typography.xs.medium.color(colorPalette.text)
-                            )
-                        }
-                    }
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier = modifier.weight(1f)
-                    ) {
-                        BasicText(
-                            text = format?.bitrate?.let { stringResource(R.string.bitrate) + " : " + "${it / 1000} kbps" }
-                                ?: (stringResource(R.string.bitrate) + " : " + stringResource(R.string.audio_quality_format_unknown)),
-                            maxLines = 1,
-                            style = typography.xs.medium.color(colorPalette.text)
-                        )
-                    }
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier = modifier.weight(1f)
-                    ) {
-                        BasicText(
-                            text = format?.contentLength
-                                ?.let {stringResource(R.string.size) + " : " + Formatter.formatShortFileSize(context,it)}
-                                ?: (stringResource(R.string.size) + " : " + stringResource(R.string.audio_quality_format_unknown)),
-                            maxLines = 1,
-                            style = typography.xs.medium.color(colorPalette.text)
-                        )
-                    }
-                }
-                AnimatedVisibility(visible = statsfornerdsfull) {
-                  Column {
-                      Row(
-                          verticalAlignment = Alignment.CenterVertically,
-                          horizontalArrangement = Arrangement.Center,
-                          modifier = modifier
-                              .background(colorPalette.background2.copy(alpha = if ((transparentBackgroundActionBarPlayer) || ((playerBackgroundColors == PlayerBackgroundColors.CoverColorGradient) || (playerBackgroundColors == PlayerBackgroundColors.ThemeColorGradient)) && blackgradient) 0.0f else 0.7f))
-                              .padding(vertical = 5.dp)
-                              .fillMaxWidth(if (isLandscape) 0.8f else 1f)
+                BasicText(
+                    text = format?.bitrate?.let { stringResource(R.string.bitrate) + " : " + "${it / 1000} kbps" }
+                        ?: (stringResource(R.string.bitrate) + " : " + stringResource(R.string.audio_quality_format_unknown)),
+                    maxLines = 1,
+                    style = typography.xs.medium.color(colorPalette.text)
+                )
+            }
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = modifier.weight(1f)
+            ) {
+                BasicText(
+                    text = format?.contentLength
+                        ?.let {stringResource(R.string.size) + " : " + Formatter.formatShortFileSize(context,it)}
+                        ?: (stringResource(R.string.size) + " : " + stringResource(R.string.audio_quality_format_unknown)),
+                    maxLines = 1,
+                    style = typography.xs.medium.color(colorPalette.text)
+                )
+            }
+        }
+        AnimatedVisibility(visible = statsfornerdsfull) {
+          Column {
+              Row(
+                  verticalAlignment = Alignment.CenterVertically,
+                  horizontalArrangement = Arrangement.Center,
+                  modifier = modifier
+                      .background(colorPalette.background2.copy(alpha = if ((transparentBackgroundActionBarPlayer) || ((playerBackgroundColors == PlayerBackgroundColors.CoverColorGradient) || (playerBackgroundColors == PlayerBackgroundColors.ThemeColorGradient)) && blackgradient) 0.0f else 0.7f))
+                      .padding(vertical = 5.dp)
+                      .fillMaxWidth(if (isLandscape) 0.8f else 1f)
+              ) {
+                  Box(
+                      contentAlignment = Alignment.Center,
+                      modifier = modifier.weight(1f)
+                  ) {
+                      BasicText(
+                          text = stringResource(R.string.id) + " : " + mediaId,
+                          maxLines = 1,
+                          style = typography.xs.medium.color(colorPalette.onOverlay)
+                      )
+                  }
+                  if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
+                      Box(
+                          contentAlignment = Alignment.Center,
+                          modifier = modifier.weight(1f)
                       ) {
-                          Box(
-                              contentAlignment = Alignment.Center,
-                              modifier = modifier.weight(1f)
-                          ) {
-                              BasicText(
-                                  text = stringResource(R.string.id) + " : " + mediaId,
-                                  maxLines = 1,
-                                  style = typography.xs.medium.color(colorPalette.onOverlay)
-                              )
-                          }
-                          if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
-                              Box(
-                                  contentAlignment = Alignment.Center,
-                                  modifier = modifier.weight(1f)
-                              ) {
-                                  BasicText(
-                                      text = (stringResource(R.string.itag) + " : " + format?.itag?.toString())
-                                          ?: (stringResource(R.string.itag) + " : " + stringResource(
-                                              R.string.audio_quality_format_unknown
-                                          )),
-                                      maxLines = 1,
-                                      style = typography.xs.medium.color(colorPalette.onOverlay)
-                                  )
-                              }
-                          }
-                      }
-                      Row(
-                          verticalAlignment = Alignment.CenterVertically,
-                          horizontalArrangement = Arrangement.Center,
-                          modifier = modifier
-                              .background(colorPalette.background2.copy(alpha = if ((transparentBackgroundActionBarPlayer) || ((playerBackgroundColors == PlayerBackgroundColors.CoverColorGradient) || (playerBackgroundColors == PlayerBackgroundColors.ThemeColorGradient)) && blackgradient) 0.0f else 0.7f))
-                              .padding(vertical = 5.dp)
-                              .fillMaxWidth(if (isLandscape) 0.8f else 1f)
-                      ) {
-                          if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == true) {
-                              Box(
-                                  contentAlignment = Alignment.Center,
-                                  modifier = modifier.weight(1f)
-                              ) {
-                                  BasicText(
-                                      text = stringResource(R.string.cached) + " : " + "100%",
-                                      maxLines = 1,
-                                      style = typography.xs.medium.color(colorPalette.onOverlay)
-                                  )
-                              }
-                          }
-                          if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
-                              Box(
-                                  contentAlignment = Alignment.Center,
-                                  modifier = modifier.weight(1f)
-                              ) {
-                                  BasicText(
-                                      text = buildString {
-                                          if (cachedBytes > downloadCachedBytes)
-                                              append(
-                                                  stringResource(R.string.cached) + " : " + Formatter.formatShortFileSize(
-                                                      context,
-                                                      cachedBytes
-                                                  )
-                                              )
-                                          else append(
-                                              stringResource(R.string.downloaded) + " : " + Formatter.formatShortFileSize(
-                                                  context,
-                                                  downloadCachedBytes
-                                              )
-                                          )
-                                          format?.contentLength?.let {
-                                              if (cachedBytes > downloadCachedBytes)
-                                                  append(" (${(cachedBytes.toFloat() / it * 100).roundToInt()}%)")
-                                              else append(" (${(downloadCachedBytes.toFloat() / it * 100).roundToInt()}%)")
-                                          }
-                                      },
-                                      maxLines = 1,
-                                      style = typography.xs.medium.color(colorPalette.onOverlay)
-                                  )
-                              }
-                              Box(
-                                  contentAlignment = Alignment.Center,
-                                  modifier = modifier.weight(1f)
-                              ) {
-                                  BasicText(
-                                      text = format?.loudnessDb?.let {
-                                          stringResource(R.string.loudness) + " : " + "%.2f dB".format(
-                                              it
-                                          )
-                                      }
-                                          ?: (stringResource(R.string.loudness) + " : " + stringResource(
-                                              R.string.audio_quality_format_unknown
-                                          )),
-                                      maxLines = 1,
-                                      style = typography.xs.medium.color(colorPalette.onOverlay)
-                                  )
-                              }
-                          }
+                          BasicText(
+                              text = (stringResource(R.string.itag) + " : " + format?.itag?.toString())
+                                  ?: (stringResource(R.string.itag) + " : " + stringResource(
+                                      R.string.audio_quality_format_unknown
+                                  )),
+                              maxLines = 1,
+                              style = typography.xs.medium.color(colorPalette.onOverlay)
+                          )
                       }
                   }
-                }
-            }
-
+              }
+              Row(
+                  verticalAlignment = Alignment.CenterVertically,
+                  horizontalArrangement = Arrangement.Center,
+                  modifier = modifier
+                      .background(colorPalette.background2.copy(alpha = if ((transparentBackgroundActionBarPlayer) || ((playerBackgroundColors == PlayerBackgroundColors.CoverColorGradient) || (playerBackgroundColors == PlayerBackgroundColors.ThemeColorGradient)) && blackgradient) 0.0f else 0.7f))
+                      .padding(vertical = 5.dp)
+                      .fillMaxWidth(if (isLandscape) 0.8f else 1f)
+              ) {
+                  if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == true) {
+                      Box(
+                          contentAlignment = Alignment.Center,
+                          modifier = modifier.weight(1f)
+                      ) {
+                          BasicText(
+                              text = stringResource(R.string.cached) + " : " + "100%",
+                              maxLines = 1,
+                              style = typography.xs.medium.color(colorPalette.onOverlay)
+                          )
+                      }
+                  }
+                  if (format?.songId?.startsWith(LOCAL_KEY_PREFIX) == false) {
+                      Box(
+                          contentAlignment = Alignment.Center,
+                          modifier = modifier.weight(1f)
+                      ) {
+                          BasicText(
+                              text = buildString {
+                                  if (cachedBytes > downloadCachedBytes)
+                                      append(
+                                          stringResource(R.string.cached) + " : " + Formatter.formatShortFileSize(
+                                              context,
+                                              cachedBytes
+                                          )
+                                      )
+                                  else append(
+                                      stringResource(R.string.downloaded) + " : " + Formatter.formatShortFileSize(
+                                          context,
+                                          downloadCachedBytes
+                                      )
+                                  )
+                                  format?.contentLength?.let {
+                                      if (cachedBytes > downloadCachedBytes)
+                                          append(" (${(cachedBytes.toFloat() / it * 100).roundToInt()}%)")
+                                      else append(" (${(downloadCachedBytes.toFloat() / it * 100).roundToInt()}%)")
+                                  }
+                              },
+                              maxLines = 1,
+                              style = typography.xs.medium.color(colorPalette.onOverlay)
+                          )
+                      }
+                      Box(
+                          contentAlignment = Alignment.Center,
+                          modifier = modifier.weight(1f)
+                      ) {
+                          BasicText(
+                              text = format?.loudnessDb?.let {
+                                  stringResource(R.string.loudness) + " : " + "%.2f dB".format(
+                                      it
+                                  )
+                              }
+                                  ?: (stringResource(R.string.loudness) + " : " + stringResource(
+                                      R.string.audio_quality_format_unknown
+                                  )),
+                              maxLines = 1,
+                              style = typography.xs.medium.color(colorPalette.onOverlay)
+                          )
+                      }
+                  }
+              }
+          }
         }
+    }
     }
 }
 

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Thumbnail.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/player/Thumbnail.kt
@@ -255,7 +255,7 @@ fun Thumbnail(
                             modifier = Modifier
                                 .pointerInput(Unit) {
                                     detectTapGestures(
-                                        onLongPress = { onShowStatsForNerds(true) },
+                                        // onLongPress = { onShowStatsForNerds(true) },
                                         onTap = if (thumbnailTapEnabledKey) {
                                             {
                                                 onShowLyrics(true)


### PR DESCRIPTION
- PlayerModern: fixed StatsForNerds not showing when thumbnail is enabled 
- essential player: disabled thumbnail-StatsForNerds as there now is the universal StatsForNerds below player
- StatsForNerds now only shown with universal StatsForNerds below player controls

If you don't like that I disabled for thumbnail in essential player, please tell. I though that we don't need it as there is now the StatsForNerds below controls