### PR TITLE
A little bit of readability improvement

### DIFF
--- a/composeApp/src/androidAccrescent/kotlin/it/fast4x/rimusic/ui/screens/settings/OtherSettings.kt
+++ b/composeApp/src/androidAccrescent/kotlin/it/fast4x/rimusic/ui/screens/settings/OtherSettings.kt
@@ -92,7 +92,6 @@ import it.fast4x.rimusic.utils.showFoldersOnDeviceKey
 import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import kotlinx.coroutines.launch
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.thumbnailShape
 import timber.log.Timber
 import java.io.File
@@ -172,10 +171,10 @@ fun OtherSettings() {
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right )
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
             .verticalScroll(rememberScrollState())
             /*

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/enums/NavigationBarPosition.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/enums/NavigationBarPosition.kt
@@ -1,8 +1,21 @@
 package it.fast4x.rimusic.enums
 
+import androidx.compose.runtime.Composable
+import it.fast4x.rimusic.utils.navigationBarPositionKey
+import it.fast4x.rimusic.utils.rememberPreference
+
 enum class NavigationBarPosition {
     Left,
     Right,
     Top,
-    Bottom
+    Bottom;
+
+    companion object {
+
+        @Composable
+        fun current() = rememberPreference( navigationBarPositionKey, Bottom ).value
+    }
+
+    @Composable
+    fun isCurrent(): Boolean = current() == this
 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/enums/NavigationBarType.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/enums/NavigationBarType.kt
@@ -1,7 +1,20 @@
 package it.fast4x.rimusic.enums
 
+import androidx.compose.runtime.Composable
+import it.fast4x.rimusic.utils.navigationBarTypeKey
+import it.fast4x.rimusic.utils.rememberPreference
+
 
 enum class NavigationBarType {
     IconAndText,
-    IconOnly
+    IconOnly;
+
+    companion object {
+
+        @Composable
+        fun current(): NavigationBarType = rememberPreference( navigationBarTypeKey, NavigationBarType.IconAndText ).value
+    }
+
+    @Composable
+    fun isCurrent(): Boolean = current() == this
 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/enums/UiType.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/enums/UiType.kt
@@ -1,6 +1,22 @@
 package it.fast4x.rimusic.enums
 
+import androidx.compose.runtime.Composable
+import it.fast4x.rimusic.utils.UiTypeKey
+import it.fast4x.rimusic.utils.rememberPreference
+
 enum class UiType {
     RiMusic,
-    ViMusic
+    ViMusic;
+
+    companion object {
+
+        @Composable
+        fun current(): UiType = rememberPreference( UiTypeKey, RiMusic ).value
+    }
+
+    @Composable
+    fun isCurrent(): Boolean = current() == this
+
+    @Composable
+    fun isNotCurrent(): Boolean = !isCurrent()
 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/NavigationRail.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/NavigationRail.kt
@@ -39,7 +39,6 @@ import it.fast4x.rimusic.utils.isLandscape
 import it.fast4x.rimusic.utils.semiBold
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 
 @Composable
 inline fun NavigationRail(
@@ -75,7 +74,7 @@ inline fun NavigationRail(
                 contentAlignment = Alignment.TopCenter,
                 modifier = Modifier
                     .height(
-                        if( uiType() == UiType.ViMusic )
+                        if( UiType.ViMusic.isCurrent() )
                             if (showButton2)
                                 Dimensions.headerHeight
                             else

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/NavigationRail.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/NavigationRail.kt
@@ -38,7 +38,6 @@ import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.utils.isLandscape
 import it.fast4x.rimusic.utils.semiBold
 import me.knighthat.colorPalette
-import me.knighthat.navBarType
 import me.knighthat.typography
 import me.knighthat.uiType
 
@@ -151,7 +150,7 @@ inline fun NavigationRail(
                     }
 
                     val textContent: @Composable () -> Unit = {
-                        if ( navBarType() == NavigationBarType.IconOnly ) {
+                        if ( NavigationBarType.IconOnly.isCurrent() ) {
                             /*
                             BasicText(
                                 text = "",
@@ -180,7 +179,7 @@ inline fun NavigationRail(
                     }
 
                     val iconContent: @Composable () -> Unit = {
-                        if ( navBarType() == NavigationBarType.IconOnly ) {
+                        if ( NavigationBarType.IconOnly.isCurrent() ) {
                             Image(
                                 painter = painterResource(icon),
                                 contentDescription = null,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/NavigationRailTB.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/NavigationRailTB.kt
@@ -44,7 +44,6 @@ import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.utils.semiBold
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 
 @OptIn(UnstableApi::class)
@@ -84,7 +83,7 @@ inline fun NavigationRailTB(
         if (localSheetState.isCollapsed) bottomDp + Dimensions.navigationBarHeight else bottomDp
     else 0.dp
      */
-    val bottomPadding = if ( navBarPos() == NavigationBarPosition.Bottom ) bottomDp else 5.dp
+    val bottomPadding = if ( NavigationBarPosition.Bottom.isCurrent() ) bottomDp else 5.dp
 
     //val topPadding = if (navigationBarPosition == NavigationBarPosition.Top) 30.dp else 0.dp
     val topPadding = 0.dp
@@ -177,7 +176,7 @@ inline fun NavigationRailTB(
                    }
 
                 val scrollState = rememberScrollState()
