### PR TITLE
Fix for nextInt function to avoid IllegalArgumentException

### DIFF
--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbums.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbums.kt
@@ -228,7 +228,7 @@ fun HomeAlbums(
                             isRotated = !isRotated
                             //onAlbumClick(items.get((0..<items.size).random()))
                             onAlbumClick(items.get(
-                                Random(System.currentTimeMillis()).nextInt(0, items.size-1)
+                                Random(System.currentTimeMillis()).nextInt(0, items.size)
                             ))
                         },
                         iconSize = 16.dp

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtists.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtists.kt
@@ -191,7 +191,7 @@ fun HomeArtists(
                             isRotated = !isRotated
                             //onArtistClick(items.get((0..<items.size).random()))
                             onArtistClick(items.get(
-                                Random(System.currentTimeMillis()).nextInt(0, items.size-1)
+                                Random(System.currentTimeMillis()).nextInt(0, items.size)
                             ))
                         },
                         iconSize = 16.dp

--- a/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
+++ b/app/src/main/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
@@ -268,7 +268,7 @@ fun HomeArtistsModern(
                             isRotated = !isRotated
                             //onArtistClick(items.get((0..<items.size).random()))
                             onArtistClick(items.get(
-                                Random(System.currentTimeMillis()).nextInt(0, items.size-1)
+                                Random(System.currentTimeMillis()).nextInt(0, items.size)
                             ))
                         },
                         iconSize = 16.dp


### PR DESCRIPTION
In the _nextInt_ function of Random, the _until_ argument cannot be the same as the _from_ argument, as this would throw an _IllegalArgumentException_.

When the _items_ array had a length of 1, the exception was thrown, and the application would crash. When the _items_ array had a length greater than 1, no error occurred, but the _nextInt_ function could never return the last element of the list.

Removing the -1 solves the problem, as the case of an empty array is already handled with _enabled = items.isNotEmpty()_.

Documentation for nextInt: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.random/-random/next-int.html