### PR TITLE
Fix encrypted preferences

### DIFF
--- a/composeApp/src/androidFoss/kotlin/it/fast4x/rimusic/ui/screens/settings/OtherSettings.kt
+++ b/composeApp/src/androidFoss/kotlin/it/fast4x/rimusic/ui/screens/settings/OtherSettings.kt
@@ -75,6 +75,7 @@ import it.fast4x.rimusic.utils.extraspaceKey
 import it.fast4x.rimusic.utils.isAtLeastAndroid10
 import it.fast4x.rimusic.utils.isAtLeastAndroid12
 import it.fast4x.rimusic.utils.isAtLeastAndroid6
+import it.fast4x.rimusic.utils.isAtLeastAndroid7
 import it.fast4x.rimusic.utils.isAtLeastAndroid81
 import it.fast4x.rimusic.utils.isDiscordPresenceEnabledKey
 import it.fast4x.rimusic.utils.isIgnoringBatteryOptimizations
@@ -250,278 +251,287 @@ fun OtherSettings() {
             }
         }
 
-        /****** PIPED ******/
-        var isPipedEnabled by rememberPreference(isPipedEnabledKey, false)
-        var isPipedCustomEnabled by rememberPreference(isPipedCustomEnabledKey, false)
-        var pipedUsername by rememberEncryptedPreference(pipedUsernameKey, "")
-        var pipedPassword by rememberEncryptedPreference(pipedPasswordKey, "")
-        var pipedInstanceName by rememberEncryptedPreference(pipedInstanceNameKey, "")
-        var pipedApiBaseUrl by rememberEncryptedPreference(pipedApiBaseUrlKey, "")
-        var pipedApiToken by rememberEncryptedPreference(pipedApiTokenKey, "")
-
-        var loadInstances by rememberSaveable { mutableStateOf(false) }
-        var isLoading by rememberSaveable { mutableStateOf(false) }
-        var instances by persistList<Instance>(tag = "otherSettings/pipedInstances")
-        var noInstances by rememberSaveable { mutableStateOf(false) }
-        var executeLogin by rememberSaveable { mutableStateOf(false) }
-        var showInstances by rememberSaveable { mutableStateOf(false) }
-        var session by rememberSaveable { mutableStateOf<Result<it.fast4x.piped.models.Session>?>(null) }
-
-        val menuState = LocalMenuState.current
-        val coroutineScope = rememberCoroutineScope()
         var extraspace by rememberPreference(extraspaceKey, false)
 
-        if (isLoading)
-            DefaultDialog(
-                onDismiss = {
-                    isLoading = false
-                }
-            ) {
-                CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
-            }
+        /****** PIPED ******/
 