-                val roundedCornerShape = if ( navBarPos() == NavigationBarPosition.Bottom )
+                val roundedCornerShape = if ( NavigationBarPosition.Bottom.isCurrent() )
                     RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)
                 else RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp)
                 Box(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/NavigationRailTB.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/NavigationRailTB.kt
@@ -45,7 +45,6 @@ import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.utils.semiBold
 import me.knighthat.colorPalette
 import me.knighthat.navBarPos
-import me.knighthat.navBarType
 import me.knighthat.typography
 
 @OptIn(UnstableApi::class)
@@ -131,7 +130,7 @@ inline fun NavigationRailTB(
                         Box(
                             modifier = contentModifier
                         ) {
-                            if ( navBarType() == NavigationBarType.IconOnly ) {
+                            if ( NavigationBarType.IconOnly.isCurrent() ) {
                                 Image(
                                     painter = painterResource(icon),
                                     contentDescription = null,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/Scaffold.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/Scaffold.kt
@@ -46,7 +46,6 @@ import it.fast4x.rimusic.utils.playerPositionKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.transitionEffectKey
 import me.knighthat.colorPalette
-import me.knighthat.uiType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalAnimationApi
@@ -108,7 +107,7 @@ fun Scaffold(
         //val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
         val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
         val customModifier =
-            if( uiType() == UiType.RiMusic )
+            if( UiType.RiMusic.isCurrent() )
                 Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
             else
                 Modifier
@@ -118,7 +117,7 @@ fun Scaffold(
             modifier = customModifier,
             containerColor = colorPalette().background0,
             topBar = {
-                if( uiType() == UiType.RiMusic ) {
+                if( UiType.RiMusic.isCurrent() ) {
                     AppBar(navController)
                 }
             },
@@ -179,7 +178,7 @@ fun Scaffold(
                     if ( NavigationBarPosition.Left.isCurrent() )
                         navigationRail()
 
-                    val topPadding = if ( uiType() == UiType.ViMusic ) 30.dp else 0.dp
+                    val topPadding = if ( UiType.ViMusic.isCurrent() ) 30.dp else 0.dp
 
                     AnimatedContent(
                         targetState = tabIndex,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/Scaffold.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/Scaffold.kt
@@ -46,7 +46,6 @@ import it.fast4x.rimusic.utils.playerPositionKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.transitionEffectKey
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.uiType
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -80,7 +79,7 @@ fun Scaffold(
     val transitionEffect by rememberPreference(transitionEffectKey, TransitionEffect.Scale)
     val playerPosition by rememberPreference(playerPositionKey, PlayerPosition.Bottom)
 
-    if ( navBarPos() == NavigationBarPosition.Top || navBarPos() == NavigationBarPosition.Bottom) {
+    if ( NavigationBarPosition.Top.isCurrent() || NavigationBarPosition.Bottom.isCurrent() ) {
             ScaffoldTB(
                 navController = navController,
                 playerEssential = playerEssential,
@@ -177,7 +176,7 @@ fun Scaffold(
                         )
                     }
 
-                    if ( navBarPos() == NavigationBarPosition.Left )
+                    if ( NavigationBarPosition.Left.isCurrent() )
                         navigationRail()
 
                     val topPadding = if ( uiType() == UiType.ViMusic ) 30.dp else 0.dp
@@ -242,7 +241,7 @@ fun Scaffold(
                             .padding(top = topPadding)
                     )
 
-                    if ( navBarPos() == NavigationBarPosition.Right )
+                    if ( NavigationBarPosition.Right.isCurrent() )
                         navigationRail()
 
                 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/ScaffoldTB.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/ScaffoldTB.kt
@@ -51,7 +51,6 @@ import it.fast4x.rimusic.utils.playerPositionKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.transitionEffectKey
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -117,7 +116,7 @@ fun ScaffoldTB(
             ) {
                 AppBar(navController)
 
-                if ( navBarPos() == NavigationBarPosition.Top )
+                if ( NavigationBarPosition.Top.isCurrent() )
                     navigationRailTB()
 
                 /*
@@ -166,7 +165,7 @@ fun ScaffoldTB(
                     }
                      */
 
-                    if ( navBarPos() == NavigationBarPosition.Bottom )
+                    if ( NavigationBarPosition.Bottom.isCurrent() )
                             navigationRailTB()
 
                 //}
@@ -174,11 +173,7 @@ fun ScaffoldTB(
 
     ) {
         val modifierBoxPadding =
-            if ( navBarPos() != NavigationBarPosition.Top )
-                Modifier
-                    .padding(it)
-                    .fillMaxSize()
-            else
+            if ( NavigationBarPosition.Top.isCurrent() )
                 Modifier
                     .padding(it)
                     .padding(
@@ -186,6 +181,10 @@ fun ScaffoldTB(
                             .only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal)
                             .asPaddingValues()
                     )
+                    .fillMaxSize()
+            else
+                Modifier
+                    .padding(it)
                     .fillMaxSize()
 
         Box(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/SimpleScaffold.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/SimpleScaffold.kt
@@ -17,7 +17,6 @@ import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.ui.components.themed.AppBar
 import it.fast4x.rimusic.ui.styling.Dimensions
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.uiType
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -52,10 +51,10 @@ fun SimpleScaffold(
             Surface(
                 modifier = Modifier
                     .fillMaxWidth(
-                        if( navBarPos() != NavigationBarPosition.Right )
-                            1f
-                        else
+                        if( NavigationBarPosition.Right.isCurrent() )
                             Dimensions.contentWidthRightBar
+                        else
+                            1f
                     ),
                 content = content
             )

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/SimpleScaffold.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/SimpleScaffold.kt
@@ -17,7 +17,6 @@ import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.ui.components.themed.AppBar
 import it.fast4x.rimusic.ui.styling.Dimensions
 import me.knighthat.colorPalette
-import me.knighthat.uiType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -26,7 +25,7 @@ fun SimpleScaffold(
     content: @Composable () -> Unit
 ) {
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-    val customModifier = if( uiType() == UiType.RiMusic)
+    val customModifier = if( UiType.RiMusic.isCurrent())
         Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
     else Modifier
 
@@ -35,7 +34,7 @@ fun SimpleScaffold(
         modifier = customModifier,
         containerColor = colorPalette().background0,
         topBar = {
-            if( uiType() == UiType.RiMusic) {
+            if( UiType.RiMusic.isCurrent()) {
                 AppBar(navController)
             }
         },

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/Snackbar.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/Snackbar.kt
@@ -49,7 +49,6 @@ import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import kotlinx.coroutines.launch
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 
 @Composable
@@ -97,7 +96,7 @@ fun Popup(
     val windowsInsets = WindowInsets.systemBars
     val bottomDp = with(density) { windowsInsets.getBottom(density).toDp() }
     val additionalBottomPadding =
-        if ( navBarPos() == NavigationBarPosition.Bottom )
+        if ( NavigationBarPosition.Bottom.isCurrent() )
             Dimensions.additionalVerticalSpaceForFloatingAction
         else
             0.dp

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/AppBar.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/AppBar.kt
@@ -52,7 +52,6 @@ import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.semiBold
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 import org.jetbrains.compose.resources.painterResource
 import rimusic.composeapp.generated.resources.Res
 import rimusic.composeapp.generated.resources.app_icon
@@ -69,7 +68,7 @@ fun AppBar(
     var showGames by remember { mutableStateOf(false) }
     //val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-    val customModifier = if( uiType() == UiType.RiMusic )
+    val customModifier = if( UiType.RiMusic.isCurrent() )
         Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
     else Modifier
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/FloatingActionsContainer.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/FloatingActionsContainer.kt
@@ -45,7 +45,6 @@ import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.scrollingInfo
 import it.fast4x.rimusic.utils.smoothScrollToTop
 import kotlinx.coroutines.launch
-import me.knighthat.navBarPos
 
 @ExperimentalMaterial3Api
 @UnstableApi
@@ -60,7 +59,7 @@ fun BoxScope.MultiFloatingActionsContainer(
     onClickSearch: (() -> Unit)? = null
 ) {
     val additionalBottomPadding =
-        if ( navBarPos() == NavigationBarPosition.Bottom )
+        if ( NavigationBarPosition.Bottom.isCurrent() )
             Dimensions.additionalVerticalSpaceForFloatingAction
         else
             0.dp
@@ -196,7 +195,7 @@ fun BoxScope.FloatingActions(
     onClick: (() -> Unit)? = null
 ) {
     val transition = updateTransition(transitionState, "")
-    val additionalBottomPadding = if ( navBarPos() == NavigationBarPosition.Bottom )
+    val additionalBottomPadding = if ( NavigationBarPosition.Bottom.isCurrent() )
         Dimensions.additionalVerticalSpaceForFloatingAction else 0.dp
     //val bottomPaddingValues = windowInsets.only(WindowInsetsSides.Bottom).asPaddingValues()
     val density = LocalDensity.current

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/Header.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/Header.kt
@@ -36,7 +36,6 @@ import it.fast4x.rimusic.utils.bold
 import it.fast4x.rimusic.utils.medium
 import it.fast4x.rimusic.utils.semiBold
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 import me.knighthat.uiType
 import kotlin.random.Random
@@ -183,7 +182,7 @@ fun HeaderWithIcon (
         )
 
         if ( showIcon && uiType() == UiType.ViMusic &&
-            ( navBarPos() == NavigationBarPosition.Left || navBarPos() == NavigationBarPosition.Right))
+            ( NavigationBarPosition.Left.isCurrent() || NavigationBarPosition.Right.isCurrent()) )
             SecondaryButton(
                 iconId = iconId,
                 enabled = enabled,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/Header.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/Header.kt
@@ -37,7 +37,6 @@ import it.fast4x.rimusic.utils.medium
 import it.fast4x.rimusic.utils.semiBold
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 import kotlin.random.Random
 
 @Composable
@@ -172,16 +171,16 @@ fun HeaderWithIcon (
                 fontSize = typography().xxl.bold.fontSize,
                 fontWeight = typography().xxl.bold.fontWeight,
                 color = colorPalette().text,
-                textAlign = if( uiType() != UiType.ViMusic) TextAlign.Center else TextAlign.End
+                textAlign = if( UiType.ViMusic.isNotCurrent()) TextAlign.Center else TextAlign.End
 
             ),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier
-                .fillMaxSize(if( showIcon && uiType() == UiType.ViMusic ) 0.9f else 1f)
+                .fillMaxSize(if( showIcon && UiType.ViMusic.isCurrent() ) 0.9f else 1f)
         )
 
-        if ( showIcon && uiType() == UiType.ViMusic &&
+        if ( showIcon && UiType.ViMusic.isCurrent() &&
             ( NavigationBarPosition.Left.isCurrent() || NavigationBarPosition.Right.isCurrent()) )
             SecondaryButton(
                 iconId = iconId,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumDetailsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumDetailsModern.kt
@@ -62,8 +62,11 @@ import it.fast4x.compose.persist.persistList
 import it.fast4x.innertube.Innertube
 import it.fast4x.innertube.models.NavigationEndpoint
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.LocalPlayerServiceBinder
+import it.fast4x.rimusic.MODIFIED_PREFIX
 import it.fast4x.rimusic.R
+import it.fast4x.rimusic.cleanPrefix
 import it.fast4x.rimusic.enums.NavRoutes
 import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.models.Album
@@ -93,17 +96,14 @@ import it.fast4x.rimusic.ui.components.themed.SelectorDialog
 import it.fast4x.rimusic.ui.components.themed.SmartMessage
 import it.fast4x.rimusic.ui.items.AlbumItem
 import it.fast4x.rimusic.ui.items.AlbumItemPlaceholder
-import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.ui.items.SongItem
 import it.fast4x.rimusic.ui.items.SongItemPlaceholder
-import it.fast4x.rimusic.MODIFIED_PREFIX
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.align
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.center
-import it.fast4x.rimusic.cleanPrefix
 import it.fast4x.rimusic.utils.color
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.durationTextToMillis
@@ -130,7 +130,6 @@ import me.bush.translator.Language
 import me.bush.translator.Translator
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 import timber.log.Timber
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -1209,7 +1208,7 @@ fun AlbumDetailsModern(
 
 
             val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-            if ( uiType() == UiType.ViMusic && showFloatingIcon )
+            if ( UiType.ViMusic.isCurrent() && showFloatingIcon )
                 MultiFloatingActionsContainer(
                     iconId = R.drawable.shuffle,
                     onClick = {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreen.kt
@@ -34,6 +34,7 @@ import it.fast4x.innertube.Innertube
 import it.fast4x.innertube.models.bodies.BrowseBody
 import it.fast4x.innertube.requests.albumPage
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.MODIFIED_PREFIX
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.NavRoutes
 import it.fast4x.rimusic.enums.ThumbnailRoundness
@@ -49,7 +50,6 @@ import it.fast4x.rimusic.ui.components.themed.adaptiveThumbnailContent
 import it.fast4x.rimusic.ui.items.AlbumItem
 import it.fast4x.rimusic.ui.items.AlbumItemPlaceholder
 import it.fast4x.rimusic.ui.screens.globalRoutes
-import it.fast4x.rimusic.MODIFIED_PREFIX
 import it.fast4x.rimusic.ui.screens.searchresult.ItemsPage
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.asMediaItem
@@ -59,7 +59,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
-import me.knighthat.uiType
 
 
 @ExperimentalMaterialApi
@@ -254,7 +253,7 @@ fun AlbumScreen(
                 navController = navController,
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 onTopIconButtonClick = pop,
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreenWithoutNavBar.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreenWithoutNavBar.kt
@@ -58,6 +58,7 @@ import it.fast4x.innertube.Innertube
 import it.fast4x.innertube.models.bodies.BrowseBody
 import it.fast4x.innertube.requests.albumPage
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.MODIFIED_PREFIX
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.NavRoutes
 import it.fast4x.rimusic.enums.PlayerPosition
@@ -75,8 +76,6 @@ import it.fast4x.rimusic.ui.components.themed.adaptiveThumbnailContent
 import it.fast4x.rimusic.ui.items.AlbumItem
 import it.fast4x.rimusic.ui.items.AlbumItemPlaceholder
 import it.fast4x.rimusic.ui.screens.globalRoutes
-import it.fast4x.rimusic.MODIFIED_PREFIX
-import it.fast4x.rimusic.ui.screens.localplaylist.LocalPlaylistSongs
 import it.fast4x.rimusic.ui.screens.searchresult.ItemsPage
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.asMediaItem
@@ -88,7 +87,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
-import me.knighthat.uiType
 
 
 @ExperimentalMaterialApi
@@ -287,7 +285,7 @@ fun AlbumScreenWithoutNavBar(
                 modifier = Modifier,
                 containerColor = colorPalette().background0,
                 topBar = {
-                    if( uiType() == UiType.RiMusic )
+                    if( UiType.RiMusic.isCurrent() )
                         AppBar(navController)
                 }
             ) {
@@ -303,7 +301,7 @@ fun AlbumScreenWithoutNavBar(
                             .background(colorPalette().background0)
                             .fillMaxSize()
                     ) {
-                        val topPadding = if ( uiType() == UiType.ViMusic ) 30.dp else 0.dp
+                        val topPadding = if ( UiType.ViMusic.isCurrent() ) 30.dp else 0.dp
 
                         AnimatedContent(
                             targetState = 0,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreenWithoutScaffold.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreenWithoutScaffold.kt
@@ -69,7 +69,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -220,9 +219,7 @@ fun AlbumScreenWithoutScaffold(
 
                         Header(title = album?.title ?: "Unknown") {
 
-                            if ( navBarPos() == NavigationBarPosition.Left
-                                || navBarPos() == NavigationBarPosition.Top
-                            ) {
+                            if ( NavigationBarPosition.Left.isCurrent() || NavigationBarPosition.Top.isCurrent() ) {
                                 IconButton(
                                     onClick = { pop() },
                                     icon = R.drawable.chevron_back,
@@ -295,9 +292,7 @@ fun AlbumScreenWithoutScaffold(
                                     }
                                 }
                             )
-                            if ( navBarPos() == NavigationBarPosition.Right
-                                || navBarPos() == NavigationBarPosition.Bottom
-                            ) {
+                            if ( NavigationBarPosition.Right.isCurrent() || NavigationBarPosition.Bottom.isCurrent() ) {
                                 Spacer(modifier = Modifier.width(10.dp))
                                 IconButton(
                                     onClick = { pop() },

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumSongs.kt
@@ -54,7 +54,9 @@ import coil.size.Size
 import it.fast4x.compose.persist.persist
 import it.fast4x.compose.persist.persistList
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.LocalPlayerServiceBinder
+import it.fast4x.rimusic.MODIFIED_PREFIX
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.PopupType
 import it.fast4x.rimusic.enums.UiType
@@ -81,10 +83,8 @@ import it.fast4x.rimusic.ui.components.themed.NowPlayingShow
 import it.fast4x.rimusic.ui.components.themed.SelectorDialog
 import it.fast4x.rimusic.ui.components.themed.SmartMessage
 import it.fast4x.rimusic.ui.items.AlbumItemPlaceholder
-import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.ui.items.SongItem
 import it.fast4x.rimusic.ui.items.SongItemPlaceholder
-import it.fast4x.rimusic.MODIFIED_PREFIX
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.asMediaItem
@@ -106,7 +106,6 @@ import it.fast4x.rimusic.utils.semiBold
 import it.fast4x.rimusic.utils.showFloatingIconKey
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 import java.text.SimpleDateFormat
 import java.util.Date
 
@@ -815,7 +814,7 @@ fun AlbumSongs(
                 }
 
             val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-            if( uiType() == UiType.ViMusic && showFloatingIcon )
+            if( UiType.ViMusic.isCurrent() && showFloatingIcon )
                 MultiFloatingActionsContainer(
                     iconId = R.drawable.shuffle,
                     onClick = {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistLocalSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistLocalSongs.kt
@@ -58,7 +58,6 @@ import it.fast4x.rimusic.utils.manageDownload
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.showFloatingIconKey
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.uiType
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -130,10 +129,10 @@ fun ArtistLocalSongs(
                 //.fillMaxSize()
                 .fillMaxHeight()
                 .fillMaxWidth(
-                    if ( navBarPos() != NavigationBarPosition.Right )
-                        1f
-                    else
+                    if( NavigationBarPosition.Right.isCurrent() )
                         Dimensions.contentWidthRightBar
+                    else
+                        1f
                 )
         ) {
             LazyColumn(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistLocalSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistLocalSongs.kt
@@ -58,7 +58,6 @@ import it.fast4x.rimusic.utils.manageDownload
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.showFloatingIconKey
 import me.knighthat.colorPalette
-import me.knighthat.uiType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @ExperimentalTextApi
@@ -342,7 +341,7 @@ fun ArtistLocalSongs(
             }
 
             val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-            if( uiType() == UiType.ViMusic && showFloatingIcon )
+            if( UiType.ViMusic.isCurrent() && showFloatingIcon )
                 MultiFloatingActionsContainer(
                     iconId = R.drawable.shuffle,
                     onClick = {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
@@ -115,7 +115,6 @@ import me.bush.translator.Language
 import me.bush.translator.Translator
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 import kotlin.random.Random
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -892,7 +891,7 @@ fun ArtistOverviewModern(
             }
 
             val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-            if( uiType() == UiType.ViMusic && showFloatingIcon )
+            if( UiType.ViMusic.isCurrent() && showFloatingIcon )
                 youtubeArtistPage?.radioEndpoint?.let { endpoint ->
 
                     MultiFloatingActionsContainer(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
@@ -114,7 +114,6 @@ import kotlinx.coroutines.withContext
 import me.bush.translator.Language
 import me.bush.translator.Translator
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 import me.knighthat.uiType
 import kotlin.random.Random
@@ -196,10 +195,10 @@ fun ArtistOverviewModern(
                 //.fillMaxSize()
                 .fillMaxHeight()
                 .fillMaxWidth(
-                    if ( navBarPos() != NavigationBarPosition.Right )
-                        1f
-                    else
+                    if( NavigationBarPosition.Right.isCurrent() )
                         Dimensions.contentWidthRightBar
+                    else
+                        1f
                 )
         ) {
             Column(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
@@ -85,7 +85,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -399,7 +398,7 @@ fun ArtistScreen(
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
                 onTopIconButtonClick = pop,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,
                 showButton2 = false,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/builtinplaylist/BuiltInPlaylistScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/builtinplaylist/BuiltInPlaylistScreen.kt
@@ -34,7 +34,6 @@ import it.fast4x.rimusic.utils.showMyTopPlaylistKey
 import it.fast4x.rimusic.utils.showOnDevicePlaylistKey
 import it.fast4x.rimusic.utils.showSearchTabKey
 import it.fast4x.rimusic.utils.showStatsInNavbarKey
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -115,11 +114,11 @@ fun BuiltInPlaylistScreen(
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
                 onTopIconButtonClick = pop,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,
-                showButton2 = if( uiType() == UiType.RiMusic ) false else showStatsInNavbar,
-                showBottomButton = if( uiType() == UiType.RiMusic ) false else showSearchTab,
+                showButton2 = if( UiType.RiMusic.isCurrent() ) false else showStatsInNavbar,
+                showBottomButton = if( UiType.RiMusic.isCurrent() ) false else showSearchTab,
                 onBottomIconButtonClick = {
                     //searchRoute("")
                     navController.navigate(NavRoutes.search.name)

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/builtinplaylist/BuiltInPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/builtinplaylist/BuiltInPlaylistSongs.kt
@@ -144,7 +144,6 @@ import it.fast4x.rimusic.utils.songSortOrderKey
 import it.fast4x.rimusic.utils.thumbnail
 import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.thumbnailShape
 import me.knighthat.typography
 import java.text.SimpleDateFormat
@@ -484,10 +483,10 @@ fun BuiltInPlaylistSongs(
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if ( navBarPos() != NavigationBarPosition.Right )
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
     ) {
         LazyColumn(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/history/HistoryList.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/history/HistoryList.kt
@@ -34,6 +34,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.offline.Download
 import androidx.navigation.NavController
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.LocalPlayerAwareWindowInsets
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
@@ -48,7 +49,6 @@ import it.fast4x.rimusic.ui.components.themed.HeaderWithIcon
 import it.fast4x.rimusic.ui.components.themed.NonQueuedMediaItemMenuLibrary
 import it.fast4x.rimusic.ui.components.themed.NowPlayingShow
 import it.fast4x.rimusic.ui.components.themed.Title
-import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.ui.items.SongItem
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.favoritesOverlay
@@ -64,7 +64,6 @@ import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.map
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
@@ -157,10 +156,10 @@ fun HistoryList(
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if ( navBarPos() != NavigationBarPosition.Right )
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
     ) {
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/history/HistoryScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/history/HistoryScreen.kt
@@ -17,7 +17,6 @@ import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.ui.components.Scaffold
 import it.fast4x.rimusic.ui.screens.globalRoutes
 import it.fast4x.rimusic.ui.screens.homeRoute
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -43,7 +42,7 @@ fun HistoryScreen(
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
                 onTopIconButtonClick = pop,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,
                 showButton2 = false,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
@@ -108,7 +108,6 @@ import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import me.knighthat.colorPalette
 import me.knighthat.thumbnailShape
 import me.knighthat.typography
-import me.knighthat.uiType
 import kotlin.random.Random
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -215,7 +214,7 @@ fun HomeAlbumsModern(
                 contentType = 0,
                 span = { GridItemSpan(maxLineSpan) }
             ) {
-                if ( uiType() == UiType.ViMusic )
+                if ( UiType.ViMusic.isCurrent() )
                     HeaderWithIcon(
                         title = stringResource(R.string.albums),
                         iconId = R.drawable.search,
@@ -241,7 +240,7 @@ fun HomeAlbumsModern(
                         .padding(top = 10.dp, bottom = 16.dp)
                         .fillMaxWidth()
                 ) {
-                    if ( uiType() == UiType.RiMusic )
+                    if ( UiType.RiMusic.isCurrent() )
                         TitleSection(title = stringResource(R.string.albums))
 
                     HeaderInfo(
@@ -640,7 +639,7 @@ fun HomeAlbumsModern(
         FloatingActionsContainerWithScrollToTop(lazyListState = lazyListState)
 
         val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-        if ( uiType() == UiType.ViMusic && showFloatingIcon )
+        if ( UiType.ViMusic.isCurrent() && showFloatingIcon )
             MultiFloatingActionsContainer(
                 iconId = R.drawable.search,
                 onClick = onSearchClick,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
@@ -101,7 +101,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 import me.knighthat.uiType
 import kotlin.random.Random
@@ -172,10 +171,10 @@ fun HomeArtistsModern(
             .background(colorPalette().background0)
             .fillMaxHeight()
             .fillMaxWidth(
-                if ( navBarPos() != NavigationBarPosition.Right )
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
     ) {
         LazyVerticalGrid(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
@@ -102,7 +102,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 import kotlin.random.Random
 
 @ExperimentalMaterial3Api
@@ -190,7 +189,7 @@ fun HomeArtistsModern(
                 contentType = 0,
                 span = { GridItemSpan(maxLineSpan) }
             ) {
-                if ( uiType() == UiType.ViMusic)
+                if ( UiType.ViMusic.isCurrent())
                     HeaderWithIcon(
                         title = stringResource(R.string.artists),
                         iconId = R.drawable.search,
@@ -215,7 +214,7 @@ fun HomeArtistsModern(
                         .padding(top = 10.dp, bottom = 16.dp)
                         .fillMaxWidth()
                 ){
-                    if ( uiType() == UiType.RiMusic )
+                    if ( UiType.RiMusic.isCurrent() )
                         TitleSection(title = stringResource(R.string.artists))
 
                     HeaderInfo(
@@ -498,7 +497,7 @@ fun HomeArtistsModern(
         FloatingActionsContainerWithScrollToTop(lazyGridState = lazyGridState)
 
         val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-        if( uiType() == UiType.ViMusic && showFloatingIcon )
+        if( UiType.ViMusic.isCurrent() && showFloatingIcon )
             MultiFloatingActionsContainer(
                 iconId = R.drawable.search,
                 onClick = onSearchClick,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeDiscovery.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeDiscovery.kt
@@ -77,7 +77,6 @@ import it.fast4x.rimusic.utils.semiBold
 import it.fast4x.rimusic.utils.showSearchTabKey
 import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 import me.knighthat.uiType
 
@@ -143,10 +142,10 @@ fun HomeDiscovery(
                 //.fillMaxSize()
                 .fillMaxHeight()
                 .fillMaxWidth(
-                    if( navBarPos() != NavigationBarPosition.Right )
-                        1f
-                    else
+                    if( NavigationBarPosition.Right.isCurrent() )
                         Dimensions.contentWidthRightBar
+                    else
+                        1f
                 )
                 .verticalScroll(scrollState)
                 .padding(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeDiscovery.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeDiscovery.kt
@@ -78,7 +78,6 @@ import it.fast4x.rimusic.utils.showSearchTabKey
 import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @SuppressLint("SuspiciousIndentation")
@@ -300,7 +299,7 @@ fun HomeDiscovery(
             }
         }
 
-        if( uiType() == UiType.ViMusic )
+        if( UiType.ViMusic.isCurrent() )
         FloatingActionsContainerWithScrollToTop(
             scrollState = scrollState,
             iconId = R.drawable.search,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -68,6 +68,9 @@ import it.fast4x.compose.persist.persistList
 import it.fast4x.rimusic.Database
 import it.fast4x.rimusic.LocalPlayerAwareWindowInsets
 import it.fast4x.rimusic.LocalPlayerServiceBinder
+import it.fast4x.rimusic.MONTHLY_PREFIX
+import it.fast4x.rimusic.PINNED_PREFIX
+import it.fast4x.rimusic.PIPED_PREFIX
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.BuiltInPlaylist
 import it.fast4x.rimusic.enums.LibraryItemSize
@@ -104,9 +107,6 @@ import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.CheckMonthlyPlaylist
 import it.fast4x.rimusic.utils.ImportPipedPlaylists
-import it.fast4x.rimusic.MONTHLY_PREFIX
-import it.fast4x.rimusic.PINNED_PREFIX
-import it.fast4x.rimusic.PIPED_PREFIX
 import it.fast4x.rimusic.utils.PlayShuffledSongs
 import it.fast4x.rimusic.utils.autosyncKey
 import it.fast4x.rimusic.utils.createPipedPlaylist
@@ -133,8 +133,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
-
 
 
 @ExperimentalMaterial3Api
@@ -352,7 +350,7 @@ fun HomeLibraryModern(
         ) {
             item(key = "header", contentType = 0, span = { GridItemSpan(maxLineSpan) }) {
 
-                if ( uiType() == UiType.ViMusic )
+                if ( UiType.ViMusic.isCurrent() )
                     HeaderWithIcon(
                         title = stringResource(R.string.playlists),
                         iconId = R.drawable.search,
@@ -374,7 +372,7 @@ fun HomeLibraryModern(
                         .fillMaxWidth()
 
                 ) {
-                    if ( uiType() == UiType.RiMusic )
+                    if ( UiType.RiMusic.isCurrent() )
                         TitleSection(title = stringResource(R.string.playlists))
 
                     HeaderInfo(
@@ -774,7 +772,7 @@ fun HomeLibraryModern(
         FloatingActionsContainerWithScrollToTop(lazyGridState = lazyGridState)
 
         val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-        if( uiType() == UiType.ViMusic && showFloatingIcon )
+        if( UiType.ViMusic.isCurrent() && showFloatingIcon )
             MultiFloatingActionsContainer(
                 iconId = R.drawable.search,
                 onClick = onSearchClick,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeScreen.kt
@@ -46,8 +46,6 @@ import it.fast4x.rimusic.utils.preferences
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.showSearchTabKey
 import it.fast4x.rimusic.utils.showStatsInNavbarKey
-import me.knighthat.uiType
-
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -215,14 +213,14 @@ fun HomeScreen(
                     //settingsRoute()
                     navController.navigate(NavRoutes.settings.name)
                 },
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 topIconButton2Id = R.drawable.stats_chart,
                 onTopIconButton2Click = {
                     //statisticsTypeRoute(StatisticsType.Today)
                     navController.navigate(NavRoutes.statistics.name)
                 },
-                showButton2 = if( uiType() == UiType.RiMusic ) false else showStatsInNavbar,
-                showBottomButton = if( uiType() == UiType.RiMusic ) false else showSearchTab,
+                showButton2 = if( UiType.RiMusic.isCurrent() ) false else showStatsInNavbar,
+                showBottomButton = if( UiType.RiMusic.isCurrent() ) false else showSearchTab,
                 onBottomIconButtonClick = {
                     //searchRoute("")
                     navController.navigate(NavRoutes.search.name)

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSearch.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSearch.kt
@@ -32,7 +32,6 @@ import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.ui.styling.px
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.thumbnailShape
 
 @ExperimentalAnimationApi
@@ -50,10 +49,10 @@ fun HomeSearch(
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right )
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
     ) {
         LazyVerticalGrid(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -180,7 +180,6 @@ import kotlinx.coroutines.launch
 import me.knighthat.colorPalette
 import me.knighthat.thumbnailShape
 import me.knighthat.typography
-import me.knighthat.uiType
 import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -695,7 +694,7 @@ fun HomeSongsModern(
                         .fillMaxWidth()
                         .background(colorPalette().background0)
                 ) {
-                    if ( uiType() == UiType.ViMusic )
+                    if ( UiType.ViMusic.isCurrent() )
                         HeaderWithIcon(
                             title = stringResource(R.string.songs),
                             iconId = R.drawable.search,
@@ -712,7 +711,7 @@ fun HomeSongsModern(
                             .padding(all = 12.dp)
                             .fillMaxSize()
                     ) {
-                        if ( uiType() == UiType.RiMusic )
+                        if ( UiType.RiMusic.isCurrent() )
                             TitleSection(title = stringResource(R.string.songs))
 
                         HeaderInfo(
@@ -1695,7 +1694,7 @@ fun HomeSongsModern(
         FloatingActionsContainerWithScrollToTop(lazyListState = lazyListState)
 
         val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-        if( uiType() == UiType.ViMusic && showFloatingIcon )
+        if( UiType.ViMusic.isCurrent() && showFloatingIcon )
             MultiFloatingActionsContainer(
                 iconId = R.drawable.search,
                 onClick = onSearchClick,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -80,6 +80,7 @@ import androidx.navigation.NavController
 import com.github.doyaaaaaken.kotlincsv.dsl.csvWriter
 import it.fast4x.compose.persist.persistList
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.BuiltInPlaylist
@@ -125,7 +126,6 @@ import it.fast4x.rimusic.ui.components.themed.SecondaryTextButton
 import it.fast4x.rimusic.ui.components.themed.SmartMessage
 import it.fast4x.rimusic.ui.components.themed.SortMenu
 import it.fast4x.rimusic.ui.components.themed.TitleSection
-import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.ui.items.FolderItem
 import it.fast4x.rimusic.ui.items.SongItem
 import it.fast4x.rimusic.ui.screens.ondevice.musicFilesAsFlow
@@ -178,7 +178,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.thumbnailShape
 import me.knighthat.typography
 import me.knighthat.uiType
@@ -678,10 +677,10 @@ fun HomeSongsModern(
             .fillMaxHeight()
             //.fillMaxWidth(if (navigationBarPosition == NavigationBarPosition.Left) 1f else Dimensions.contentWidthRightBar)
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right )
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
     ) {
         LazyColumn(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeStatistics.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeStatistics.kt
@@ -52,7 +52,6 @@ import it.fast4x.rimusic.utils.playlistSortOrderKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.showSearchTabKey
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.thumbnailShape
 import me.knighthat.uiType
 
@@ -121,10 +120,10 @@ fun HomeStatistics(
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right )
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
     ) {
         LazyVerticalGrid(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeStatistics.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeStatistics.kt
@@ -53,7 +53,6 @@ import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.showSearchTabKey
 import me.knighthat.colorPalette
 import me.knighthat.thumbnailShape
-import me.knighthat.uiType
 
 @SuppressLint("SuspiciousIndentation")
 @ExperimentalAnimationApi
@@ -261,7 +260,7 @@ fun HomeStatistics(
             }
 
         }
-        if( uiType() == UiType.ViMusic )
+        if( UiType.ViMusic.isCurrent() )
             FloatingActionsContainerWithScrollToTop(
                 lazyGridState = lazyGridState,
                 iconId = R.drawable.search,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
@@ -67,6 +67,7 @@ import it.fast4x.innertube.requests.chartsPageComplete
 import it.fast4x.innertube.requests.discoverPage
 import it.fast4x.innertube.requests.relatedPage
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.LocalPlayerAwareWindowInsets
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
@@ -92,7 +93,6 @@ import it.fast4x.rimusic.ui.components.themed.Title
 import it.fast4x.rimusic.ui.components.themed.Title2Actions
 import it.fast4x.rimusic.ui.items.AlbumItem
 import it.fast4x.rimusic.ui.items.ArtistItem
-import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.ui.items.PlaylistItem
 import it.fast4x.rimusic.ui.items.SongItem
 import it.fast4x.rimusic.ui.styling.Dimensions
@@ -129,7 +129,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 import me.knighthat.uiType
 import timber.log.Timber
@@ -323,10 +322,10 @@ fun QuickPicksModern(
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxWidth(
-                    if( navBarPos() != NavigationBarPosition.Right )
-                        1f
-                    else
+                    if( NavigationBarPosition.Right.isCurrent() )
                         Dimensions.contentWidthRightBar
+                    else
+                        1f
                 )
 
         ) {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
@@ -130,7 +130,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 import timber.log.Timber
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
@@ -358,7 +357,7 @@ fun QuickPicksModern(
                 //relatedPageResult?.getOrNull()?.let { related ->
                 related = relatedPageResult?.getOrNull()
 
-                if ( uiType() == UiType.ViMusic )
+                if ( UiType.ViMusic.isCurrent() )
                     HeaderWithIcon(
                         title = stringResource(R.string.quick_picks),
                         iconId = R.drawable.search,
@@ -1075,7 +1074,7 @@ fun QuickPicksModern(
 
 
             val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-            if( uiType() == UiType.ViMusic && showFloatingIcon )
+            if( UiType.ViMusic.isCurrent() && showFloatingIcon )
                 MultiFloatingActionsContainer(
                     iconId = R.drawable.search,
                     onClick = onSearchClick,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistScreen.kt
@@ -18,7 +18,6 @@ import it.fast4x.rimusic.enums.NavRoutes
 import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.ui.components.Scaffold
 import it.fast4x.rimusic.ui.screens.globalRoutes
-import me.knighthat.uiType
 
 @OptIn(KotlinCsvExperimental::class)
 @ExperimentalMaterialApi
@@ -44,7 +43,7 @@ fun LocalPlaylistScreen(
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
                 onTopIconButtonClick = pop,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,
                 showButton2 = false,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistScreenWithoutNavBar.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistScreenWithoutNavBar.kt
@@ -49,7 +49,6 @@ import it.fast4x.rimusic.utils.playerPositionKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.transitionEffectKey
 import me.knighthat.colorPalette
-import me.knighthat.uiType
 
 @OptIn(KotlinCsvExperimental::class)
 @ExperimentalMaterialApi
@@ -77,7 +76,7 @@ fun LocalPlaylistScreenWithoutNavBar(
                 modifier = modifier,
                 containerColor = colorPalette().background0,
                 topBar = {
-                    if( uiType() == UiType.RiMusic )
+                    if( UiType.RiMusic.isCurrent() )
                         AppBar(navController)
                 }
             ) {
@@ -93,7 +92,7 @@ fun LocalPlaylistScreenWithoutNavBar(
                             .background(colorPalette().background0)
                             .fillMaxSize()
                     ) {
-                        val topPadding = if ( uiType() == UiType.ViMusic ) 30.dp else 0.dp
+                        val topPadding = if ( UiType.ViMusic.isCurrent() ) 30.dp else 0.dp
 
                         AnimatedContent(
                             targetState = 0,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
@@ -91,8 +91,13 @@ import it.fast4x.innertube.models.bodies.NextBody
 import it.fast4x.innertube.requests.playlistPage
 import it.fast4x.innertube.requests.relatedSongs
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.LocalPlayerServiceBinder
+import it.fast4x.rimusic.MONTHLY_PREFIX
+import it.fast4x.rimusic.PINNED_PREFIX
+import it.fast4x.rimusic.PIPED_PREFIX
 import it.fast4x.rimusic.R
+import it.fast4x.rimusic.cleanPrefix
 import it.fast4x.rimusic.enums.MaxSongs
 import it.fast4x.rimusic.enums.NavRoutes
 import it.fast4x.rimusic.enums.NavigationBarPosition
@@ -126,21 +131,16 @@ import it.fast4x.rimusic.ui.components.themed.PlaylistsItemMenu
 import it.fast4x.rimusic.ui.components.themed.SmartMessage
 import it.fast4x.rimusic.ui.components.themed.SortMenu
 import it.fast4x.rimusic.ui.items.SongItem
-import it.fast4x.rimusic.PINNED_PREFIX
-import it.fast4x.rimusic.PIPED_PREFIX
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.ui.styling.onOverlay
 import it.fast4x.rimusic.ui.styling.overlay
 import it.fast4x.rimusic.ui.styling.px
-import it.fast4x.rimusic.MONTHLY_PREFIX
-import it.fast4x.rimusic.utils.UiTypeKey
 import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.addToPipedPlaylist
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.autosyncKey
 import it.fast4x.rimusic.utils.center
-import it.fast4x.rimusic.cleanPrefix
 import it.fast4x.rimusic.utils.color
 import it.fast4x.rimusic.utils.completed
 import it.fast4x.rimusic.utils.deletePipedPlaylist
@@ -182,14 +182,10 @@ import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
 import me.knighthat.thumbnailShape
 import me.knighthat.typography
-import me.knighthat.uiType
 import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.UUID
-import it.fast4x.compose.reordering.animateItemPlacement
-import it.fast4x.rimusic.EXPLICIT_PREFIX
-import it.fast4x.rimusic.utils.parentalControlEnabledKey
 
 
 @KotlinCsvExperimental
@@ -1822,7 +1818,7 @@ fun LocalPlaylistSongs(
             FloatingActionsContainerWithScrollToTop(lazyListState = lazyListState)
 
             val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-            if ( uiType() == UiType.ViMusic && showFloatingIcon )
+            if ( UiType.ViMusic.isCurrent() && showFloatingIcon )
                 FloatingActionsContainerWithScrollToTop(
                     lazyListState = lazyListState,
                     iconId = R.drawable.shuffle,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodList.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodList.kt
@@ -54,7 +54,6 @@ import it.fast4x.rimusic.utils.center
 import it.fast4x.rimusic.utils.secondary
 import it.fast4x.rimusic.utils.semiBold
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 
 internal const val defaultBrowseId = "FEmusic_moods_and_genres_category"
@@ -93,10 +92,10 @@ fun MoodList(
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right )
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
     ) {
         moodPage?.getOrNull()?.let { moodResult ->

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodScreen.kt
@@ -18,7 +18,6 @@ import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.models.Mood
 import it.fast4x.rimusic.ui.components.Scaffold
 import it.fast4x.rimusic.ui.screens.globalRoutes
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -43,7 +42,7 @@ fun MoodScreen(
                 navController = navController,
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 onTopIconButtonClick = pop,
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodsPage.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodsPage.kt
@@ -48,7 +48,6 @@ import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.utils.center
 import it.fast4x.rimusic.utils.secondary
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 
 @ExperimentalFoundationApi
@@ -80,10 +79,10 @@ fun MoodsPage(
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right )
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
     ) {
         discoverPage?.getOrNull()?.let { moodResult ->

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodsPageScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodsPageScreen.kt
@@ -17,7 +17,6 @@ import it.fast4x.rimusic.enums.NavRoutes
 import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.ui.components.Scaffold
 import it.fast4x.rimusic.ui.screens.globalRoutes
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -39,7 +38,7 @@ fun MoodsPageScreen(
             Scaffold(
                 navController = navController,
                 topIconButtonId = R.drawable.chevron_back,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 onTopIconButtonClick = pop,
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/newreleases/NewReleasesScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/newreleases/NewReleasesScreen.kt
@@ -21,7 +21,6 @@ import it.fast4x.rimusic.enums.NavRoutes
 import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.ui.components.Scaffold
 import it.fast4x.rimusic.ui.screens.globalRoutes
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -51,7 +50,7 @@ fun NewreleasesScreen(
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
                 onTopIconButtonClick = pop,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,
                 showButton2 = false,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongs.kt
@@ -146,7 +146,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 import me.knighthat.uiType
 import timber.log.Timber
@@ -340,10 +339,10 @@ fun DeviceListSongs(
                 //.fillMaxSize()
                 .fillMaxHeight()
                 .fillMaxWidth(
-                    if( navBarPos() != NavigationBarPosition.Right )
-                        1f
-                    else
+                    if( NavigationBarPosition.Right.isCurrent() )
                         Dimensions.contentWidthRightBar
+                    else
+                        1f
                 )
         ) {
         LazyColumn(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongs.kt
@@ -147,7 +147,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 import timber.log.Timber
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
@@ -951,7 +950,7 @@ fun DeviceListSongs(
             }
         }
 
-            if( uiType() == UiType.ViMusic )
+            if( UiType.ViMusic.isCurrent() )
             FloatingActionsContainerWithScrollToTop(
                 lazyListState = lazyListState,
                 iconId = R.drawable.shuffle,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongsScreen.kt
@@ -32,7 +32,6 @@ import it.fast4x.rimusic.utils.showFavoritesPlaylistKey
 import it.fast4x.rimusic.utils.showMyTopPlaylistKey
 import it.fast4x.rimusic.utils.showOnDevicePlaylistKey
 import it.fast4x.rimusic.utils.showSearchTabKey
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -107,7 +106,7 @@ fun DeviceListSongsScreen(
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
                 onTopIconButtonClick = pop,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,
                 showButton2 = false,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongList.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongList.kt
@@ -114,7 +114,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 import timber.log.Timber
 
 
@@ -768,7 +767,7 @@ fun PlaylistSongList(
             }
 
             val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-            if( uiType() == UiType.ViMusic && showFloatingIcon )
+            if( UiType.ViMusic.isCurrent() && showFloatingIcon )
             FloatingActionsContainerWithScrollToTop(
                 lazyListState = lazyListState,
                 iconId = R.drawable.shuffle,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongList.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongList.kt
@@ -113,7 +113,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 import me.knighthat.uiType
 import timber.log.Timber
@@ -644,10 +643,10 @@ fun PlaylistSongList(
                 //.fillMaxSize()
                 .fillMaxHeight()
                 .fillMaxWidth(
-                    if( navBarPos() != NavigationBarPosition.Right)
-                        1f
-                    else
+                    if( NavigationBarPosition.Right.isCurrent() )
                         Dimensions.contentWidthRightBar
+                    else
+                        1f
                 )
         ) {
             LazyColumn(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongListModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongListModern.kt
@@ -72,6 +72,7 @@ import it.fast4x.innertube.models.NavigationEndpoint
 import it.fast4x.innertube.models.bodies.BrowseBody
 import it.fast4x.innertube.requests.playlistPage
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.NavRoutes
@@ -100,7 +101,6 @@ import it.fast4x.rimusic.ui.components.themed.PlaylistsItemMenu
 import it.fast4x.rimusic.ui.components.themed.SmartMessage
 import it.fast4x.rimusic.ui.components.themed.adaptiveThumbnailContent
 import it.fast4x.rimusic.ui.items.AlbumItemPlaceholder
-import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.ui.items.SongItem
 import it.fast4x.rimusic.ui.items.SongItemPlaceholder
 import it.fast4x.rimusic.ui.styling.Dimensions
@@ -133,7 +133,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 import me.knighthat.uiType
 import timber.log.Timber
@@ -301,10 +300,10 @@ fun PlaylistSongListModern(
                 //.fillMaxSize()
                 .fillMaxHeight()
                 .fillMaxWidth(
-                    if( navBarPos() != NavigationBarPosition.Right)
-                        1f
-                    else
+                    if( NavigationBarPosition.Right.isCurrent() )
                         Dimensions.contentWidthRightBar
+                    else
+                        1f
                 )
         ) {
             LazyColumn(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongListModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongListModern.kt
@@ -134,7 +134,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 import timber.log.Timber
 
 
@@ -839,7 +838,7 @@ fun PlaylistSongListModern(
             }
 
             val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-            if( uiType() == UiType.ViMusic && showFloatingIcon )
+            if( UiType.ViMusic.isCurrent() && showFloatingIcon )
             FloatingActionsContainerWithScrollToTop(
                 lazyListState = lazyListState,
                 iconId = R.drawable.shuffle,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/podcast/Podcast.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/podcast/Podcast.kt
@@ -127,7 +127,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 import me.knighthat.uiType
 import timber.log.Timber
@@ -250,10 +249,10 @@ fun Podcast(
                 //.fillMaxSize()
                 .fillMaxHeight()
                 .fillMaxWidth(
-                    if( navBarPos() != NavigationBarPosition.Right)
-                        1f
-                    else
+                    if( NavigationBarPosition.Right.isCurrent() )
                         Dimensions.contentWidthRightBar
+                    else
+                        1f
                 )
         ) {
             LazyColumn(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/podcast/Podcast.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/podcast/Podcast.kt
@@ -128,7 +128,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 import timber.log.Timber
 
 
@@ -799,7 +798,7 @@ fun Podcast(
             }
 
             val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-            if( uiType() == UiType.ViMusic && showFloatingIcon )
+            if( UiType.ViMusic.isCurrent() && showFloatingIcon )
             FloatingActionsContainerWithScrollToTop(
                 lazyListState = lazyListState,
                 iconId = R.drawable.shuffle,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/podcast/PodcastScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/podcast/PodcastScreen.kt
@@ -17,7 +17,6 @@ import it.fast4x.rimusic.enums.NavRoutes
 import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.ui.components.Scaffold
 import it.fast4x.rimusic.ui.screens.globalRoutes
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -45,7 +44,7 @@ fun PodcastScreen(
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
                 onTopIconButtonClick = pop,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,
                 showButton2 = false,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/GoToLink.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/GoToLink.kt
@@ -57,7 +57,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 
 @ExperimentalTextApi
@@ -95,10 +94,10 @@ fun GoToLink(
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right)
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
     ) {
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/LocalSongSearch.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/LocalSongSearch.kt
@@ -64,7 +64,6 @@ import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import kotlinx.coroutines.delay
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 
 @ExperimentalTextApi
@@ -121,10 +120,10 @@ fun LocalSongSearch(
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right)
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
     ) {
         LazyColumn(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/OnlineSearch.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/OnlineSearch.kt
@@ -90,7 +90,6 @@ import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 
 @UnstableApi
@@ -179,10 +178,10 @@ fun OnlineSearch(
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right)
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
     ) {
         LazyColumn(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/SearchScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/SearchScreen.kt
@@ -40,7 +40,6 @@ import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.utils.secondary
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -90,7 +89,7 @@ fun SearchScreen(
                        // .weight(1f)
                         .padding(horizontal = 10.dp)
                 ) {
-                    if ( uiType() == UiType.ViMusic )
+                    if ( UiType.ViMusic.isCurrent() )
                         Column (
                             verticalArrangement = Arrangement.Center
                         ) {
@@ -162,7 +161,7 @@ fun SearchScreen(
                 navController = navController,
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 onTopIconButtonClick = {
                     //onGoToHome()
                     navController.navigate(NavRoutes.home.name)

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/ItemsPage.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/ItemsPage.kt
@@ -34,7 +34,6 @@ import it.fast4x.rimusic.utils.secondary
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 
 @ExperimentalAnimationApi
@@ -83,10 +82,10 @@ inline fun <T : Innertube.Item> ItemsPage(
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right)
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
     ) {
         LazyColumn(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
@@ -38,6 +38,7 @@ import it.fast4x.innertube.requests.albumPage
 import it.fast4x.innertube.requests.searchPage
 import it.fast4x.innertube.utils.from
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.NavRoutes
@@ -56,7 +57,6 @@ import it.fast4x.rimusic.ui.items.AlbumItem
 import it.fast4x.rimusic.ui.items.AlbumItemPlaceholder
 import it.fast4x.rimusic.ui.items.ArtistItem
 import it.fast4x.rimusic.ui.items.ArtistItemPlaceholder
-import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.ui.items.PlaylistItem
 import it.fast4x.rimusic.ui.items.PlaylistItemPlaceholder
 import it.fast4x.rimusic.ui.items.SongItem
@@ -85,7 +85,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -141,7 +140,7 @@ fun SearchResultScreen(
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
                 onTopIconButtonClick = pop,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,
                 showButton2 = false,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/About.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/About.kt
@@ -24,7 +24,6 @@ import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.utils.getVersionName
 import it.fast4x.rimusic.utils.secondary
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 
 
@@ -39,10 +38,10 @@ fun About() {
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right)
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
             .verticalScroll(rememberScrollState())
             /*

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/CacheSettings.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/CacheSettings.kt
@@ -46,7 +46,6 @@ import it.fast4x.rimusic.utils.exoPlayerDiskCacheMaxSizeKey
 import it.fast4x.rimusic.utils.exoPlayerDiskDownloadCacheMaxSizeKey
 import it.fast4x.rimusic.utils.rememberPreference
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 
 @SuppressLint("SuspiciousIndentation")
 @OptIn(ExperimentalCoilApi::class)
@@ -101,10 +100,10 @@ fun CacheSettings() {
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right)
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
             .verticalScroll(rememberScrollState())
             .padding(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/DataSettings.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/DataSettings.kt
@@ -69,7 +69,6 @@ import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.semiBold
 import kotlinx.coroutines.flow.distinctUntilChanged
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -305,10 +304,10 @@ fun DataSettings() {
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right)
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
             .verticalScroll(rememberScrollState())
             /*

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/QuickPicsSettings.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/QuickPicsSettings.kt
@@ -43,7 +43,6 @@ import it.fast4x.rimusic.utils.showSimilarArtistsKey
 import it.fast4x.rimusic.utils.showTipsKey
 import kotlinx.coroutines.flow.distinctUntilChanged
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 
 @ExperimentalAnimationApi
 @UnstableApi
@@ -84,10 +83,10 @@ fun  QuickPicsSettings() {
             //.fillMaxSize()
             .fillMaxHeight()
             .fillMaxWidth(
-                if( navBarPos() != NavigationBarPosition.Right)
-                    1f
-                else
+                if( NavigationBarPosition.Right.isCurrent() )
                     Dimensions.contentWidthRightBar
+                else
+                    1f
             )
             .verticalScroll(rememberScrollState())
             /*

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/SettingsScreen.kt
@@ -60,7 +60,6 @@ import it.fast4x.rimusic.utils.secondary
 import it.fast4x.rimusic.utils.semiBold
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -87,7 +86,7 @@ fun SettingsScreen(
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
                 onTopIconButtonClick = pop,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,
                 showButton2 = false,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/UiSettings.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/UiSettings.kt
@@ -228,7 +228,6 @@ import it.fast4x.rimusic.utils.visualizerEnabledKey
 import it.fast4x.rimusic.utils.volumeNormalizationKey
 import me.knighthat.colorPalette
 import me.knighthat.typography
-import me.knighthat.uiType
 
 @Composable
 fun DefaultUiSettings() {
@@ -1370,7 +1369,7 @@ fun UiSettings(
         if (filter.isNullOrBlank() || stringResource(R.string.interface_in_use).contains(filterCharSequence,true))
             EnumValueSelectorSettingsEntry(
                 title = stringResource(R.string.interface_in_use),
-                selectedValue = uiType(),
+                selectedValue = uiType,
                 onValueSelected = {
                     uiType = it
                     if (uiType == UiType.ViMusic) {
@@ -1775,7 +1774,7 @@ fun UiSettings(
                 }
             )
 
-        if ( uiType() == UiType.ViMusic ) {
+        if ( UiType.ViMusic.isCurrent() ) {
             if (filter.isNullOrBlank() || stringResource(R.string.vimusic_show_search_button_in_navigation_bar).contains(
                     filterCharSequence,
                     true

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPage.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPage.kt
@@ -85,7 +85,6 @@ import it.fast4x.rimusic.utils.semiBold
 import it.fast4x.rimusic.utils.showStatsListeningTimeKey
 import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import me.knighthat.colorPalette
-import me.knighthat.navBarPos
 import me.knighthat.typography
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
@@ -223,10 +222,10 @@ fun StatisticsPage(
                 //.fillMaxSize()
                 .fillMaxHeight()
                 .fillMaxWidth(
-                    if( navBarPos() != NavigationBarPosition.Right)
-                        1f
-                    else
+                    if( NavigationBarPosition.Right.isCurrent() )
                         Dimensions.contentWidthRightBar
+                    else
+                        1f
                 )
                 .verticalScroll(scrollState)
                 /*

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsScreen.kt
@@ -20,7 +20,6 @@ import it.fast4x.rimusic.enums.StatisticsType
 import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.ui.components.Scaffold
 import it.fast4x.rimusic.ui.screens.globalRoutes
-import me.knighthat.uiType
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -59,7 +58,7 @@ fun StatisticsScreen(
                 playerEssential = playerEssential,
                 topIconButtonId = R.drawable.chevron_back,
                 onTopIconButtonClick = pop,
-                showButton1 = uiType() != UiType.RiMusic,
+                showButton1 = UiType.RiMusic.isNotCurrent(),
                 topIconButton2Id = R.drawable.chevron_back,
                 onTopIconButton2Click = pop,
                 showButton2 = false,

--- a/composeApp/src/androidMain/kotlin/me/knighthat/GlobalVars.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/GlobalVars.kt
@@ -2,13 +2,7 @@ package me.knighthat
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
-import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.ui.styling.LocalAppearance
-import it.fast4x.rimusic.utils.UiTypeKey
-import it.fast4x.rimusic.utils.rememberPreference
-
-@Composable
-fun uiType() = rememberPreference( UiTypeKey, UiType.RiMusic ).value
 
 @Composable
 fun typography() = LocalAppearance.current.typography

--- a/composeApp/src/androidMain/kotlin/me/knighthat/GlobalVars.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/GlobalVars.kt
@@ -15,9 +15,6 @@ import it.fast4x.rimusic.utils.rememberPreference
 fun uiType() = rememberPreference( UiTypeKey, UiType.RiMusic ).value
 
 @Composable
-fun navBarType() = rememberPreference( navigationBarTypeKey, NavigationBarType.IconAndText ).value
-
-@Composable
 fun navBarPos() = rememberPreference(navigationBarPositionKey, NavigationBarPosition.Bottom).value
 
 @Composable

--- a/composeApp/src/androidMain/kotlin/me/knighthat/GlobalVars.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/GlobalVars.kt
@@ -2,20 +2,13 @@ package me.knighthat
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
-import it.fast4x.rimusic.enums.NavigationBarPosition
-import it.fast4x.rimusic.enums.NavigationBarType
 import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.ui.styling.LocalAppearance
 import it.fast4x.rimusic.utils.UiTypeKey
-import it.fast4x.rimusic.utils.navigationBarPositionKey
-import it.fast4x.rimusic.utils.navigationBarTypeKey
 import it.fast4x.rimusic.utils.rememberPreference
 
 @Composable
 fun uiType() = rememberPreference( UiTypeKey, UiType.RiMusic ).value
-
-@Composable
-fun navBarPos() = rememberPreference(navigationBarPositionKey, NavigationBarPosition.Bottom).value
 
 @Composable
 fun typography() = LocalAppearance.current.typography


### PR DESCRIPTION
# Description

This commit aims to populate the enum classes that are "empty". Use them to store values like "current", and checking if current is the given value

# What's changed

- [NavigationBarPosition.kt](https://github.com/fast4x/RiMusic/compare/master...knighthat:code-cleanup?expand=1#diff-44a4a480415d900ba0c0c21a17cc5ea9e8f5623efa8729392aeccda838ef47c5)
- [NavigationBarType.kt](https://github.com/fast4x/RiMusic/compare/master...knighthat:code-cleanup?expand=1#diff-1919956e6e6c2420d182c1414115059efb2971aa62cc287bceabd247d35a8ffa)
- [UiType.kt](https://github.com/fast4x/RiMusic/compare/master...knighthat:code-cleanup?expand=1#diff-3db2f23b65569ee90fe917a9656617db91cd7020852312d2f4b01903e8545daa)

# Usage

## In the past

To compare if UiType is ViMusic. We used to use:

```kotlin
if( uiType() == UiType.ViMusic ) 
```

Or when you want to get current UiType. You used:

```kotlin
uiType()
```

## This version

New definition makes the code more verbose and less confusing by forcing user to specify the value before comparison. 

For example, to get current UiType:

```kotlin
UiType.current()
```

To check if current UiType is the value we want:

```kotlin
UiType.RiMusic.isCurrent()
```

# Question

Why aren't we using uppercase for enums? For example, `NavigationBarPosition.LEFT`

# Note

As always, each commit is designed to work independently, feel free to cherry pick
