### PR TITLE
Fixed search abandon anything after `#` character - #3779

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/AppNavigation.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/AppNavigation.kt
@@ -79,6 +79,8 @@ import it.fast4x.rimusic.utils.preferences
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import it.fast4x.rimusic.utils.transitionEffectKey
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @OptIn(ExperimentalFoundationApi::class, ExperimentalAnimationApi::class,
@@ -380,7 +382,8 @@ fun AppNavigation(
                 onViewPlaylist = {},
                 //pop = popDestination,
                 onSearch = { query ->
-                    navController.navigate(route = "${NavRoutes.searchResults.name}/$query")
+                    val uriSafe = URLEncoder.encode( query, StandardCharsets.UTF_8.toString() )
+                    navController.navigate(route = "${NavRoutes.searchResults.name}/$uriSafe")
 
                     if (!context.preferences.getBoolean(pauseSearchHistoryKey, false)) {
                         it.fast4x.rimusic.query {
@@ -402,7 +405,6 @@ fun AppNavigation(
             )
         ) { navBackStackEntry ->
             val query = navBackStackEntry.arguments?.getString("query") ?: ""
-
             SearchResultScreen(
                 navController = navController,
                 playerEssential = playerEssential,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
@@ -38,6 +38,7 @@ import it.fast4x.innertube.requests.albumPage
 import it.fast4x.innertube.requests.searchPage
 import it.fast4x.innertube.utils.from
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.NavRoutes
@@ -56,7 +57,6 @@ import it.fast4x.rimusic.ui.items.AlbumItem
 import it.fast4x.rimusic.ui.items.AlbumItemPlaceholder
 import it.fast4x.rimusic.ui.items.ArtistItem
 import it.fast4x.rimusic.ui.items.ArtistItemPlaceholder
-import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.ui.items.PlaylistItem
 import it.fast4x.rimusic.ui.items.PlaylistItemPlaceholder
 import it.fast4x.rimusic.ui.items.SongItem
@@ -86,6 +86,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.uiType
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -98,7 +100,8 @@ import me.knighthat.uiType
 fun SearchResultScreen(
     navController: NavController,
     playerEssential: @Composable () -> Unit = {},
-    query: String, onSearchAgain: () -> Unit
+    query: String,
+    onSearchAgain: () -> Unit
 ) {
     val context = LocalContext.current
     val binder = LocalPlayerServiceBinder.current
@@ -122,7 +125,7 @@ fun SearchResultScreen(
         host {
             val headerContent: @Composable (textButton: (@Composable () -> Unit)?) -> Unit = {
                 Header(
-                    title = query,
+                    title = URLDecoder.decode( query, StandardCharsets.UTF_8.toString() ),
                     modifier = Modifier
                         .pointerInput(Unit) {
                             detectTapGestures {


### PR DESCRIPTION
# Description

As described in #3779. If you search for a song title that contains `#` character, everything from that character will be dropped. As the result, the query only look for string before the `#`

# What I found

> I couldn't pin point the exact location where the problem occurred. But I narrowed down the scope and implemented a simple fix

The problem seems to be a string sanitization happens before the string is passed to param for query. As observed, line 383 of [AppNavigation.kt](https://github.com/fast4x/RiMusic/compare/master...knighthat:issue-3779?expand=1#diff-3f07aa22f7950d97fc4ecfaf95252b66c219c114ad2e30abaad57017ca83b627) yields both string with and without `#`.

# Solution

This can be prevent by converting query string to URL-safe string (with special characters converted into their corresponding percent-encoded format) with the implementation of `URLEncoder#encode()`. For example, string `CC#2 OST Arknights` will be converted into `CC%232+OST+Arknights`

However, this creates another problem. The query string is now `CC%232+OST+Arknights` instead of what user input. When present this to user in [SearchResultScreen.kt](https://github.com/fast4x/RiMusic/blob/master/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt), the result is undesired.

To counter this effect, `URLDecoder#decode()` is implemented to convert URL-safe string to readable string.

# Conclusion

The problem seems to go away when the implementation is introduced. But I think this is just a temporary solution until the root cause is found.

Songs with `#` or most special characters is showing up in search result