-        if (loadInstances) {
-            LaunchedEffect(Unit) {
-                isLoading = true
-                Piped.getInstances()?.getOrNull()?.let {
-                    instances = it
-                    //println("mediaItem Instances $it")
-                } ?: run { noInstances = true }
-                isLoading = false
-                showInstances = true
-            }
-        }
-        if (noInstances) {
-            SmartMessage("No instances found", type = PopupType.Info, context = context)
-        }
+        // rememberEncryptedPreference only works correct with API 24 and up
+        if(isAtLeastAndroid7){
+            var isPipedEnabled by rememberPreference(isPipedEnabledKey, false)
+            var isPipedCustomEnabled by rememberPreference(isPipedCustomEnabledKey, false)
+            var pipedUsername by rememberEncryptedPreference(pipedUsernameKey, "")
+            var pipedPassword by rememberEncryptedPreference(pipedPasswordKey, "")
+            var pipedInstanceName by rememberEncryptedPreference(pipedInstanceNameKey, "")
+            var pipedApiBaseUrl by rememberEncryptedPreference(pipedApiBaseUrlKey, "")
+            var pipedApiToken by rememberEncryptedPreference(pipedApiTokenKey, "")
 
-        if (executeLogin) {
-            LaunchedEffect(Unit) {
-                coroutineScope.launch {
-                    isLoading = true
-                    session = Piped.login(
-                        apiBaseUrl = Url(pipedApiBaseUrl), //instances[instanceSelected!!].apiBaseUrl,
-                        username = pipedUsername,
-                        password = pipedPassword
-                    )?.onFailure {
-                        Timber.e("Failed piped login ${it.stackTraceToString()}")
+            var loadInstances by rememberSaveable { mutableStateOf(false) }
+            var isLoading by rememberSaveable { mutableStateOf(false) }
+            var instances by persistList<Instance>(tag = "otherSettings/pipedInstances")
+            var noInstances by rememberSaveable { mutableStateOf(false) }
+            var executeLogin by rememberSaveable { mutableStateOf(false) }
+            var showInstances by rememberSaveable { mutableStateOf(false) }
+            var session by rememberSaveable { mutableStateOf<Result<it.fast4x.piped.models.Session>?>(null) }
+
+            val menuState = LocalMenuState.current
+            val coroutineScope = rememberCoroutineScope()
+
+            if (isLoading)
+                DefaultDialog(
+                    onDismiss = {
                         isLoading = false
-                        SmartMessage("Piped login failed", type = PopupType.Error, context = context)
+                    }
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
+                }
+
+            if (loadInstances) {
+                LaunchedEffect(Unit) {
+                    isLoading = true
+                    Piped.getInstances()?.getOrNull()?.let {
+                        instances = it
+                        //println("mediaItem Instances $it")
+                    } ?: run { noInstances = true }
+                    isLoading = false
+                    showInstances = true
+                }
+            }
+            if (noInstances) {
+                SmartMessage("No instances found", type = PopupType.Info, context = context)
+            }
+
+            if (executeLogin) {
+                LaunchedEffect(Unit) {
+                    coroutineScope.launch {
+                        isLoading = true
+                        session = Piped.login(
+                            apiBaseUrl = Url(pipedApiBaseUrl), //instances[instanceSelected!!].apiBaseUrl,
+                            username = pipedUsername,
+                            password = pipedPassword
+                        )?.onFailure {
+                            Timber.e("Failed piped login ${it.stackTraceToString()}")
+                            isLoading = false
+                            SmartMessage("Piped login failed", type = PopupType.Error, context = context)
+                            loadInstances = false
+                            session = null
+                            executeLogin = false
+                        }
+                        if (session?.isSuccess == false)
+                            return@launch
+
+                        SmartMessage("Piped login successful", type = PopupType.Success, context = context)
+                        Timber.i("Piped login successful")
+
+                        session.let {
+                            it?.getOrNull()?.token?.let { it1 ->
+                                pipedApiToken = it1
+                                pipedApiBaseUrl = it.getOrNull()!!.apiBaseUrl.toString()
+                            }
+                        }
+
+                        isLoading = false
                         loadInstances = false
-                        session = null
                         executeLogin = false
                     }
-                    if (session?.isSuccess == false)
-                        return@launch
-
-                    SmartMessage("Piped login successful", type = PopupType.Success, context = context)
-                    Timber.i("Piped login successful")
-
-                    session.let {
-                        it?.getOrNull()?.token?.let { it1 ->
-                            pipedApiToken = it1
-                            pipedApiBaseUrl = it.getOrNull()!!.apiBaseUrl.toString()
-                        }
-                    }
-
-                    isLoading = false
-                    loadInstances = false
-                    executeLogin = false
                 }
             }
-        }
 
-        if (showInstances && instances.isNotEmpty()) {
-            menuState.display {
-                Menu {
-                    MenuEntry(
-                        icon = R.drawable.chevron_back,
-                        text = stringResource(R.string.cancel),
-                        onClick = {
-                            showInstances = false
-                            menuState.hide()
-                        }
-                    )
-                    instances.forEach {
+            if (showInstances && instances.isNotEmpty()) {
+                menuState.display {
+                    Menu {
                         MenuEntry(
-                            icon = R.drawable.server,
-                            text = it.name,
-                            secondaryText = "${it.locationsFormatted} Users: ${it.userCount}",
+                            icon = R.drawable.chevron_back,
+                            text = stringResource(R.string.cancel),
                             onClick = {
-                                menuState.hide()
-                                pipedApiBaseUrl = it.apiBaseUrl.toString()
-                                pipedInstanceName = it.name
-                                /*
-                                instances.indexOf(it).let { index ->
-                                    //instances[index].apiBaseUrl
-                                    instanceSelected = index
-                                    //println("mediaItem Instance ${instances[index].apiBaseUrl}")
-                                }
-                                 */
                                 showInstances = false
+                                menuState.hide()
+                            }
+                        )
+                        instances.forEach {
+                            MenuEntry(
+                                icon = R.drawable.server,
+                                text = it.name,
+                                secondaryText = "${it.locationsFormatted} Users: ${it.userCount}",
+                                onClick = {
+                                    menuState.hide()
+                                    pipedApiBaseUrl = it.apiBaseUrl.toString()
+                                    pipedInstanceName = it.name
+                                    /*
+                                    instances.indexOf(it).let { index ->
+                                        //instances[index].apiBaseUrl
+                                        instanceSelected = index
+                                        //println("mediaItem Instance ${instances[index].apiBaseUrl}")
+                                    }
+                                     */
+                                    showInstances = false
+                                }
+                            )
+                        }
+                        MenuEntry(
+                            icon = R.drawable.chevron_back,
+                            text = stringResource(R.string.cancel),
+                            onClick = {
+                                showInstances = false
+                                menuState.hide()
                             }
                         )
                     }
-                    MenuEntry(
-                        icon = R.drawable.chevron_back,
-                        text = stringResource(R.string.cancel),
-                        onClick = {
-                            showInstances = false
-                            menuState.hide()
-                        }
-                    )
                 }
             }
-        }
 
 
 
 
-        SettingsGroupSpacer()
-        SettingsEntryGroupText(title = stringResource(R.string.piped_account))
-        SwitchSettingEntry(
-            title = stringResource(R.string.enable_piped_syncronization),
-            text = "",
-            isChecked = isPipedEnabled,
-            onCheckedChange = { isPipedEnabled = it }
-        )
+            SettingsGroupSpacer()
+            SettingsEntryGroupText(title = stringResource(R.string.piped_account))
+            SwitchSettingEntry(
+                title = stringResource(R.string.enable_piped_syncronization),
+                text = "",
+                isChecked = isPipedEnabled,
+                onCheckedChange = { isPipedEnabled = it }
+            )
 
-        AnimatedVisibility(visible = isPipedEnabled) {
-            Column(
-                modifier = Modifier.padding(start = 25.dp)
-            ) {
-                SwitchSettingEntry(
-                    title = stringResource(R.string.piped_custom_instance),
-                    text = "",
-                    isChecked = isPipedCustomEnabled,
-                    onCheckedChange = { isPipedCustomEnabled = it }
-                )
-                AnimatedVisibility(visible = isPipedCustomEnabled) {
-                    Column {
-                        TextDialogSettingEntry(
-                            title = stringResource(R.string.piped_custom_instance),
-                            text = pipedApiBaseUrl,
-                            currentText = pipedApiBaseUrl,
-                            onTextSave = {
-                                pipedApiBaseUrl = it
-                            }
-                        )
-                    }
-                }
-                AnimatedVisibility(visible = !isPipedCustomEnabled) {
-                    Column {
-                        ButtonBarSettingEntry(
-                            //isEnabled = pipedApiToken.isEmpty(),
-                            title = stringResource(R.string.piped_change_instance),
-                            text = pipedInstanceName,
-                            icon = R.drawable.open,
-                            onClick = {
-                                loadInstances = true
-                            }
-                        )
-                    }
-                }
-
-                TextDialogSettingEntry(
-                    //isEnabled = pipedApiToken.isEmpty(),
-                    title = stringResource(R.string.piped_username),
-                    text = pipedUsername,
-                    currentText = pipedUsername,
-                    onTextSave = { pipedUsername = it }
-                )
-                TextDialogSettingEntry(
-                    //isEnabled = pipedApiToken.isEmpty(),
-                    title = stringResource(R.string.piped_password),
-                    text = if (pipedPassword.isNotEmpty()) "********" else "",
-                    currentText = pipedPassword,
-                    onTextSave = { pipedPassword = it },
-                    modifier = Modifier
-                        .semantics {
-                            password()
+            AnimatedVisibility(visible = isPipedEnabled) {
+                Column(
+                    modifier = Modifier.padding(start = 25.dp)
+                ) {
+                    SwitchSettingEntry(
+                        title = stringResource(R.string.piped_custom_instance),
+                        text = "",
+                        isChecked = isPipedCustomEnabled,
+                        onCheckedChange = { isPipedCustomEnabled = it }
+                    )
+                    AnimatedVisibility(visible = isPipedCustomEnabled) {
+                        Column {
+                            TextDialogSettingEntry(
+                                title = stringResource(R.string.piped_custom_instance),
+                                text = pipedApiBaseUrl,
+                                currentText = pipedApiBaseUrl,
+                                onTextSave = {
+                                    pipedApiBaseUrl = it
+                                }
+                            )
                         }
-                )
-
-                ButtonBarSettingEntry(
-                    isEnabled = pipedPassword.isNotEmpty() && pipedUsername.isNotEmpty() && pipedApiBaseUrl.isNotEmpty(),
-                    title = if (pipedApiToken.isNotEmpty()) stringResource(R.string.piped_disconnect) else stringResource(
-                        R.string.piped_connect
-                    ),
-                    text = if (pipedApiToken.isNotEmpty()) stringResource(R.string.piped_connected_to_s).format(pipedInstanceName) else "",
-                    icon = R.drawable.piped_logo,
-                    iconColor = colorPalette.red,
-                    onClick = {
-                        if (pipedApiToken.isNotEmpty()) {
-                            pipedApiToken = ""
-                            executeLogin = false
-                        } else executeLogin = true
                     }
-                )
+                    AnimatedVisibility(visible = !isPipedCustomEnabled) {
+                        Column {
+                            ButtonBarSettingEntry(
+                                //isEnabled = pipedApiToken.isEmpty(),
+                                title = stringResource(R.string.piped_change_instance),
+                                text = pipedInstanceName,
+                                icon = R.drawable.open,
+                                onClick = {
+                                    loadInstances = true
+                                }
+                            )
+                        }
+                    }
 
+                    TextDialogSettingEntry(
+                        //isEnabled = pipedApiToken.isEmpty(),
+                        title = stringResource(R.string.piped_username),
+                        text = pipedUsername,
+                        currentText = pipedUsername,
+                        onTextSave = { pipedUsername = it }
+                    )
+                    TextDialogSettingEntry(
+                        //isEnabled = pipedApiToken.isEmpty(),
+                        title = stringResource(R.string.piped_password),
+                        text = if (pipedPassword.isNotEmpty()) "********" else "",
+                        currentText = pipedPassword,
+                        onTextSave = { pipedPassword = it },
+                        modifier = Modifier
+                            .semantics {
+                                password()
+                            }
+                    )
+
+                    ButtonBarSettingEntry(
+                        isEnabled = pipedPassword.isNotEmpty() && pipedUsername.isNotEmpty() && pipedApiBaseUrl.isNotEmpty(),
+                        title = if (pipedApiToken.isNotEmpty()) stringResource(R.string.piped_disconnect) else stringResource(
+                            R.string.piped_connect
+                        ),
+                        text = if (pipedApiToken.isNotEmpty()) stringResource(R.string.piped_connected_to_s).format(pipedInstanceName) else "",
+                        icon = R.drawable.piped_logo,
+                        iconColor = colorPalette.red,
+                        onClick = {
+                            if (pipedApiToken.isNotEmpty()) {
+                                pipedApiToken = ""
+                                executeLogin = false
+                            } else executeLogin = true
+                        }
+                    )
+
+                }
             }
         }
 
         /****** PIPED ******/
 
         /****** DISCORD ******/
-        var isDiscordPresenceEnabled by rememberPreference(isDiscordPresenceEnabledKey, false)
-        var loginDiscord by remember { mutableStateOf(false) }
-        var discordPersonalAccessToken by rememberEncryptedPreference(key = discordPersonalAccessTokenKey, defaultValue = "")
-        SettingsGroupSpacer()
-        SettingsEntryGroupText(title = stringResource(R.string.social_discord))
-        SwitchSettingEntry(
-            isEnabled = isAtLeastAndroid81,
-            title = stringResource(R.string.discord_enable_rich_presence),
-            text = "",
-            isChecked = isDiscordPresenceEnabled,
-            onCheckedChange = { isDiscordPresenceEnabled = it }
-        )
 
-        AnimatedVisibility(visible = isDiscordPresenceEnabled) {
-            Column(
-                modifier = Modifier.padding(start = 25.dp)
-            ) {
-                ButtonBarSettingEntry(
-                    isEnabled = true,
-                    title = if (discordPersonalAccessToken.isNotEmpty()) stringResource(R.string.discord_disconnect) else stringResource(
-                        R.string.discord_connect
-                    ),
-                    text = if (discordPersonalAccessToken.isNotEmpty()) stringResource(R.string.discord_connected_to_discord_account) else "",
-                    icon = R.drawable.logo_discord,
-                    iconColor = colorPalette.text,
-                    onClick = {
-                        if (discordPersonalAccessToken.isNotEmpty())
-                            discordPersonalAccessToken = ""
-                        else
-                            loginDiscord = true
-                    }
-                )
+        // rememberEncryptedPreference only works correct with API 24 and up
+        if(isAtLeastAndroid7){
+            var isDiscordPresenceEnabled by rememberPreference(isDiscordPresenceEnabledKey, false)
+            var loginDiscord by remember { mutableStateOf(false) }
+            var discordPersonalAccessToken by rememberEncryptedPreference(key = discordPersonalAccessTokenKey, defaultValue = "")
+            SettingsGroupSpacer()
+            SettingsEntryGroupText(title = stringResource(R.string.social_discord))
+            SwitchSettingEntry(
+                isEnabled = isAtLeastAndroid81,
+                title = stringResource(R.string.discord_enable_rich_presence),
+                text = "",
+                isChecked = isDiscordPresenceEnabled,
+                onCheckedChange = { isDiscordPresenceEnabled = it }
+            )
 
-                CustomModalBottomSheet(
-                    showSheet = loginDiscord,
-                    onDismissRequest = {
-                        loginDiscord = false
-                    },
-                    containerColor = colorPalette.background0,
-                    contentColor = colorPalette.background0,
-                    modifier = Modifier.fillMaxWidth(),
-                    sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-                    dragHandle = {
-                        Surface(
-                            modifier = Modifier.padding(vertical = 0.dp),
-                            color = colorPalette.background0,
-                            shape = thumbnailShape
-                        ) {}
-                    },
-                    shape = thumbnailRoundness.shape()
+            AnimatedVisibility(visible = isDiscordPresenceEnabled) {
+                Column(
+                    modifier = Modifier.padding(start = 25.dp)
                 ) {
-                    DiscordLoginAndGetToken(
-                        rememberNavController(),
-                        onGetToken = { token ->
-                            loginDiscord = false
-                            discordPersonalAccessToken = token
-                            SmartMessage(token, type = PopupType.Info, context = context)
+                    ButtonBarSettingEntry(
+                        isEnabled = true,
+                        title = if (discordPersonalAccessToken.isNotEmpty()) stringResource(R.string.discord_disconnect) else stringResource(
+                            R.string.discord_connect
+                        ),
+                        text = if (discordPersonalAccessToken.isNotEmpty()) stringResource(R.string.discord_connected_to_discord_account) else "",
+                        icon = R.drawable.logo_discord,
+                        iconColor = colorPalette.text,
+                        onClick = {
+                            if (discordPersonalAccessToken.isNotEmpty())
+                                discordPersonalAccessToken = ""
+                            else
+                                loginDiscord = true
                         }
                     )
+
+                    CustomModalBottomSheet(
+                        showSheet = loginDiscord,
+                        onDismissRequest = {
+                            loginDiscord = false
+                        },
+                        containerColor = colorPalette.background0,
+                        contentColor = colorPalette.background0,
+                        modifier = Modifier.fillMaxWidth(),
+                        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+                        dragHandle = {
+                            Surface(
+                                modifier = Modifier.padding(vertical = 0.dp),
+                                color = colorPalette.background0,
+                                shape = thumbnailShape
+                            ) {}
+                        },
+                        shape = thumbnailRoundness.shape()
+                    ) {
+                        DiscordLoginAndGetToken(
+                            rememberNavController(),
+                            onGetToken = { token ->
+                                loginDiscord = false
+                                discordPersonalAccessToken = token
+                                SmartMessage(token, type = PopupType.Info, context = context)
+                            }
+                        )
+                    }
                 }
             }
         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/EncryptedPreferences.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/EncryptedPreferences.kt
@@ -2,16 +2,18 @@ package it.fast4x.rimusic.utils
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.SnapshotMutationPolicy
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.edit
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import timber.log.Timber
+import java.security.GeneralSecurityException
 
 
 const val pipedUsernameKey = "pipedUsername"
@@ -43,15 +45,34 @@ inline fun <reified T : Enum<T>> SharedPreferences.Editor.putEnum(
 
 
 val Context.encryptedPreferences: SharedPreferences
-    get() = EncryptedSharedPreferences.create(
-        applicationContext,
-        "secure_preferences",
-        MasterKey.Builder(applicationContext, MasterKey.DEFAULT_MASTER_KEY_ALIAS)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build(),
-        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-    )
+    get() = getEncryptedSharedPreferencesResult().onFailure {
+        // idea based on https://gist.github.com/rynkowsg/86ebd680a67669dfcece4cc9ec9974df
+        run {
+            Timber.w("Cannot retrieve preferences encrypted with current master key. Deleting and recreating.")
+
+            /**
+             * can only delete preferences this way on high enough API level.
+             * the code should behave the same as before for lower api levels
+             * (maybe this bug is only present on devices with high API levels anyway).
+             */
+            if (isAtLeastAndroid7) {
+                deleteSharedPreferences("secure_preferences")
+            }
+            return getEncryptedSharedPreferencesResult().getOrThrow()
+        }
+    }.getOrThrow()
+
+fun Context.getEncryptedSharedPreferencesResult(): Result<SharedPreferences> = runCatching {
+        EncryptedSharedPreferences.create(
+            applicationContext,
+            "secure_preferences",
+            MasterKey.Builder(applicationContext, MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build(),
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
 
 @Composable
 fun rememberEncryptedPreference(key: String, defaultValue: Boolean): MutableState<Boolean> {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Utils.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Utils.kt
@@ -602,6 +602,9 @@ fun getVersionCode(): Int {
 inline val isAtLeastAndroid6
     get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
 
+inline val isAtLeastAndroid7
+    get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+
 inline val isAtLeastAndroid8
     get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
 


### PR DESCRIPTION
encryptedPreferences (main change):
- implemented a fix for an javax.crypto.AEADBadTagException (on API level 24 and up)
- does not change anything for previous API levels (there)

OtherSettings:
- changed discord and piped integration to require API 24 (also because of the main change)
- extracted "extraSpace" as it would be disabled (not available)

isAtLeastAndroid7: added new method for check for android 7

Demo:
<details><summary>API 21 (foss)</summary>
<p>

![rimusic_api21_changed_foss](https://github.com/user-attachments/assets/70f48ac4-6567-40f4-a307-7f29fae6e18e)

</p>
</details> 

<details><summary>API 21 (accrescent)</summary>
<p>

![rimusic_api21_changed_accrescent](https://github.com/user-attachments/assets/a30a7f60-e03b-47f1-94a3-9e73d7efaef9)

</p>
</details> 

<details><summary>API 34 (foss)</summary>
<p>

![rimusic_api_34_changed_foss](https://github.com/user-attachments/assets/eca2ce48-8fdf-45fb-a616-bee47014605d)

</p>
</details> 

<details><summary>API 34 (accrescent)</summary>
<p>

![rimusic_api_34_changed_accrescent](https://github.com/user-attachments/assets/e970184e-8962-46da-bbbf-c9db124e14ea)

</p>
</details> 