### PR TITLE
fix: get uri of a compose resource

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/PlayerMediaBrowserService.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/PlayerMediaBrowserService.kt
@@ -210,6 +210,8 @@ class PlayerMediaBrowserService : MediaBrowserServiceCompat(), ServiceConnection
         .appendPath(resources.getResourceEntryName(id))
         .build()
 
+    private fun uriFor(path: String) = Res.getUri(path).toUri()
+
 
     private val shuffleBrowserMediaItem
         inline get() = MediaItem(
@@ -226,7 +228,7 @@ class PlayerMediaBrowserService : MediaBrowserServiceCompat(), ServiceConnection
             MediaDescriptionCompat.Builder()
                 .setMediaId(MediaId.songs)
                 .setTitle((this as Context).resources.getString(R.string.songs))
-                .setIconUri(uriFor(Res.drawable.musical_notes.hashCode()))
+                .setIconUri(uriFor("drawable/musical_notes.xml"))
                 .build(),
             MediaItem.FLAG_BROWSABLE
         )
@@ -237,7 +239,7 @@ class PlayerMediaBrowserService : MediaBrowserServiceCompat(), ServiceConnection
             MediaDescriptionCompat.Builder()
                 .setMediaId(MediaId.playlists)
                 .setTitle((this as Context).resources.getString(R.string.library))
-                .setIconUri(uriFor(Res.drawable.library.hashCode()))
+                .setIconUri(uriFor("drawable/library.xml"))
                 .build(),
             MediaItem.FLAG_BROWSABLE
         )
@@ -247,7 +249,7 @@ class PlayerMediaBrowserService : MediaBrowserServiceCompat(), ServiceConnection
             MediaDescriptionCompat.Builder()
                 .setMediaId(MediaId.albums)
                 .setTitle((this as Context).resources.getString(R.string.albums))
-                .setIconUri(uriFor(Res.drawable.album.hashCode()))
+                .setIconUri(uriFor("drawable/album.xml"))
                 .build(),
             MediaItem.FLAG_BROWSABLE
         )
@@ -297,7 +299,7 @@ class PlayerMediaBrowserService : MediaBrowserServiceCompat(), ServiceConnection
             MediaDescriptionCompat.Builder()
                 .setMediaId(MediaId.ondevice)
                 .setTitle((this as Context).resources.getString(R.string.on_device))
-                .setIconUri(uriFor(Res.drawable.musical_notes.hashCode()))
+                .setIconUri(uriFor("drawable/musical_notes.xml"))
                 .build(),
             MediaItem.FLAG_PLAYABLE
         )


### PR DESCRIPTION
RiMusic doesn't work in Android Auto since 0.6.54.1

The application try to get the uri of a compose resource by looking into android resources, which causes a crash because the resource doesn't exist in android.

The only way to obtain the uri of a compose resource:
```kotlin
Res.getUri("drawable/image.xml").toUri()
```

Based on this [reply](https://github.com/JetBrains/compose-multiplatform/issues/4360#issuecomment-2037687322), I don't think they'll add a more practical way.