### PR TITLE
Ensured randomness when shuffle song position

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
@@ -360,7 +360,9 @@ fun LocalPlaylistSongs(
             onDismiss = { isRenumbering = false },
             onConfirm = {
                 query {
-                    playlistSongs.forEachIndexed { index, song ->
+                    val shuffled = playlistSongs.shuffled()
+
+                    shuffled.forEachIndexed { index, song ->
                         playlistPreview?.playlist?.let {
                             Database.updateSongPosition(it.id, song.song.id, index)
                         }


### PR DESCRIPTION
# Description
Make sure the positions are random when user shuffles song positions.

# What is it aiming to solve
When you shuffle song positions, the position isn't changed, but rather flipped. Therefore, no matter how many times you shuffle it, there are only 2 (approximately) combinations.

By using built-in `.shuffled()` function, the positions of the song list are completely randomized.