### PR TITLE
Fixes the position issue of the controls in essential player.

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
@@ -1007,8 +1007,8 @@ fun PlayerModern(
 
 
     val controlsContent: @Composable (
-        //modifier: Modifier
-    ) -> Unit = { //modifier ->
+        modifier: Modifier
+    ) -> Unit = { modifierValue ->
         Controls(
             navController = navController,
             onCollapse = onDismiss,
@@ -1022,7 +1022,7 @@ fun PlayerModern(
             shouldBePlaying = shouldBePlaying,
             position = positionAndDuration.first,
             duration = positionAndDuration.second,
-            modifier = modifier,
+            modifier = modifierValue,
             onBlurScaleChange = { blurStrength = it }
         )
     }
@@ -2023,12 +2023,10 @@ fun PlayerModern(
                     }
                     if (playerType == PlayerType.Essential || isShowingVisualizer) {
                         controlsContent(
-                            /*
-                            modifier = Modifier
-                                .padding(vertical = 8.dp)
+                            Modifier
+                                .padding(vertical = 8.dp, horizontal= 8.dp)
                                 .conditional(playerType == PlayerType.Essential) { fillMaxHeight() }
                                 .conditional(playerType == PlayerType.Essential) { weight(1f) }
-                             */
                         )
                     } else {
 
@@ -2283,7 +2281,7 @@ fun PlayerModern(
                                          previousPage = it
                                      }
                                  }
-                                 
+
                                  val screenHeight = configuration.screenHeightDp.dp
                                  val pageSpacing = (thumbnailSpacing.toInt()*0.01*(screenHeight) - if (carousel) (3*carouselSize.size.dp) else (2*playerThumbnailSize.size.dp))
                                  VerticalPager(
@@ -2526,12 +2524,10 @@ fun PlayerModern(
                     .conditional(!expandedplayer){weight(1f)}) {
                     if (playerType == PlayerType.Essential || isShowingLyrics || isShowingVisualizer) {
                         controlsContent(
-                            /*
-                            modifier = Modifier
+                            Modifier
                                 .padding(vertical = 4.dp)
                                 .fillMaxWidth()
                             //.weight(1f)
-                             */
                         )
                     } else {
                                 Controls(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/PlayerModern.kt
@@ -2024,7 +2024,7 @@ fun PlayerModern(
                     if (playerType == PlayerType.Essential || isShowingVisualizer) {
                         controlsContent(
                             Modifier
-                                .padding(vertical = 8.dp, horizontal= 8.dp)
+                                .padding(vertical = 8.dp)
                                 .conditional(playerType == PlayerType.Essential) { fillMaxHeight() }
                                 .conditional(playerType == PlayerType.Essential) { weight(1f) }
                         )


### PR DESCRIPTION
controlsContent:
- uncommented argument, renamed it such that it does not shadow outside argument

other places (usages of controlsContent):
- uncommented modifier definitions
- also removed named argument as there was a warning

Examples:
<details><summary>Broken without Cover</summary>
<p>

![rimusic_essential_landscape1](https://github.com/user-attachments/assets/4d634719-d159-4941-8a7a-b66a7758695a)

</p>
</details>

<details><summary>Broken with Cover</summary>
<p>

![rimusic_essential_landscape2](https://github.com/user-attachments/assets/14b33666-24a1-465c-815a-dcaa4b4d61f8)

</p>
</details> 

<details><summary>Fixed without Cover</summary>
<p>

![rimusic_essential_landscape3](https://github.com/user-attachments/assets/8e805ad9-831d-4c1a-a01f-f60acba525a4)


</p>
</details> 

<details><summary>Fixed with Cover</summary>
<p>

![rimusic_essential_landscape4](https://github.com/user-attachments/assets/09a68d56-27ca-4d0e-a998-a8b48b7fe5a7)

</p>
</details> 