### PR TITLE
automatically build & deploy custom version every week

### DIFF
--- a/.github/workflows/weekly-deploy-customversion.yml
+++ b/.github/workflows/weekly-deploy-customversion.yml
@@ -3,7 +3,7 @@ name: Weekly Android app deploy
 on:
   schedule:
   # Gotta wait until contributors.json is updated
-  - cron: '1 0 * * 1'  # Every Monday at 1AM
+  - cron: '0 0 * * 2'  # Every Tuesday at 0AM
 
   # Allow manual trigger
   workflow_dispatch:

--- a/.github/workflows/weekly-deploy-customversion.yml
+++ b/.github/workflows/weekly-deploy-customversion.yml
@@ -1,0 +1,92 @@
+name: Weekly Android app deploy
+
+on:
+  schedule:
+  # Gotta wait until contributors.json is updated
+  - cron: '1 0 * * 1'  # Every Monday at 1AM
+
+  # Allow manual trigger
+  workflow_dispatch:
+
+concurrency:
+  group: 'Weekly-deploy'
+  cancel-in-progress: false  # Don't cancel any in-progress runs in this group
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    # Set date as a variable
+    outputs:
+      BUILD_DATE: ${{ steps.date.outputs.date }}
+      APK_FILENAME: app-foss-release-${{ steps.date.outputs.date }}.apk
+
+    steps:
+    - name: Get date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y%m%d')"
+
+  build-apk:
+    needs: setup
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4.2.1
+
+    - name: Setup Java 21
+      uses: actions/setup-java@v4.4.0
+      with:
+        java-version: "21"
+        distribution: "corretto"
+        cache: gradle
+
+    - name: Build with Gradle
+      run: ./gradlew assembleDebug
+
+    - name: Rename to match build number
+      run: |
+        mkdir -p app
+
+        cp composeApp/build/outputs/apk/foss/debug/app-foss-debug.apk app/${{ needs.setup.outputs.APK_FILENAME }}
+
+    - name: Upload built artifact for next job
+      uses: actions/upload-artifact@v4.4.1
+      with:
+        name: ${{ needs.setup.outputs.APK_FILENAME }}
+        path: app/${{ needs.setup.outputs.APK_FILENAME }}
+
+
+  upload-to-release:
+    needs: [setup, build-apk]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Retrieve APK
+      uses: actions/download-artifact@v4.1.8
+      with:
+        name: ${{ needs.setup.outputs.APK_FILENAME }}
+
+    - name: Upload built APK to release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: ${{ needs.setup.outputs.APK_FILENAME }}
+        prerelease: true
+        name: RiMusic Weekly Build | Custom Version | ${{ needs.setup.outputs.BUILD_DATE }}
+        tag_name: "custom-version"
+        body: |
+          <div align="center">
+            <img src="/assets/design/latest/app_logo.svg" width="300" height="100" />
+            <p><b>RiMusic</b> Custom Version</p>
+            <p>Remember, the custom version is not an official release.</p>
+          </div>
+
+          ## ❗ CUSTOM VERSION
+          **WARNING**: This custom version is not an official release, it only serves to anticipate fix or feature pending the official release. Downloading only if invited by the developer, it may damage your current installation.
+
+          ## 📲 Installation
+
+          > Android treats this installation as a different app and will not remove old RiMusic app.
+
+          Download [HERE](https://github.com/knighthat/RiMusic/releases/download/custom-version/${{ needs.setup.outputs.APK_FILENAME }}) or use link down below
+
+        token: ${{ secrets.RELEASE_TOKEN }}
+        generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@
 
 ## ❗ CUSTOM VERSION
 WARNING, the custom version is not an official release, download only if invited by the developer!
-[Go to custom version](https://github.com/fast4x/RiMusic/tree/master/customVersion)
+[Go to custom version](https://github.com/fast4x/RiMusic/releases/tag/custom-version)
 
 ## ❓ FAQs
 - See [Wiki page FAQs](https://github.com/fast4x/RiMusic/wiki/FAQs)


### PR DESCRIPTION
This makes CI/CD a little bit less heavy. Update of Custom Version is more predictable

### Requirements

RELEASE_TOKEN secret with `read & write` permissions to `actions` and `content` of fine-grained token

![Screenshot_20241008_132042](https://github.com/user-attachments/assets/76ff1924-ab93-44d6-a19a-115fd1caa112)


### Demo

![Screenshot_20241008_130937](https://github.com/user-attachments/assets/836369ed-81c1-498e-a3b8-4150a621f617)
