### PR TITLE
Re-arrange header | Sticky header | Improve UX with proper keyboard handler

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/Header.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/Header.kt
@@ -23,10 +23,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import it.fast4x.rimusic.enums.NavigationBarPosition
 import it.fast4x.rimusic.enums.UiType
@@ -239,15 +240,14 @@ fun HalfHeader(
 @Composable
 fun HeaderInfo (
     title: String,
-    icon: Painter,
-    spacer: Int = 5
+    iconId: Int,
+    spacer: Dp = 5.dp
 ) {
     Image(
-        painter = icon,
+        painter = painterResource( iconId ),
         contentDescription = null,
         colorFilter = ColorFilter.tint(colorPalette().textSecondary),
-        modifier = Modifier
-            .size(12.dp)
+        modifier = Modifier.size( 12.dp )
     )
     BasicText(
         text = title,
@@ -259,12 +259,10 @@ fun HeaderInfo (
         ),
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
-        modifier = Modifier
-            .padding(start = 4.dp)
+        modifier = Modifier.padding( start = 4.dp )
     )
 
     Spacer(
-        modifier = Modifier
-            .width(spacer.dp)
+        modifier = Modifier.width( spacer )
     )
 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
@@ -53,11 +53,11 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.UnstableApi
 import it.fast4x.compose.persist.persist
@@ -253,8 +253,8 @@ fun HomeAlbumsModern(
 
                     HeaderInfo(
                         title = "${items.size}",
-                        icon = painterResource(R.drawable.album),
-                        spacer = 0
+                        iconId = R.drawable.album,
+                        spacer = Dp.Hairline
                     )
 
                     Spacer(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
@@ -112,6 +112,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
+import me.knighthat.component.tab.TabHeader
 import me.knighthat.thumbnailShape
 import me.knighthat.typography
 import kotlin.random.Random
@@ -206,66 +207,19 @@ fun HomeAlbumsModern(
                 else Dimensions.contentWidthRightBar
             )
     ) {
-
+        TabHeader( R.string.albums ) {
+            HeaderInfo( items.size.toString(), R.drawable.album )
+        }
 
         LazyVerticalGrid(
             state = lazyGridState,
             columns = GridCells.Adaptive(itemSize.dp + 24.dp),
             //contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
             modifier = Modifier
+                .padding( top = TabHeader.height() )
                 .background(colorPalette().background0)
                 .fillMaxSize()
         ) {
-
-            item(
-                key = "header",
-                contentType = 0,
-                span = { GridItemSpan(maxLineSpan) }
-            ) {
-                if ( UiType.ViMusic.isCurrent() )
-                    HeaderWithIcon(
-                        title = stringResource(R.string.albums),
-                        iconId = R.drawable.search,
-                        enabled = true,
-                        showIcon = !showSearchTab,
-                        modifier = Modifier,
-                        onClick = onSearchClick
-                    )
-
-            }
-
-            item(
-                key = "headerNew",
-                contentType = 0,
-                span = { GridItemSpan(maxLineSpan) }
-            ) {
-
-                Row(
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .padding(horizontal = 12.dp)
-                        .padding(top = 10.dp, bottom = 4.dp)
-                        .fillMaxWidth()
-                ) {
-                    if (UiType.RiMusic.isCurrent())
-                        TitleSection(title = stringResource(R.string.albums))
-
-                    HeaderInfo(
-                        title = "${items.size}",
-                        iconId = R.drawable.album,
-                        spacer = Dp.Hairline
-                    )
-
-                    Spacer(
-                        modifier = Modifier
-                            .weight(1f)
-                    )
-
-                }
-
-            }
-
             item(
                 key = "headerButtons",
                 contentType = 0,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
@@ -47,10 +47,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusModifier
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -235,7 +234,8 @@ fun HomeAlbumsModern(
                                 onDuration = { sortBy = AlbumSortBy.Duration }
                             )
                         }
-                    }
+                    },
+                    modifier = Modifier.graphicsLayer { rotationZ = sortOrderIconRotation }
                 )
 
                 TabToolBar.Icon( R.drawable.search_circle ) {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -57,7 +56,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.UnstableApi
 import it.fast4x.compose.persist.persist
@@ -79,9 +77,7 @@ import it.fast4x.rimusic.transaction
 import it.fast4x.rimusic.ui.components.LocalMenuState
 import it.fast4x.rimusic.ui.components.themed.AlbumsItemMenu
 import it.fast4x.rimusic.ui.components.themed.FloatingActionsContainerWithScrollToTop
-import it.fast4x.rimusic.ui.components.themed.HeaderIconButton
 import it.fast4x.rimusic.ui.components.themed.HeaderInfo
-import it.fast4x.rimusic.ui.components.themed.HeaderWithIcon
 import it.fast4x.rimusic.ui.components.themed.IconButton
 import it.fast4x.rimusic.ui.components.themed.InputTextDialog
 import it.fast4x.rimusic.ui.components.themed.Menu
@@ -89,7 +85,6 @@ import it.fast4x.rimusic.ui.components.themed.MenuEntry
 import it.fast4x.rimusic.ui.components.themed.MultiFloatingActionsContainer
 import it.fast4x.rimusic.ui.components.themed.SmartMessage
 import it.fast4x.rimusic.ui.components.themed.SortMenu
-import it.fast4x.rimusic.ui.components.themed.TitleSection
 import it.fast4x.rimusic.ui.items.AlbumItem
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.favoritesIcon
@@ -112,6 +107,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
+import me.knighthat.component.header.TabToolBar
 import me.knighthat.component.tab.TabHeader
 import me.knighthat.thumbnailShape
 import me.knighthat.typography
@@ -235,150 +231,87 @@ fun HomeAlbumsModern(
                         .fillMaxWidth()
                 ) {
 
-                    HeaderIconButton(
-                        icon = R.drawable.arrow_up,
-                        color = colorPalette().text,
-                        onClick = {},
-                        modifier = Modifier
-                            .padding(horizontal = 2.dp)
-                            .graphicsLayer { rotationZ = sortOrderIconRotation }
-                            .combinedClickable(
-                                onClick = { sortOrder = !sortOrder },
-                                onLongClick = {
-                                    menuState.display {
-                                        SortMenu(
-                                            title = stringResource(R.string.sorting_order),
-                                            onDismiss = menuState::hide,
-                                            onTitle = { sortBy = AlbumSortBy.Title },
-                                            onYear = { sortBy = AlbumSortBy.Year },
-                                            onDateAdded = { sortBy = AlbumSortBy.DateAdded },
-                                            onArtist = { sortBy = AlbumSortBy.Artist },
-                                            onSongNumber = { sortBy = AlbumSortBy.Songs },
-                                            onDuration = { sortBy = AlbumSortBy.Duration }
-                                        )
-                                    }
-                                }
-                            )
-                    )
-
-                    HeaderIconButton(
-                        onClick = { searching = !searching },
-                        icon = R.drawable.search_circle,
-                        color = colorPalette().text,
-                        iconSize = 24.dp,
-                        modifier = Modifier
-                            .padding(horizontal = 2.dp)
-                    )
-
-                    HeaderIconButton(
-                        modifier = Modifier
-                            .padding(horizontal = 2.dp)
-                            .rotate(rotationAngle),
-                        icon = R.drawable.dice,
-                        enabled = items.isNotEmpty(),
-                        color = colorPalette().text,
-                        onClick = {
-                            isRotated = !isRotated
-                            //onAlbumClick(items.get((0..<items.size).random()))
-                            onAlbumClick(
-                                items.get(
-                                    Random(System.currentTimeMillis()).nextInt(0, items.size - 1)
-                                )
-                            )
-                        },
-                        iconSize = 16.dp
-                    )
-
-                    HeaderIconButton(
-                        icon = R.drawable.shuffle,
-                        color = colorPalette().text,
-                        iconSize = 24.dp,
-                        onClick = {},
-                        modifier = Modifier
-                            .padding(horizontal = 4.dp)
-                            .combinedClickable (
-                                onClick = {
-                                    coroutineScope.launch {
-                                        withContext(Dispatchers.IO) {
-                                            Database.songsInAllBookmarkedAlbums()
-                                                .collect { PlayShuffledSongs(songsList = it, binder = binder, context = context) }
-                                        }
-                                    }
-
-                                },
-                                onLongClick = {
-                                    SmartMessage(
-                                        context.resources.getString(R.string.shuffle),
-                                        context = context
-                                    )
-                                }
-                            )
-                    )
-
-                    HeaderIconButton(
-                        onClick = {
+                    TabToolBar.Icon(
+                        iconId = R.drawable.arrow_up,
+                        onShortClick = { sortOrder = !sortOrder },
+                        onLongClick = {
                             menuState.display {
-                                Menu {
-                                    MenuEntry(
-                                        icon = R.drawable.arrow_forward,
-                                        text = stringResource(R.string.small),
-                                        onClick = {
-                                            itemSize = LibraryItemSize.Small.size
-                                            menuState.hide()
-                                        }
-                                    )
-                                    MenuEntry(
-                                        icon = R.drawable.arrow_forward,
-                                        text = stringResource(R.string.medium),
-                                        onClick = {
-                                            itemSize = LibraryItemSize.Medium.size
-                                            menuState.hide()
-                                        }
-                                    )
-                                    MenuEntry(
-                                        icon = R.drawable.arrow_forward,
-                                        text = stringResource(R.string.big),
-                                        onClick = {
-                                            itemSize = LibraryItemSize.Big.size
-                                            menuState.hide()
-                                        }
-                                    )
-                                }
+                                SortMenu(
+                                    title = stringResource(R.string.sorting_order),
+                                    onDismiss = menuState::hide,
+                                    onTitle = { sortBy = AlbumSortBy.Title },
+                                    onYear = { sortBy = AlbumSortBy.Year },
+                                    onDateAdded = { sortBy = AlbumSortBy.DateAdded },
+                                    onArtist = { sortBy = AlbumSortBy.Artist },
+                                    onSongNumber = { sortBy = AlbumSortBy.Songs },
+                                    onDuration = { sortBy = AlbumSortBy.Duration }
+                                )
                             }
-                        },
-                        icon = R.drawable.resize,
-                        color = colorPalette().text,
-                        modifier = Modifier.padding(horizontal = 2.dp)
+                        }
                     )
 
+                    TabToolBar.Icon( R.drawable.search_circle ) { searching = !searching }
 
-                    /*
-                    BasicText(
-                        text = when (sortBy) {
-                            AlbumSortBy.Title -> stringResource(R.string.sort_title)
-                            AlbumSortBy.Year -> stringResource(R.string.sort_year)
-                            AlbumSortBy.DateAdded -> stringResource(R.string.sort_date_added)
-                        },
-                        style = typography().xs.semiBold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier
-                            .clickable {
-                                menuState.display{
-                                    SortMenu(
-                                        title = stringResource(R.string.sorting_order),
-                                        onDismiss = menuState::hide,
-                                        onTitle = { sortBy = AlbumSortBy.Title },
-                                        onYear = { sortBy = AlbumSortBy.Year },
-                                        onDateAdded = { sortBy = AlbumSortBy.DateAdded },
-                                    )
+                    TabToolBar.Icon(
+                        iconId = R.drawable.dice,
+                        enabled = items.isNotEmpty(),
+                        modifier = Modifier.rotate( rotationAngle )
+                    ) {
+                        isRotated = !isRotated
+
+                        val randIndex = Random( System.currentTimeMillis() ).nextInt( items.size )
+                        onAlbumClick( items[randIndex] )
+                    }
+
+                    TabToolBar.Icon(
+                        iconId = R.drawable.shuffle,
+                        onShortClick = {
+                            coroutineScope.launch {
+                                withContext(Dispatchers.IO) {
+                                    Database.songsInAllBookmarkedAlbums()
+                                        .collect { PlayShuffledSongs(songsList = it, binder = binder, context = context) }
                                 }
-                                //showSortTypeSelectDialog = true
                             }
+
+                        },
+                        onLongClick = {
+                            SmartMessage(
+                                context.resources.getString(R.string.shuffle),
+                                context = context
+                            )
+                        }
                     )
-                    */
 
-
+                    TabToolBar.Icon( R.drawable.resize ) {
+                        menuState.display {
+                            Menu {
+                                MenuEntry(
+                                    icon = R.drawable.arrow_forward,
+                                    text = stringResource(R.string.small),
+                                    onClick = {
+                                        itemSize = LibraryItemSize.Small.size
+                                        menuState.hide()
+                                    }
+                                )
+                                MenuEntry(
+                                    icon = R.drawable.arrow_forward,
+                                    text = stringResource(R.string.medium),
+                                    onClick = {
+                                        itemSize = LibraryItemSize.Medium.size
+                                        menuState.hide()
+                                    }
+                                )
+                                MenuEntry(
+                                    icon = R.drawable.arrow_forward,
+                                    text = stringResource(R.string.big),
+                                    onClick = {
+                                        itemSize = LibraryItemSize.Big.size
+                                        menuState.hide()
+                                    }
+                                )
+                            }
+                        }
+                    }
                 }
             }
             if (searching)

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusModifier
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
@@ -303,94 +304,88 @@ fun HomeAlbumsModern(
             }
 
             // Sticky search bar
-            if (searching)
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalAlignment = Alignment.Bottom,
-                    modifier = Modifier
-                        //.requiredHeight(30.dp)
-                        .padding(all = 10.dp)
-                        .fillMaxWidth()
-                ) {
-                    AnimatedVisibility(visible = searching) {
-                        val focusRequester = remember { FocusRequester() }
-                        val focusManager = LocalFocusManager.current
-                        val keyboardController = LocalSoftwareKeyboardController.current
+            AnimatedVisibility(
+                visible = searching,
+                modifier = Modifier.padding( all = 10.dp )
+                                  .fillMaxWidth()
+            ) {
+                val focusRequester = remember { FocusRequester() }
+                val focusManager = LocalFocusManager.current
+                val keyboardController = LocalSoftwareKeyboardController.current
 
-                        LaunchedEffect(searching) {
-                            focusRequester.requestFocus()
-                        }
-
-                        BasicTextField(
-                            value = filter ?: "",
-                            onValueChange = { filter = it },
-                            textStyle = typography().xs.semiBold,
-                            singleLine = true,
-                            maxLines = 1,
-                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                            keyboardActions = KeyboardActions(onDone = {
-                                if (filter.isNullOrBlank()) filter = ""
-                                focusManager.clearFocus()
-                            }),
-                            cursorBrush = SolidColor(colorPalette().text),
-                            decorationBox = { innerTextField ->
-                                Box(
-                                    contentAlignment = Alignment.CenterStart,
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .padding(horizontal = 10.dp)
-                                ) {
-                                    IconButton(
-                                        onClick = {},
-                                        icon = R.drawable.search,
-                                        color = colorPalette().favoritesIcon,
-                                        modifier = Modifier
-                                            .align(Alignment.CenterStart)
-                                            .size(16.dp)
-                                    )
-                                }
-                                Box(
-                                    contentAlignment = Alignment.CenterStart,
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .padding(horizontal = 30.dp)
-                                ) {
-                                    androidx.compose.animation.AnimatedVisibility(
-                                        visible = filter?.isEmpty() ?: true,
-                                        enter = fadeIn(tween(100)),
-                                        exit = fadeOut(tween(100)),
-                                    ) {
-                                        BasicText(
-                                            text = stringResource(R.string.search),
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis,
-                                            style = typography().xs.semiBold.secondary.copy(color = colorPalette().textDisabled)
-                                        )
-                                    }
-
-                                    innerTextField()
-                                }
-                            },
-                            modifier = Modifier
-                                .height(30.dp)
-                                .fillMaxWidth()
-                                .background(
-                                    colorPalette().background4,
-                                    shape = thumbnailRoundness.shape()
-                                )
-                                .focusRequester(focusRequester)
-                                .onFocusChanged {
-                                    if (!it.hasFocus) {
-                                        keyboardController?.hide()
-                                        if (filter?.isBlank() == true) {
-                                            filter = null
-                                            searching = false
-                                        }
-                                    }
-                                }
-                        )
-                    }
+                LaunchedEffect(searching) {
+                    focusRequester.requestFocus()
                 }
+
+                BasicTextField(
+                    value = filter ?: "",
+                    onValueChange = { filter = it },
+                    textStyle = typography().xs.semiBold,
+                    singleLine = true,
+                    maxLines = 1,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = {
+                        if (filter.isNullOrBlank()) filter = ""
+                        focusManager.clearFocus()
+                    }),
+                    cursorBrush = SolidColor(colorPalette().text),
+                    decorationBox = { innerTextField ->
+                        Box(
+                            contentAlignment = Alignment.CenterStart,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 10.dp)
+                        ) {
+                            IconButton(
+                                onClick = {},
+                                icon = R.drawable.search,
+                                color = colorPalette().favoritesIcon,
+                                modifier = Modifier
+                                    .align(Alignment.CenterStart)
+                                    .size(16.dp)
+                            )
+                        }
+                        Box(
+                            contentAlignment = Alignment.CenterStart,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 30.dp)
+                        ) {
+                            androidx.compose.animation.AnimatedVisibility(
+                                visible = filter?.isEmpty() ?: true,
+                                enter = fadeIn(tween(100)),
+                                exit = fadeOut(tween(100)),
+                            ) {
+                                BasicText(
+                                    text = stringResource(R.string.search),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    style = typography().xs.semiBold.secondary.copy(color = colorPalette().textDisabled)
+                                )
+                            }
+
+                            innerTextField()
+                        }
+                    },
+                    modifier = Modifier
+                        .height(30.dp)
+                        .fillMaxWidth()
+                        .background(
+                            colorPalette().background4,
+                            shape = thumbnailRoundness.shape()
+                        )
+                        .focusRequester(focusRequester)
+                        .onFocusChanged {
+                            if (!it.hasFocus) {
+                                keyboardController?.hide()
+                                if (filter?.isBlank() == true) {
+                                    filter = null
+                                    searching = false
+                                }
+                            }
+                        }
+                )
+            }
 
             LazyVerticalGrid(
                 state = lazyGridState,
@@ -565,15 +560,5 @@ fun HomeAlbumsModern(
                 onClickSettings = onSettingsClick,
                 onClickSearch = onSearchClick
             )
-
-        /*
-        FloatingActionsContainerWithScrollToTop(
-                lazyListState = lazyListState,
-                iconId = R.drawable.search,
-                onClick = onSearchClick
-            )
-         */
-
-
     }
 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -203,376 +204,354 @@ fun HomeAlbumsModern(
                 else Dimensions.contentWidthRightBar
             )
     ) {
-        TabHeader( R.string.albums ) {
-            HeaderInfo( items.size.toString(), R.drawable.album )
-        }
+        Column( Modifier.fillMaxSize() ) {
+            // Sticky tab's title
+            TabHeader( R.string.albums ) {
+                HeaderInfo( items.size.toString(), R.drawable.album )
+            }
 
-        LazyVerticalGrid(
-            state = lazyGridState,
-            columns = GridCells.Adaptive(itemSize.dp + 24.dp),
-            //contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
-            modifier = Modifier
-                .padding( top = TabHeader.height() )
-                .background(colorPalette().background0)
-                .fillMaxSize()
-        ) {
-            item(
-                key = "headerButtons",
-                contentType = 0,
-                span = { GridItemSpan(maxLineSpan) }
+            // Sticky tab's tool bar
+            Row(
+                horizontalArrangement = Arrangement.SpaceAround,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .padding(vertical = 4.dp)
+                    .fillMaxWidth()
             ) {
-
-                Row(
-                    horizontalArrangement = Arrangement.SpaceAround,
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .padding(horizontal = 12.dp)
-                        .padding(vertical = 4.dp)
-                        .fillMaxWidth()
-                ) {
-
-                    TabToolBar.Icon(
-                        iconId = R.drawable.arrow_up,
-                        onShortClick = { sortOrder = !sortOrder },
-                        onLongClick = {
-                            menuState.display {
-                                SortMenu(
-                                    title = stringResource(R.string.sorting_order),
-                                    onDismiss = menuState::hide,
-                                    onTitle = { sortBy = AlbumSortBy.Title },
-                                    onYear = { sortBy = AlbumSortBy.Year },
-                                    onDateAdded = { sortBy = AlbumSortBy.DateAdded },
-                                    onArtist = { sortBy = AlbumSortBy.Artist },
-                                    onSongNumber = { sortBy = AlbumSortBy.Songs },
-                                    onDuration = { sortBy = AlbumSortBy.Duration }
-                                )
-                            }
-                        }
-                    )
-
-                    TabToolBar.Icon( R.drawable.search_circle ) { searching = !searching }
-
-                    TabToolBar.Icon(
-                        iconId = R.drawable.dice,
-                        enabled = items.isNotEmpty(),
-                        modifier = Modifier.rotate( rotationAngle )
-                    ) {
-                        isRotated = !isRotated
-
-                        val randIndex = Random( System.currentTimeMillis() ).nextInt( items.size )
-                        onAlbumClick( items[randIndex] )
-                    }
-
-                    TabToolBar.Icon(
-                        iconId = R.drawable.shuffle,
-                        onShortClick = {
-                            coroutineScope.launch {
-                                withContext(Dispatchers.IO) {
-                                    Database.songsInAllBookmarkedAlbums()
-                                        .collect { PlayShuffledSongs(songsList = it, binder = binder, context = context) }
-                                }
-                            }
-
-                        },
-                        onLongClick = {
-                            SmartMessage(
-                                context.resources.getString(R.string.shuffle),
-                                context = context
+                TabToolBar.Icon(
+                    iconId = R.drawable.arrow_up,
+                    onShortClick = { sortOrder = !sortOrder },
+                    onLongClick = {
+                        menuState.display {
+                            SortMenu(
+                                title = stringResource(R.string.sorting_order),
+                                onDismiss = menuState::hide,
+                                onTitle = { sortBy = AlbumSortBy.Title },
+                                onYear = { sortBy = AlbumSortBy.Year },
+                                onDateAdded = { sortBy = AlbumSortBy.DateAdded },
+                                onArtist = { sortBy = AlbumSortBy.Artist },
+                                onSongNumber = { sortBy = AlbumSortBy.Songs },
+                                onDuration = { sortBy = AlbumSortBy.Duration }
                             )
                         }
-                    )
+                    }
+                )
 
-                    TabToolBar.Icon( R.drawable.resize ) {
-                        menuState.display {
-                            Menu {
-                                MenuEntry(
-                                    icon = R.drawable.arrow_forward,
-                                    text = stringResource(R.string.small),
-                                    onClick = {
-                                        itemSize = LibraryItemSize.Small.size
-                                        menuState.hide()
-                                    }
-                                )
-                                MenuEntry(
-                                    icon = R.drawable.arrow_forward,
-                                    text = stringResource(R.string.medium),
-                                    onClick = {
-                                        itemSize = LibraryItemSize.Medium.size
-                                        menuState.hide()
-                                    }
-                                )
-                                MenuEntry(
-                                    icon = R.drawable.arrow_forward,
-                                    text = stringResource(R.string.big),
-                                    onClick = {
-                                        itemSize = LibraryItemSize.Big.size
-                                        menuState.hide()
-                                    }
-                                )
+                TabToolBar.Icon( R.drawable.search_circle ) { searching = !searching }
+
+                TabToolBar.Icon(
+                    iconId = R.drawable.dice,
+                    enabled = items.isNotEmpty(),
+                    modifier = Modifier.rotate( rotationAngle )
+                ) {
+                    isRotated = !isRotated
+
+                    val randIndex = Random( System.currentTimeMillis() ).nextInt( items.size )
+                    onAlbumClick( items[randIndex] )
+                }
+
+                TabToolBar.Icon(
+                    iconId = R.drawable.shuffle,
+                    onShortClick = {
+                        coroutineScope.launch {
+                            withContext(Dispatchers.IO) {
+                                Database.songsInAllBookmarkedAlbums()
+                                    .collect { PlayShuffledSongs(songsList = it, binder = binder, context = context) }
                             }
+                        }
+
+                    },
+                    onLongClick = {
+                        SmartMessage(
+                            context.resources.getString(R.string.shuffle),
+                            context = context
+                        )
+                    }
+                )
+
+                TabToolBar.Icon( R.drawable.resize ) {
+                    menuState.display {
+                        Menu {
+                            MenuEntry(
+                                icon = R.drawable.arrow_forward,
+                                text = stringResource(R.string.small),
+                                onClick = {
+                                    itemSize = LibraryItemSize.Small.size
+                                    menuState.hide()
+                                }
+                            )
+                            MenuEntry(
+                                icon = R.drawable.arrow_forward,
+                                text = stringResource(R.string.medium),
+                                onClick = {
+                                    itemSize = LibraryItemSize.Medium.size
+                                    menuState.hide()
+                                }
+                            )
+                            MenuEntry(
+                                icon = R.drawable.arrow_forward,
+                                text = stringResource(R.string.big),
+                                onClick = {
+                                    itemSize = LibraryItemSize.Big.size
+                                    menuState.hide()
+                                }
+                            )
                         }
                     }
                 }
             }
+
+            // Sticky search bar
             if (searching)
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalAlignment = Alignment.Bottom,
+                    modifier = Modifier
+                        //.requiredHeight(30.dp)
+                        .padding(all = 10.dp)
+                        .fillMaxWidth()
+                ) {
+                    AnimatedVisibility(visible = searching) {
+                        val focusRequester = remember { FocusRequester() }
+                        val focusManager = LocalFocusManager.current
+                        val keyboardController = LocalSoftwareKeyboardController.current
+
+                        LaunchedEffect(searching) {
+                            focusRequester.requestFocus()
+                        }
+
+                        BasicTextField(
+                            value = filter ?: "",
+                            onValueChange = { filter = it },
+                            textStyle = typography().xs.semiBold,
+                            singleLine = true,
+                            maxLines = 1,
+                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                            keyboardActions = KeyboardActions(onDone = {
+                                if (filter.isNullOrBlank()) filter = ""
+                                focusManager.clearFocus()
+                            }),
+                            cursorBrush = SolidColor(colorPalette().text),
+                            decorationBox = { innerTextField ->
+                                Box(
+                                    contentAlignment = Alignment.CenterStart,
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(horizontal = 10.dp)
+                                ) {
+                                    IconButton(
+                                        onClick = {},
+                                        icon = R.drawable.search,
+                                        color = colorPalette().favoritesIcon,
+                                        modifier = Modifier
+                                            .align(Alignment.CenterStart)
+                                            .size(16.dp)
+                                    )
+                                }
+                                Box(
+                                    contentAlignment = Alignment.CenterStart,
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(horizontal = 30.dp)
+                                ) {
+                                    androidx.compose.animation.AnimatedVisibility(
+                                        visible = filter?.isEmpty() ?: true,
+                                        enter = fadeIn(tween(100)),
+                                        exit = fadeOut(tween(100)),
+                                    ) {
+                                        BasicText(
+                                            text = stringResource(R.string.search),
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                            style = typography().xs.semiBold.secondary.copy(color = colorPalette().textDisabled)
+                                        )
+                                    }
+
+                                    innerTextField()
+                                }
+                            },
+                            modifier = Modifier
+                                .height(30.dp)
+                                .fillMaxWidth()
+                                .background(
+                                    colorPalette().background4,
+                                    shape = thumbnailRoundness.shape()
+                                )
+                                .focusRequester(focusRequester)
+                                .onFocusChanged {
+                                    if (!it.hasFocus) {
+                                        keyboardController?.hide()
+                                        if (filter?.isBlank() == true) {
+                                            filter = null
+                                            searching = false
+                                        }
+                                    }
+                                }
+                        )
+                    }
+                }
+
+            LazyVerticalGrid(
+                state = lazyGridState,
+                columns = GridCells.Adaptive(itemSize.dp + 24.dp),
+                //contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+                modifier = Modifier
+                    .background(colorPalette().background0)
+                    .fillMaxSize()
+            ) {
+                items(
+                    items = items,
+                    key = Album::id
+                ) { album ->
+                    var songs = remember { listOf<Song>() }
+                    query {
+                        songs = Database.albumSongsList(album.id)
+                    }
+
+                    var showDialogChangeAlbumTitle by remember {
+                        mutableStateOf(false)
+                    }
+                    var showDialogChangeAlbumAuthors by remember {
+                        mutableStateOf(false)
+                    }
+                    var showDialogChangeAlbumCover by remember {
+                        mutableStateOf(false)
+                    }
+
+                    if (showDialogChangeAlbumTitle)
+                        InputTextDialog(
+                            onDismiss = { showDialogChangeAlbumTitle = false },
+                            title = stringResource(R.string.update_title),
+                            value = album.title.toString(),
+                            placeholder = stringResource(R.string.title),
+                            setValue = {
+                                if (it.isNotEmpty()) {
+                                    query {
+                                        Database.updateAlbumTitle(album.id, it)
+                                    }
+                                    //context.toast("Album Saved $it")
+                                }
+                            },
+                            prefix = MODIFIED_PREFIX
+                        )
+                    if (showDialogChangeAlbumAuthors)
+                        InputTextDialog(
+                            onDismiss = { showDialogChangeAlbumAuthors = false },
+                            title = stringResource(R.string.update_authors),
+                            value = album?.authorsText.toString(),
+                            placeholder = stringResource(R.string.authors),
+                            setValue = {
+                                if (it.isNotEmpty()) {
+                                    query {
+                                        Database.updateAlbumAuthors(album.id, it)
+                                    }
+                                    //context.toast("Album Saved $it")
+                                }
+                            },
+                            prefix = MODIFIED_PREFIX
+                        )
+
+                    if (showDialogChangeAlbumCover)
+                        InputTextDialog(
+                            onDismiss = { showDialogChangeAlbumCover = false },
+                            title = stringResource(R.string.update_cover),
+                            value = album?.thumbnailUrl.toString(),
+                            placeholder = stringResource(R.string.cover),
+                            setValue = {
+                                if (it.isNotEmpty()) {
+                                    query {
+                                        Database.updateAlbumCover(album.id, it)
+                                    }
+                                    //context.toast("Album Saved $it")
+                                }
+                            },
+                            prefix = MODIFIED_PREFIX
+                        )
+
+                    var position by remember {
+                        mutableIntStateOf(0)
+                    }
+                    val context = LocalContext.current
+
+                    AlbumItem(
+                        alternative = true,
+                        showAuthors = true,
+                        album = album,
+                        thumbnailSizePx = thumbnailSizePx,
+                        thumbnailSizeDp = thumbnailSizeDp,
+                        modifier = Modifier
+                            .combinedClickable(
+
+                                onLongClick = {
+                                    menuState.display {
+                                        AlbumsItemMenu(
+                                            onDismiss = menuState::hide,
+                                            album = album,
+                                            onChangeAlbumTitle = {
+                                                showDialogChangeAlbumTitle = true
+                                            },
+                                            onChangeAlbumAuthors = {
+                                                showDialogChangeAlbumAuthors = true
+                                            },
+                                            onChangeAlbumCover = {
+                                                showDialogChangeAlbumCover = true
+                                            },
+                                            onPlayNext = {
+                                                println("mediaItem ${songs}")
+                                                binder?.player?.addNext(
+                                                    songs.map(Song::asMediaItem), context
+                                                )
+
+                                            },
+                                            onEnqueue = {
+                                                println("mediaItem ${songs}")
+                                                binder?.player?.enqueue(
+                                                    songs.map(Song::asMediaItem), context
+                                                )
+
+                                            },
+                                            onAddToPlaylist = { playlistPreview ->
+                                                position =
+                                                    playlistPreview.songCount.minus(1) ?: 0
+                                                //Log.d("mediaItem", " maxPos in Playlist $it ${position}")
+                                                if (position > 0) position++ else position =
+                                                    0
+                                                //Log.d("mediaItem", "next initial pos ${position}")
+                                                //if (listMediaItems.isEmpty()) {
+                                                songs.forEachIndexed { index, song ->
+                                                    transaction {
+                                                        Database.insert(song.asMediaItem)
+                                                        Database.insert(
+                                                            SongPlaylistMap(
+                                                                songId = song.asMediaItem.mediaId,
+                                                                playlistId = playlistPreview.playlist.id,
+                                                                position = position + index
+                                                            )
+                                                        )
+                                                    }
+                                                    //Log.d("mediaItemPos", "added position ${position + index}")
+                                                }
+                                                //}
+                                            }
+                                        )
+                                    }
+                                },
+                                onClick = {
+                                    onAlbumClick(album)
+                                }
+                            )
+                            .clip(thumbnailShape())
+                    )
+                }
+
                 item(
-                    key = "headerFilter",
+                    key = "footer",
                     contentType = 0,
                     span = { GridItemSpan(maxLineSpan) }
                 ) {
-                    /*        */
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(10.dp),
-                        verticalAlignment = Alignment.Bottom,
-                        modifier = Modifier
-                            //.requiredHeight(30.dp)
-                            .padding(all = 10.dp)
-                            .fillMaxWidth()
-                    ) {
-                        AnimatedVisibility(visible = searching) {
-                            val focusRequester = remember { FocusRequester() }
-                            val focusManager = LocalFocusManager.current
-                            val keyboardController = LocalSoftwareKeyboardController.current
-
-                            LaunchedEffect(searching) {
-                                focusRequester.requestFocus()
-                            }
-
-                            BasicTextField(
-                                value = filter ?: "",
-                                onValueChange = { filter = it },
-                                textStyle = typography().xs.semiBold,
-                                singleLine = true,
-                                maxLines = 1,
-                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                keyboardActions = KeyboardActions(onDone = {
-                                    if (filter.isNullOrBlank()) filter = ""
-                                    focusManager.clearFocus()
-                                }),
-                                cursorBrush = SolidColor(colorPalette().text),
-                                decorationBox = { innerTextField ->
-                                    Box(
-                                        contentAlignment = Alignment.CenterStart,
-                                        modifier = Modifier
-                                            .weight(1f)
-                                            .padding(horizontal = 10.dp)
-                                    ) {
-                                        IconButton(
-                                            onClick = {},
-                                            icon = R.drawable.search,
-                                            color = colorPalette().favoritesIcon,
-                                            modifier = Modifier
-                                                .align(Alignment.CenterStart)
-                                                .size(16.dp)
-                                        )
-                                    }
-                                    Box(
-                                        contentAlignment = Alignment.CenterStart,
-                                        modifier = Modifier
-                                            .weight(1f)
-                                            .padding(horizontal = 30.dp)
-                                    ) {
-                                        androidx.compose.animation.AnimatedVisibility(
-                                            visible = filter?.isEmpty() ?: true,
-                                            enter = fadeIn(tween(100)),
-                                            exit = fadeOut(tween(100)),
-                                        ) {
-                                            BasicText(
-                                                text = stringResource(R.string.search),
-                                                maxLines = 1,
-                                                overflow = TextOverflow.Ellipsis,
-                                                style = typography().xs.semiBold.secondary.copy(color = colorPalette().textDisabled)
-                                            )
-                                        }
-
-                                        innerTextField()
-                                    }
-                                },
-                                modifier = Modifier
-                                    .height(30.dp)
-                                    .fillMaxWidth()
-                                    .background(
-                                        colorPalette().background4,
-                                        shape = thumbnailRoundness.shape()
-                                    )
-                                    .focusRequester(focusRequester)
-                                    .onFocusChanged {
-                                        if (!it.hasFocus) {
-                                            keyboardController?.hide()
-                                            if (filter?.isBlank() == true) {
-                                                filter = null
-                                                searching = false
-                                            }
-                                        }
-                                    }
-                            )
-                        }
-                        /*
-                        else {
-                            HeaderIconButton(
-                                onClick = { searching = true },
-                                icon = R.drawable.search_circle,
-                                color = colorPalette().text,
-                                iconSize = 24.dp
-                            )
-                        }
-
-                         */
-                    }
-                    /*        */
+                    Spacer(modifier = Modifier.height(Dimensions.bottomSpacer))
                 }
-
-            items(
-                items = items,
-                key = Album::id
-            ) { album ->
-                var songs = remember { listOf<Song>() }
-                query {
-                    songs = Database.albumSongsList(album.id)
-                }
-
-                var showDialogChangeAlbumTitle by remember {
-                    mutableStateOf(false)
-                }
-                var showDialogChangeAlbumAuthors by remember {
-                    mutableStateOf(false)
-                }
-                var showDialogChangeAlbumCover by remember {
-                    mutableStateOf(false)
-                }
-
-                if (showDialogChangeAlbumTitle)
-                    InputTextDialog(
-                        onDismiss = { showDialogChangeAlbumTitle = false },
-                        title = stringResource(R.string.update_title),
-                        value = album.title.toString(),
-                        placeholder = stringResource(R.string.title),
-                        setValue = {
-                            if (it.isNotEmpty()) {
-                                query {
-                                    Database.updateAlbumTitle(album.id, it)
-                                }
-                                //context.toast("Album Saved $it")
-                            }
-                        },
-                        prefix = MODIFIED_PREFIX
-                    )
-                if (showDialogChangeAlbumAuthors)
-                    InputTextDialog(
-                        onDismiss = { showDialogChangeAlbumAuthors = false },
-                        title = stringResource(R.string.update_authors),
-                        value = album?.authorsText.toString(),
-                        placeholder = stringResource(R.string.authors),
-                        setValue = {
-                            if (it.isNotEmpty()) {
-                                query {
-                                    Database.updateAlbumAuthors(album.id, it)
-                                }
-                                //context.toast("Album Saved $it")
-                            }
-                        },
-                        prefix = MODIFIED_PREFIX
-                    )
-
-                if (showDialogChangeAlbumCover)
-                    InputTextDialog(
-                        onDismiss = { showDialogChangeAlbumCover = false },
-                        title = stringResource(R.string.update_cover),
-                        value = album?.thumbnailUrl.toString(),
-                        placeholder = stringResource(R.string.cover),
-                        setValue = {
-                            if (it.isNotEmpty()) {
-                                query {
-                                    Database.updateAlbumCover(album.id, it)
-                                }
-                                //context.toast("Album Saved $it")
-                            }
-                        },
-                        prefix = MODIFIED_PREFIX
-                    )
-
-                var position by remember {
-                    mutableIntStateOf(0)
-                }
-                val context = LocalContext.current
-
-                AlbumItem(
-                    alternative = true,
-                    showAuthors = true,
-                    album = album,
-                    thumbnailSizePx = thumbnailSizePx,
-                    thumbnailSizeDp = thumbnailSizeDp,
-                    modifier = Modifier
-                        .combinedClickable(
-
-                            onLongClick = {
-                                menuState.display {
-                                    AlbumsItemMenu(
-                                        onDismiss = menuState::hide,
-                                        album = album,
-                                        onChangeAlbumTitle = {
-                                            showDialogChangeAlbumTitle = true
-                                        },
-                                        onChangeAlbumAuthors = {
-                                            showDialogChangeAlbumAuthors = true
-                                        },
-                                        onChangeAlbumCover = {
-                                            showDialogChangeAlbumCover = true
-                                        },
-                                        onPlayNext = {
-                                            println("mediaItem ${songs}")
-                                            binder?.player?.addNext(
-                                                songs.map(Song::asMediaItem), context
-                                            )
-
-                                        },
-                                        onEnqueue = {
-                                            println("mediaItem ${songs}")
-                                            binder?.player?.enqueue(
-                                                songs.map(Song::asMediaItem), context
-                                            )
-
-                                        },
-                                        onAddToPlaylist = { playlistPreview ->
-                                            position =
-                                                playlistPreview.songCount.minus(1) ?: 0
-                                            //Log.d("mediaItem", " maxPos in Playlist $it ${position}")
-                                            if (position > 0) position++ else position =
-                                                0
-                                            //Log.d("mediaItem", "next initial pos ${position}")
-                                            //if (listMediaItems.isEmpty()) {
-                                            songs.forEachIndexed { index, song ->
-                                                transaction {
-                                                    Database.insert(song.asMediaItem)
-                                                    Database.insert(
-                                                        SongPlaylistMap(
-                                                            songId = song.asMediaItem.mediaId,
-                                                            playlistId = playlistPreview.playlist.id,
-                                                            position = position + index
-                                                        )
-                                                    )
-                                                }
-                                                //Log.d("mediaItemPos", "added position ${position + index}")
-                                            }
-                                            //}
-                                        }
-                                    )
-                                }
-                            },
-                            onClick = {
-                                onAlbumClick(album)
-                            }
-                        )
-                        .clip(thumbnailShape())
-                )
-            }
-
-            item(
-                key = "footer",
-                contentType = 0,
-                span = { GridItemSpan(maxLineSpan) }
-            ) {
-                Spacer(modifier = Modifier.height(Dimensions.bottomSpacer))
             }
         }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
@@ -271,6 +271,88 @@ fun HomeArtistsModern(
             }
 
             // Sticky search bar
+            AnimatedVisibility(
+                visible = searching,
+                modifier = Modifier.padding( all = 10.dp )
+                                   .fillMaxWidth()
+            ) {
+                val focusRequester = remember { FocusRequester() }
+                val focusManager = LocalFocusManager.current
+                val keyboardController = LocalSoftwareKeyboardController.current
+
+                LaunchedEffect(searching) {
+                    focusRequester.requestFocus()
+                }
+
+                BasicTextField(
+                    value = filter ?: "",
+                    onValueChange = { filter = it },
+                    textStyle = typography().xs.semiBold,
+                    singleLine = true,
+                    maxLines = 1,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = {
+                        if (filter.isNullOrBlank()) filter = ""
+                        focusManager.clearFocus()
+                    }),
+                    cursorBrush = SolidColor(colorPalette().text),
+                    decorationBox = { innerTextField ->
+                        Box(
+                            contentAlignment = Alignment.CenterStart,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 10.dp)
+                        ) {
+                            IconButton(
+                                onClick = {},
+                                icon = R.drawable.search,
+                                color = colorPalette().favoritesIcon,
+                                modifier = Modifier
+                                    .align(Alignment.CenterStart)
+                                    .size(16.dp)
+                            )
+                        }
+                        Box(
+                            contentAlignment = Alignment.CenterStart,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 30.dp)
+                        ) {
+                            androidx.compose.animation.AnimatedVisibility(
+                                visible = filter?.isEmpty() ?: true,
+                                enter = fadeIn(tween(100)),
+                                exit = fadeOut(tween(100)),
+                            ) {
+                                BasicText(
+                                    text = stringResource(R.string.search),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    style = typography().xs.semiBold.secondary.copy(color = colorPalette().textDisabled)
+                                )
+                            }
+
+                            innerTextField()
+                        }
+                    },
+                    modifier = Modifier
+                        .height(30.dp)
+                        .fillMaxWidth()
+                        .background(
+                            colorPalette().background4,
+                            shape = thumbnailRoundness.shape()
+                        )
+                        .focusRequester(focusRequester)
+                        .onFocusChanged {
+                            if (!it.hasFocus) {
+                                keyboardController?.hide()
+                                if (filter?.isBlank() == true) {
+                                    filter = null
+                                    searching = false
+                                }
+                            }
+                        }
+                )
+            }
             if (searching)
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -280,84 +362,7 @@ fun HomeArtistsModern(
                         .padding(all = 10.dp)
                         .fillMaxWidth()
                 ) {
-                    AnimatedVisibility(visible = searching) {
-                        val focusRequester = remember { FocusRequester() }
-                        val focusManager = LocalFocusManager.current
-                        val keyboardController = LocalSoftwareKeyboardController.current
 
-                        LaunchedEffect(searching) {
-                            focusRequester.requestFocus()
-                        }
-
-                        BasicTextField(
-                            value = filter ?: "",
-                            onValueChange = { filter = it },
-                            textStyle = typography().xs.semiBold,
-                            singleLine = true,
-                            maxLines = 1,
-                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                            keyboardActions = KeyboardActions(onDone = {
-                                if (filter.isNullOrBlank()) filter = ""
-                                focusManager.clearFocus()
-                            }),
-                            cursorBrush = SolidColor(colorPalette().text),
-                            decorationBox = { innerTextField ->
-                                Box(
-                                    contentAlignment = Alignment.CenterStart,
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .padding(horizontal = 10.dp)
-                                ) {
-                                    IconButton(
-                                        onClick = {},
-                                        icon = R.drawable.search,
-                                        color = colorPalette().favoritesIcon,
-                                        modifier = Modifier
-                                            .align(Alignment.CenterStart)
-                                            .size(16.dp)
-                                    )
-                                }
-                                Box(
-                                    contentAlignment = Alignment.CenterStart,
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .padding(horizontal = 30.dp)
-                                ) {
-                                    androidx.compose.animation.AnimatedVisibility(
-                                        visible = filter?.isEmpty() ?: true,
-                                        enter = fadeIn(tween(100)),
-                                        exit = fadeOut(tween(100)),
-                                    ) {
-                                        BasicText(
-                                            text = stringResource(R.string.search),
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis,
-                                            style = typography().xs.semiBold.secondary.copy(color = colorPalette().textDisabled)
-                                        )
-                                    }
-
-                                    innerTextField()
-                                }
-                            },
-                            modifier = Modifier
-                                .height(30.dp)
-                                .fillMaxWidth()
-                                .background(
-                                    colorPalette().background4,
-                                    shape = thumbnailRoundness.shape()
-                                )
-                                .focusRequester(focusRequester)
-                                .onFocusChanged {
-                                    if (!it.hasFocus) {
-                                        keyboardController?.hide()
-                                        if (filter?.isBlank() == true) {
-                                            filter = null
-                                            searching = false
-                                        }
-                                    }
-                                }
-                        )
-                    }
                 }
 
             LazyVerticalGrid(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
@@ -101,6 +101,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
+import me.knighthat.component.tab.TabHeader
 import me.knighthat.typography
 import kotlin.random.Random
 
@@ -176,61 +177,19 @@ fun HomeArtistsModern(
                     1f
             )
     ) {
+        TabHeader( R.string.artists ) {
+            HeaderInfo(items.size.toString(), R.drawable.artists)
+        }
+
         LazyVerticalGrid(
             state = lazyGridState,
             columns = GridCells.Adaptive(itemSize.dp + 24.dp),
             //contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
             modifier = Modifier
+                .padding( top = TabHeader.height() )
                 .background(colorPalette().background0)
                 .fillMaxSize()
         ) {
-            item(
-                key = "header",
-                contentType = 0,
-                span = { GridItemSpan(maxLineSpan) }
-            ) {
-                if ( UiType.ViMusic.isCurrent())
-                    HeaderWithIcon(
-                        title = stringResource(R.string.artists),
-                        iconId = R.drawable.search,
-                        enabled = true,
-                        showIcon = !showSearchTab,
-                        modifier = Modifier,
-                        onClick = onSearchClick
-                    )
-            }
-
-            item(
-                key = "headerNew",
-                contentType = 0,
-                span = { GridItemSpan(maxLineSpan) }
-            ) {
-
-                Row (
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .padding(horizontal = 12.dp)
-                        .padding(top = 10.dp, bottom = 4.dp)
-                        .fillMaxWidth()
-                ){
-                    if ( UiType.RiMusic.isCurrent() )
-                        TitleSection(title = stringResource(R.string.artists))
-
-                    HeaderInfo(
-                        title = "${items.size}",
-                        iconId = R.drawable.artists,
-                        spacer = Dp.Hairline
-                    )
-
-                    Spacer(
-                        modifier = Modifier
-                            .weight(1f)
-                    )
-
-                    }
-                }
-
             item(
                 key = "headerButtons",
                 contentType = 0,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
@@ -57,7 +57,6 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.UnstableApi
 import it.fast4x.compose.persist.persistList
@@ -75,14 +74,12 @@ import it.fast4x.rimusic.ui.components.LocalMenuState
 import it.fast4x.rimusic.ui.components.themed.FloatingActionsContainerWithScrollToTop
 import it.fast4x.rimusic.ui.components.themed.HeaderIconButton
 import it.fast4x.rimusic.ui.components.themed.HeaderInfo
-import it.fast4x.rimusic.ui.components.themed.HeaderWithIcon
 import it.fast4x.rimusic.ui.components.themed.IconButton
 import it.fast4x.rimusic.ui.components.themed.Menu
 import it.fast4x.rimusic.ui.components.themed.MenuEntry
 import it.fast4x.rimusic.ui.components.themed.MultiFloatingActionsContainer
 import it.fast4x.rimusic.ui.components.themed.SmartMessage
 import it.fast4x.rimusic.ui.components.themed.SortMenu
-import it.fast4x.rimusic.ui.components.themed.TitleSection
 import it.fast4x.rimusic.ui.items.ArtistItem
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.favoritesIcon
@@ -101,6 +98,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
+import me.knighthat.component.header.TabToolBar
 import me.knighthat.component.tab.TabHeader
 import me.knighthat.typography
 import kotlin.random.Random
@@ -205,142 +203,84 @@ fun HomeArtistsModern(
                         .fillMaxWidth()
                 ){
 
-                    HeaderIconButton(
-                        icon = R.drawable.arrow_up,
-                        color = colorPalette().text,
-                        onClick = {},
-                        modifier = Modifier
-                            .padding(horizontal = 2.dp)
-                            .graphicsLayer { rotationZ = sortOrderIconRotation }
-                            .combinedClickable(
-                                onClick = { sortOrder = !sortOrder },
-                                onLongClick = {
-                                    menuState.display {
-                                        SortMenu(
-                                            title = stringResource(R.string.sorting_order),
-                                            onDismiss = menuState::hide,
-                                            onName = { sortBy = ArtistSortBy.Name },
-                                            onDateAdded = { sortBy = ArtistSortBy.DateAdded },
-                                        )
-                                    }
-                                }
-                            )
-                    )
-
-                    HeaderIconButton(
-                        onClick = { searching = !searching },
-                        icon = R.drawable.search_circle,
-                        color = colorPalette().text,
-                        iconSize = 24.dp,
-                        modifier = Modifier
-                            .padding(horizontal = 2.dp)
-                    )
-
-                    HeaderIconButton(
-                        modifier = Modifier
-                            .padding(horizontal = 2.dp)
-                            .rotate(rotationAngle),
-                        icon = R.drawable.dice,
-                        enabled = items.isNotEmpty() ,
-                        color = colorPalette().text,
-                        onClick = {
-                            isRotated = !isRotated
-                            //onArtistClick(items.get((0..<items.size).random()))
-                            onArtistClick(items.get(
-                                Random(System.currentTimeMillis()).nextInt(0, items.size)
-                            ))
-                        },
-                        iconSize = 16.dp
-                    )
-
-                    HeaderIconButton(
-                        icon = R.drawable.shuffle,
-                        color = colorPalette().text,
-                        iconSize = 24.dp,
-                        onClick = {},
-                        modifier = Modifier
-                            .padding(horizontal = 4.dp)
-                            .combinedClickable (
-                                onClick = {
-                                    coroutineScope.launch {
-                                        withContext(Dispatchers.IO) {
-                                            Database.songsInAllFollowedArtists()
-                                                .collect { PlayShuffledSongs(songsList = it, binder = binder, context = context) }
-                                        }
-                                    }
-
-                                },
-                                onLongClick = {
-                                    SmartMessage(
-                                        context.resources.getString(R.string.shuffle),
-                                        context = context
-                                    )
-                                }
-                            )
-                    )
-
-                    HeaderIconButton(
-                        onClick = {
+                    TabToolBar.Icon(
+                        iconId = R.drawable.arrow_up,
+                        modifier = Modifier.graphicsLayer { rotationZ = sortOrderIconRotation },
+                        onShortClick = { sortOrder = !sortOrder },
+                        onLongClick = {
                             menuState.display {
-                                Menu {
-                                    MenuEntry(
-                                        icon = R.drawable.arrow_forward,
-                                        text = stringResource(R.string.small),
-                                        onClick = {
-                                            itemSize = LibraryItemSize.Small.size
-                                            menuState.hide()
-                                        }
-                                    )
-                                    MenuEntry(
-                                        icon = R.drawable.arrow_forward,
-                                        text = stringResource(R.string.medium),
-                                        onClick = {
-                                            itemSize = LibraryItemSize.Medium.size
-                                            menuState.hide()
-                                        }
-                                    )
-                                    MenuEntry(
-                                        icon = R.drawable.arrow_forward,
-                                        text = stringResource(R.string.big),
-                                        onClick = {
-                                            itemSize = LibraryItemSize.Big.size
-                                            menuState.hide()
-                                        }
-                                    )
+                                SortMenu(
+                                    title = stringResource(R.string.sorting_order),
+                                    onDismiss = menuState::hide,
+                                    onName = { sortBy = ArtistSortBy.Name },
+                                    onDateAdded = { sortBy = ArtistSortBy.DateAdded },
+                                )
+                            }
+                        }
+                    )
+
+                    TabToolBar.Icon(iconId = R.drawable.search_circle) { searching = !searching }
+
+                    TabToolBar.Icon(
+                        iconId = R.drawable.dice,
+                        enabled = items.isNotEmpty(),
+                        modifier = Modifier.rotate( rotationAngle )
+                    ) {
+                        isRotated = !isRotated
+
+                        val randIndex = Random( System.currentTimeMillis() ).nextInt( items.size )
+                        onArtistClick( items[randIndex] )
+                    }
+
+                    TabToolBar.Icon(
+                        iconId = R.drawable.shuffle,
+                        onShortClick = {
+                            coroutineScope.launch {
+                                withContext(Dispatchers.IO) {
+                                    Database.songsInAllFollowedArtists()
+                                        .collect { PlayShuffledSongs(songsList = it, binder = binder, context = context) }
                                 }
                             }
                         },
-                        icon = R.drawable.resize,
-                        color = colorPalette().text
+                        onLongClick = {
+                            SmartMessage(
+                                context.resources.getString(R.string.shuffle),
+                                context = context
+                            )
+                        }
                     )
 
-
-                    /*
-                    BasicText(
-                        text = when (sortBy) {
-                            ArtistSortBy.Name -> stringResource(R.string.sort_name)
-                            ArtistSortBy.DateAdded -> stringResource(R.string.sort_date_added)
-                        },
-                        style = typography().xs.semiBold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier
-                            .clickable {
-                                menuState.display{
-                                    SortMenu(
-                                        title = stringResource(R.string.sorting_order),
-                                        onDismiss = menuState::hide,
-                                        onName= { sortBy = ArtistSortBy.Name },
-                                        onDateAdded = { sortBy = ArtistSortBy.DateAdded },
-                                    )
-                                }
-                                //showSortTypeSelectDialog = true
+                    TabToolBar.Icon( R.drawable.resize ) {
+                        menuState.display {
+                            Menu {
+                                MenuEntry(
+                                    icon = R.drawable.arrow_forward,
+                                    text = stringResource(R.string.small),
+                                    onClick = {
+                                        itemSize = LibraryItemSize.Small.size
+                                        menuState.hide()
+                                    }
+                                )
+                                MenuEntry(
+                                    icon = R.drawable.arrow_forward,
+                                    text = stringResource(R.string.medium),
+                                    onClick = {
+                                        itemSize = LibraryItemSize.Medium.size
+                                        menuState.hide()
+                                    }
+                                )
+                                MenuEntry(
+                                    icon = R.drawable.arrow_forward,
+                                    text = stringResource(R.string.big),
+                                    onClick = {
+                                        itemSize = LibraryItemSize.Big.size
+                                        menuState.hide()
+                                    }
+                                )
                             }
-                    )
-                     */
-
-            }
-
+                        }
+                    }
+                }
             }
 
             if (searching)

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
@@ -54,10 +54,10 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.UnstableApi
 import it.fast4x.compose.persist.persistList
@@ -219,8 +219,8 @@ fun HomeArtistsModern(
 
                     HeaderInfo(
                         title = "${items.size}",
-                        icon = painterResource(R.drawable.artists),
-                        spacer = 0
+                        iconId = R.drawable.artists,
+                        spacer = Dp.Hairline
                     )
 
                     Spacer(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -175,239 +176,216 @@ fun HomeArtistsModern(
                     1f
             )
     ) {
-        TabHeader( R.string.artists ) {
-            HeaderInfo(items.size.toString(), R.drawable.artists)
-        }
+        Column( Modifier.fillMaxSize() ) {
+            // Sticky tab's title
+            TabHeader( R.string.artists ) {
+                HeaderInfo(items.size.toString(), R.drawable.artists)
+            }
 
-        LazyVerticalGrid(
-            state = lazyGridState,
-            columns = GridCells.Adaptive(itemSize.dp + 24.dp),
-            //contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
-            modifier = Modifier
-                .padding( top = TabHeader.height() )
-                .background(colorPalette().background0)
-                .fillMaxSize()
-        ) {
-            item(
-                key = "headerButtons",
-                contentType = 0,
-                span = { GridItemSpan(maxLineSpan) }
-            ) {
-
-                Row (
-                    horizontalArrangement = Arrangement.SpaceAround,
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .padding(horizontal = 12.dp)
-                        .padding(vertical = 4.dp)
-                        .fillMaxWidth()
-                ){
-
-                    TabToolBar.Icon(
-                        iconId = R.drawable.arrow_up,
-                        modifier = Modifier.graphicsLayer { rotationZ = sortOrderIconRotation },
-                        onShortClick = { sortOrder = !sortOrder },
-                        onLongClick = {
-                            menuState.display {
-                                SortMenu(
-                                    title = stringResource(R.string.sorting_order),
-                                    onDismiss = menuState::hide,
-                                    onName = { sortBy = ArtistSortBy.Name },
-                                    onDateAdded = { sortBy = ArtistSortBy.DateAdded },
-                                )
-                            }
-                        }
-                    )
-
-                    TabToolBar.Icon(iconId = R.drawable.search_circle) { searching = !searching }
-
-                    TabToolBar.Icon(
-                        iconId = R.drawable.dice,
-                        enabled = items.isNotEmpty(),
-                        modifier = Modifier.rotate( rotationAngle )
-                    ) {
-                        isRotated = !isRotated
-
-                        val randIndex = Random( System.currentTimeMillis() ).nextInt( items.size )
-                        onArtistClick( items[randIndex] )
-                    }
-
-                    TabToolBar.Icon(
-                        iconId = R.drawable.shuffle,
-                        onShortClick = {
-                            coroutineScope.launch {
-                                withContext(Dispatchers.IO) {
-                                    Database.songsInAllFollowedArtists()
-                                        .collect { PlayShuffledSongs(songsList = it, binder = binder, context = context) }
-                                }
-                            }
-                        },
-                        onLongClick = {
-                            SmartMessage(
-                                context.resources.getString(R.string.shuffle),
-                                context = context
+            // Sticky tab's tool bar
+            Row (
+                horizontalArrangement = Arrangement.SpaceAround,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .padding(vertical = 4.dp)
+                    .fillMaxWidth()
+            ){
+                TabToolBar.Icon(
+                    iconId = R.drawable.arrow_up,
+                    modifier = Modifier.graphicsLayer { rotationZ = sortOrderIconRotation },
+                    onShortClick = { sortOrder = !sortOrder },
+                    onLongClick = {
+                        menuState.display {
+                            SortMenu(
+                                title = stringResource(R.string.sorting_order),
+                                onDismiss = menuState::hide,
+                                onName = { sortBy = ArtistSortBy.Name },
+                                onDateAdded = { sortBy = ArtistSortBy.DateAdded },
                             )
                         }
-                    )
+                    }
+                )
 
-                    TabToolBar.Icon( R.drawable.resize ) {
-                        menuState.display {
-                            Menu {
-                                MenuEntry(
-                                    icon = R.drawable.arrow_forward,
-                                    text = stringResource(R.string.small),
-                                    onClick = {
-                                        itemSize = LibraryItemSize.Small.size
-                                        menuState.hide()
-                                    }
-                                )
-                                MenuEntry(
-                                    icon = R.drawable.arrow_forward,
-                                    text = stringResource(R.string.medium),
-                                    onClick = {
-                                        itemSize = LibraryItemSize.Medium.size
-                                        menuState.hide()
-                                    }
-                                )
-                                MenuEntry(
-                                    icon = R.drawable.arrow_forward,
-                                    text = stringResource(R.string.big),
-                                    onClick = {
-                                        itemSize = LibraryItemSize.Big.size
-                                        menuState.hide()
-                                    }
-                                )
+                TabToolBar.Icon(iconId = R.drawable.search_circle) { searching = !searching }
+
+                TabToolBar.Icon(
+                    iconId = R.drawable.dice,
+                    enabled = items.isNotEmpty(),
+                    modifier = Modifier.rotate( rotationAngle )
+                ) {
+                    isRotated = !isRotated
+
+                    val randIndex = Random( System.currentTimeMillis() ).nextInt( items.size )
+                    onArtistClick( items[randIndex] )
+                }
+
+                TabToolBar.Icon(
+                    iconId = R.drawable.shuffle,
+                    onShortClick = {
+                        coroutineScope.launch {
+                            withContext(Dispatchers.IO) {
+                                Database.songsInAllFollowedArtists()
+                                    .collect { PlayShuffledSongs(songsList = it, binder = binder, context = context) }
                             }
+                        }
+                    },
+                    onLongClick = {
+                        SmartMessage(
+                            context.resources.getString(R.string.shuffle),
+                            context = context
+                        )
+                    }
+                )
+
+                TabToolBar.Icon( R.drawable.resize ) {
+                    menuState.display {
+                        Menu {
+                            MenuEntry(
+                                icon = R.drawable.arrow_forward,
+                                text = stringResource(R.string.small),
+                                onClick = {
+                                    itemSize = LibraryItemSize.Small.size
+                                    menuState.hide()
+                                }
+                            )
+                            MenuEntry(
+                                icon = R.drawable.arrow_forward,
+                                text = stringResource(R.string.medium),
+                                onClick = {
+                                    itemSize = LibraryItemSize.Medium.size
+                                    menuState.hide()
+                                }
+                            )
+                            MenuEntry(
+                                icon = R.drawable.arrow_forward,
+                                text = stringResource(R.string.big),
+                                onClick = {
+                                    itemSize = LibraryItemSize.Big.size
+                                    menuState.hide()
+                                }
+                            )
                         }
                     }
                 }
             }
 
+            // Sticky search bar
             if (searching)
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalAlignment = Alignment.Bottom,
+                    modifier = Modifier
+                        //.requiredHeight(30.dp)
+                        .padding(all = 10.dp)
+                        .fillMaxWidth()
+                ) {
+                    AnimatedVisibility(visible = searching) {
+                        val focusRequester = remember { FocusRequester() }
+                        val focusManager = LocalFocusManager.current
+                        val keyboardController = LocalSoftwareKeyboardController.current
+
+                        LaunchedEffect(searching) {
+                            focusRequester.requestFocus()
+                        }
+
+                        BasicTextField(
+                            value = filter ?: "",
+                            onValueChange = { filter = it },
+                            textStyle = typography().xs.semiBold,
+                            singleLine = true,
+                            maxLines = 1,
+                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                            keyboardActions = KeyboardActions(onDone = {
+                                if (filter.isNullOrBlank()) filter = ""
+                                focusManager.clearFocus()
+                            }),
+                            cursorBrush = SolidColor(colorPalette().text),
+                            decorationBox = { innerTextField ->
+                                Box(
+                                    contentAlignment = Alignment.CenterStart,
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(horizontal = 10.dp)
+                                ) {
+                                    IconButton(
+                                        onClick = {},
+                                        icon = R.drawable.search,
+                                        color = colorPalette().favoritesIcon,
+                                        modifier = Modifier
+                                            .align(Alignment.CenterStart)
+                                            .size(16.dp)
+                                    )
+                                }
+                                Box(
+                                    contentAlignment = Alignment.CenterStart,
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(horizontal = 30.dp)
+                                ) {
+                                    androidx.compose.animation.AnimatedVisibility(
+                                        visible = filter?.isEmpty() ?: true,
+                                        enter = fadeIn(tween(100)),
+                                        exit = fadeOut(tween(100)),
+                                    ) {
+                                        BasicText(
+                                            text = stringResource(R.string.search),
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                            style = typography().xs.semiBold.secondary.copy(color = colorPalette().textDisabled)
+                                        )
+                                    }
+
+                                    innerTextField()
+                                }
+                            },
+                            modifier = Modifier
+                                .height(30.dp)
+                                .fillMaxWidth()
+                                .background(
+                                    colorPalette().background4,
+                                    shape = thumbnailRoundness.shape()
+                                )
+                                .focusRequester(focusRequester)
+                                .onFocusChanged {
+                                    if (!it.hasFocus) {
+                                        keyboardController?.hide()
+                                        if (filter?.isBlank() == true) {
+                                            filter = null
+                                            searching = false
+                                        }
+                                    }
+                                }
+                        )
+                    }
+                }
+
+            LazyVerticalGrid(
+                state = lazyGridState,
+                columns = GridCells.Adaptive(itemSize.dp + 24.dp),
+                //contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+                modifier = Modifier
+                    .background(colorPalette().background0)
+                    .fillMaxSize()
+            ) {
+                items(items = items, key = Artist::id) { artist ->
+                    ArtistItem(
+                        artist = artist,
+                        thumbnailSizePx = thumbnailSizePx,
+                        thumbnailSizeDp = thumbnailSizeDp,
+                        alternative = true,
+                        modifier = Modifier
+                            .clickable(onClick = { onArtistClick(artist) })
+                            .animateItemPlacement()
+                    )
+                }
                 item(
-                    key = "headerFilter",
+                    key = "footer",
                     contentType = 0,
                     span = { GridItemSpan(maxLineSpan) }
                 ) {
-                    /*        */
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(10.dp),
-                        verticalAlignment = Alignment.Bottom,
-                        modifier = Modifier
-                            //.requiredHeight(30.dp)
-                            .padding(all = 10.dp)
-                            .fillMaxWidth()
-                    ) {
-                        AnimatedVisibility(visible = searching) {
-                            val focusRequester = remember { FocusRequester() }
-                            val focusManager = LocalFocusManager.current
-                            val keyboardController = LocalSoftwareKeyboardController.current
-
-                            LaunchedEffect(searching) {
-                                focusRequester.requestFocus()
-                            }
-
-                            BasicTextField(
-                                value = filter ?: "",
-                                onValueChange = { filter = it },
-                                textStyle = typography().xs.semiBold,
-                                singleLine = true,
-                                maxLines = 1,
-                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                keyboardActions = KeyboardActions(onDone = {
-                                    if (filter.isNullOrBlank()) filter = ""
-                                    focusManager.clearFocus()
-                                }),
-                                cursorBrush = SolidColor(colorPalette().text),
-                                decorationBox = { innerTextField ->
-                                    Box(
-                                        contentAlignment = Alignment.CenterStart,
-                                        modifier = Modifier
-                                            .weight(1f)
-                                            .padding(horizontal = 10.dp)
-                                    ) {
-                                        IconButton(
-                                            onClick = {},
-                                            icon = R.drawable.search,
-                                            color = colorPalette().favoritesIcon,
-                                            modifier = Modifier
-                                                .align(Alignment.CenterStart)
-                                                .size(16.dp)
-                                        )
-                                    }
-                                    Box(
-                                        contentAlignment = Alignment.CenterStart,
-                                        modifier = Modifier
-                                            .weight(1f)
-                                            .padding(horizontal = 30.dp)
-                                    ) {
-                                        androidx.compose.animation.AnimatedVisibility(
-                                            visible = filter?.isEmpty() ?: true,
-                                            enter = fadeIn(tween(100)),
-                                            exit = fadeOut(tween(100)),
-                                        ) {
-                                            BasicText(
-                                                text = stringResource(R.string.search),
-                                                maxLines = 1,
-                                                overflow = TextOverflow.Ellipsis,
-                                                style = typography().xs.semiBold.secondary.copy(color = colorPalette().textDisabled)
-                                            )
-                                        }
-
-                                        innerTextField()
-                                    }
-                                },
-                                modifier = Modifier
-                                    .height(30.dp)
-                                    .fillMaxWidth()
-                                    .background(
-                                        colorPalette().background4,
-                                        shape = thumbnailRoundness.shape()
-                                    )
-                                    .focusRequester(focusRequester)
-                                    .onFocusChanged {
-                                        if (!it.hasFocus) {
-                                            keyboardController?.hide()
-                                            if (filter?.isBlank() == true) {
-                                                filter = null
-                                                searching = false
-                                            }
-                                        }
-                                    }
-                            )
-                        }
-                        /*
-                        else {
-                            HeaderIconButton(
-                                onClick = { searching = true },
-                                icon = R.drawable.search_circle,
-                                color = colorPalette().text,
-                                iconSize = 24.dp
-                            )
-                        }
-
-                         */
-                    }
-                    /*        */
+                    Spacer(modifier = Modifier.height(Dimensions.bottomSpacer))
                 }
-
-            items(items = items, key = Artist::id) { artist ->
-                ArtistItem(
-                    artist = artist,
-                    thumbnailSizePx = thumbnailSizePx,
-                    thumbnailSizeDp = thumbnailSizeDp,
-                    alternative = true,
-                    modifier = Modifier
-                        .clickable(onClick = { onArtistClick(artist) })
-                        .animateItemPlacement()
-                )
-            }
-            item(
-                key = "footer",
-                contentType = 0,
-                span = { GridItemSpan(maxLineSpan) }
-            ) {
-                Spacer(modifier = Modifier.height(Dimensions.bottomSpacer))
             }
         }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -514,92 +514,86 @@ fun HomeLibraryModern(
             }
 
             // Sticky search bar
-            if (searching)
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalAlignment = Alignment.Bottom,
-                    modifier = Modifier
-                        //.requiredHeight(30.dp)
-                        .padding(all = 10.dp)
-                        .fillMaxWidth()
-                ) {
-                    AnimatedVisibility(visible = searching) {
-                        val focusRequester = remember { FocusRequester() }
-                        val focusManager = LocalFocusManager.current
+            AnimatedVisibility(
+                visible = searching,
+                modifier = Modifier.padding( all = 10.dp )
+                                   .fillMaxWidth()
+            ) {
+                val focusRequester = remember { FocusRequester() }
+                val focusManager = LocalFocusManager.current
 
-                        LaunchedEffect(searching) {
-                            if (isSearchInputFocused) focusRequester.requestFocus()
-                        }
-
-                        var searchInput by remember { mutableStateOf(TextFieldValue(filter)) }
-                        BasicTextField(
-                            value = searchInput,
-                            onValueChange = {
-                                searchInput = it.copy(
-                                    selection = TextRange(it.text.length)
-                                )
-                                filter = it.text
-                            },
-                            textStyle = typography().xs.semiBold,
-                            singleLine = true,
-                            maxLines = 1,
-                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                            keyboardActions = KeyboardActions(onDone = {
-                                focusManager.clearFocus()
-                                searching = filter.isNotBlank()
-                            }),
-                            cursorBrush = SolidColor(colorPalette().text),
-                            decorationBox = { innerTextField ->
-                                Box(
-                                    contentAlignment = Alignment.CenterStart,
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .padding(horizontal = 10.dp)
-                                ) {
-                                    IconButton(
-                                        onClick = {},
-                                        icon = R.drawable.search,
-                                        color = colorPalette().favoritesIcon,
-                                        modifier = Modifier
-                                            .align(Alignment.CenterStart)
-                                            .size(16.dp)
-                                    )
-                                }
-                                Box(
-                                    contentAlignment = Alignment.CenterStart,
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .padding(horizontal = 30.dp)
-                                ) {
-                                    androidx.compose.animation.AnimatedVisibility(
-                                        visible = filter.isBlank(),
-                                        enter = fadeIn(tween(100)),
-                                        exit = fadeOut(tween(100)),
-                                    ) {
-                                        BasicText(
-                                            text = stringResource(R.string.search),
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis,
-                                            style = typography().xs.semiBold.secondary.copy(
-                                                color = colorPalette().textDisabled
-                                            )
-                                        )
-                                    }
-
-                                    innerTextField()
-                                }
-                            },
-                            modifier = Modifier
-                                .height(30.dp)
-                                .fillMaxWidth()
-                                .background(
-                                    colorPalette().background4,
-                                    shape = thumbnailRoundness.shape()
-                                )
-                                .focusRequester(focusRequester)
-                        )
-                    }
+                LaunchedEffect(searching) {
+                    if (isSearchInputFocused) focusRequester.requestFocus()
                 }
+
+                var searchInput by remember { mutableStateOf(TextFieldValue(filter)) }
+                BasicTextField(
+                    value = searchInput,
+                    onValueChange = {
+                        searchInput = it.copy(
+                            selection = TextRange(it.text.length)
+                        )
+                        filter = it.text
+                    },
+                    textStyle = typography().xs.semiBold,
+                    singleLine = true,
+                    maxLines = 1,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = {
+                        focusManager.clearFocus()
+                        searching = filter.isNotBlank()
+                    }),
+                    cursorBrush = SolidColor(colorPalette().text),
+                    decorationBox = { innerTextField ->
+                        Box(
+                            contentAlignment = Alignment.CenterStart,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 10.dp)
+                        ) {
+                            IconButton(
+                                onClick = {},
+                                icon = R.drawable.search,
+                                color = colorPalette().favoritesIcon,
+                                modifier = Modifier
+                                    .align(Alignment.CenterStart)
+                                    .size(16.dp)
+                            )
+                        }
+                        Box(
+                            contentAlignment = Alignment.CenterStart,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 30.dp)
+                        ) {
+                            androidx.compose.animation.AnimatedVisibility(
+                                visible = filter.isBlank(),
+                                enter = fadeIn(tween(100)),
+                                exit = fadeOut(tween(100)),
+                            ) {
+                                BasicText(
+                                    text = stringResource(R.string.search),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    style = typography().xs.semiBold.secondary.copy(
+                                        color = colorPalette().textDisabled
+                                    )
+                                )
+                            }
+
+                            innerTextField()
+                        }
+                    },
+                    modifier = Modifier
+                        .height(30.dp)
+                        .fillMaxWidth()
+                        .background(
+                            colorPalette().background4,
+                            shape = thumbnailRoundness.shape()
+                        )
+                        .focusRequester(focusRequester)
+                )
+            }
 
             LazyVerticalGrid(
                 state = lazyGridState,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -14,10 +14,8 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -50,7 +48,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
@@ -85,9 +82,7 @@ import it.fast4x.rimusic.transaction
 import it.fast4x.rimusic.ui.components.ButtonsRow
 import it.fast4x.rimusic.ui.components.LocalMenuState
 import it.fast4x.rimusic.ui.components.themed.FloatingActionsContainerWithScrollToTop
-import it.fast4x.rimusic.ui.components.themed.HeaderIconButton
 import it.fast4x.rimusic.ui.components.themed.HeaderInfo
-import it.fast4x.rimusic.ui.components.themed.HeaderWithIcon
 import it.fast4x.rimusic.ui.components.themed.IconButton
 import it.fast4x.rimusic.ui.components.themed.InputTextDialog
 import it.fast4x.rimusic.ui.components.themed.Menu
@@ -95,7 +90,6 @@ import it.fast4x.rimusic.ui.components.themed.MenuEntry
 import it.fast4x.rimusic.ui.components.themed.MultiFloatingActionsContainer
 import it.fast4x.rimusic.ui.components.themed.SmartMessage
 import it.fast4x.rimusic.ui.components.themed.SortMenu
-import it.fast4x.rimusic.ui.components.themed.TitleSection
 import it.fast4x.rimusic.ui.items.PlaylistItem
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.favoritesIcon
@@ -104,7 +98,6 @@ import it.fast4x.rimusic.utils.CheckMonthlyPlaylist
 import it.fast4x.rimusic.utils.ImportPipedPlaylists
 import it.fast4x.rimusic.utils.PlayShuffledSongs
 import it.fast4x.rimusic.utils.autosyncKey
-import it.fast4x.rimusic.utils.bold
 import it.fast4x.rimusic.utils.createPipedPlaylist
 import it.fast4x.rimusic.utils.enableCreateMonthlyPlaylistsKey
 import it.fast4x.rimusic.utils.getPipedSession
@@ -128,6 +121,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
+import me.knighthat.component.header.TabToolBar
 import me.knighthat.component.tab.TabHeader
 import me.knighthat.typography
 import timber.log.Timber
@@ -364,215 +358,171 @@ fun HomeLibraryModern(
                         .fillMaxWidth()
                 ) {
 
-                    HeaderIconButton(
-                        icon = R.drawable.arrow_up,
-                        color = colorPalette().text,
-                        onClick = {},
-                        modifier = Modifier
-                            .padding(horizontal = 4.dp)
-                            .graphicsLayer { rotationZ = sortOrderIconRotation }
-                            .combinedClickable(
-                                onClick = { sortOrder = !sortOrder },
-                                onLongClick = {
-                                    menuState.display {
-                                        SortMenu(
-                                            title = stringResource(R.string.sorting_order),
-                                            onDismiss = menuState::hide,
-                                            onName = { sortBy = PlaylistSortBy.Name },
-                                            onSongNumber = {
-                                                sortBy = PlaylistSortBy.SongCount
-                                            },
-                                            onDateAdded = { sortBy = PlaylistSortBy.DateAdded },
-                                            onPlayTime = { sortBy = PlaylistSortBy.MostPlayed },
-                                        )
-                                    }
-                                }
-                            )
-                    )
-
-                    HeaderIconButton(
-                        onClick = {},
-                        icon = R.drawable.sync,
-                        color = if (autosync) colorPalette().text else colorPalette().textDisabled,
-                        iconSize = 22.dp,
-                        modifier = Modifier
-                            .padding(horizontal = 2.dp)
-                            .combinedClickable(onClick = { autosync = !autosync },
-                                onLongClick = {
-                                    SmartMessage(
-                                        context.resources.getString(R.string.autosync),
-                                        context = context
-                                    )
-                                }
-                            )
-                    )
-
-                    HeaderIconButton(
-                        onClick = {
-                            searching = !searching
-                            isSearchInputFocused = searching
-                        },
-                        icon = R.drawable.search_circle,
-                        color = colorPalette().text,
-                        iconSize = 24.dp,
-                        modifier = Modifier
-                            .padding(horizontal = 4.dp)
-                    )
-                    HeaderIconButton(
-                        icon = R.drawable.shuffle,
-                        color = colorPalette().text,
-                        iconSize = 24.dp,
-                        onClick = {},
-                        modifier = Modifier
-                            .padding(horizontal = 4.dp)
-                            .combinedClickable(
-                                onClick = {
-                                    coroutineScope.launch {
-                                        withContext(Dispatchers.IO) {
-                                            when (playlistType) {
-                                                PlaylistsType.Playlist -> {
-                                                    Database.songsInAllPlaylists()
-                                                        .collect {
-                                                            PlayShuffledSongs(
-                                                                songsList = it,
-                                                                binder = binder,
-                                                                context = context
-                                                            )
-                                                        }
-                                                }
-
-                                                PlaylistsType.PipedPlaylist -> {
-                                                    Database.songsInAllPipedPlaylists()
-                                                        .collect {
-                                                            PlayShuffledSongs(
-                                                                songsList = it,
-                                                                binder = binder,
-                                                                context = context
-                                                            )
-                                                        }
-                                                }
-
-                                                PlaylistsType.PinnedPlaylist -> {
-                                                    Database.songsInAllPinnedPlaylists()
-                                                        .collect {
-                                                            PlayShuffledSongs(
-                                                                songsList = it,
-                                                                binder = binder,
-                                                                context = context
-                                                            )
-                                                        }
-                                                }
-
-                                                PlaylistsType.MonthlyPlaylist -> {
-                                                    Database.songsInAllMonthlyPlaylists()
-                                                        .collect {
-                                                            PlayShuffledSongs(
-                                                                songsList = it,
-                                                                binder = binder,
-                                                                context = context
-                                                            )
-                                                        }
-                                                }
-                                            }
-
-                                        }
-                                    }
-
-                                },
-                                onLongClick = {
-                                    SmartMessage(
-                                        context.resources.getString(R.string.shuffle),
-                                        context = context
-                                    )
-                                }
-                            )
-                    )
-                    HeaderIconButton(
-                        icon = R.drawable.add_in_playlist,
-                        color = colorPalette().text,
-                        iconSize = 24.dp,
-                        onClick = { },
-                        modifier = Modifier
-                            .padding(horizontal = 4.dp)
-                            .combinedClickable(
-                                onClick = { isCreatingANewPlaylist = true },
-                                onLongClick = {
-                                    SmartMessage(
-                                        context.resources.getString(R.string.create_new_playlist),
-                                        context = context
-                                    )
-                                }
-                            )
-                    )
-                    HeaderIconButton(
-                        icon = R.drawable.resource_import,
-                        color = colorPalette().text,
-                        iconSize = 22.dp,
-                        onClick = {},
-                        modifier = Modifier
-                            .padding(horizontal = 4.dp)
-                            .combinedClickable(
-                                onClick = {
-                                    try {
-                                        importLauncher.launch(
-                                            arrayOf(
-                                                "text/*"
-                                            )
-                                        )
-                                    } catch (e: ActivityNotFoundException) {
-                                        SmartMessage(
-                                            context.resources.getString(R.string.info_not_find_app_open_doc),
-                                            type = PopupType.Warning, context = context
-                                        )
-                                    }
-                                },
-                                onLongClick = {
-                                    SmartMessage(
-                                        context.resources.getString(R.string.import_playlist),
-                                        context = context
-                                    )
-                                }
-                            )
-                    )
-
-                    HeaderIconButton(
-                        onClick = {
+                    TabToolBar.Icon(
+                        iconId = R.drawable.arrow_up,
+                        onShortClick = { sortOrder = !sortOrder },
+                        onLongClick = {
                             menuState.display {
-                                Menu {
-                                    MenuEntry(
-                                        icon = R.drawable.arrow_forward,
-                                        text = stringResource(R.string.small),
-                                        onClick = {
-                                            itemSize = LibraryItemSize.Small.size
-                                            menuState.hide()
+                                SortMenu(
+                                    title = stringResource(R.string.sorting_order),
+                                    onDismiss = menuState::hide,
+                                    onName = { sortBy = PlaylistSortBy.Name },
+                                    onSongNumber = {
+                                        sortBy = PlaylistSortBy.SongCount
+                                    },
+                                    onDateAdded = { sortBy = PlaylistSortBy.DateAdded },
+                                    onPlayTime = { sortBy = PlaylistSortBy.MostPlayed },
+                                )
+                            }
+                        }
+                    )
+
+                    TabToolBar.Icon(
+                        iconId = R.drawable.sync,
+                        tint = if (autosync) colorPalette().text else colorPalette().textDisabled,
+                        onShortClick = { autosync = !autosync },
+                        onLongClick = {
+                            SmartMessage(
+                                context.resources.getString(R.string.autosync),
+                                context = context
+                            )
+                        }
+                    )
+
+                    TabToolBar.Icon( iconId  = R.drawable.search_circle ) {
+                        searching = !searching
+                        isSearchInputFocused = searching
+                    }
+
+                    TabToolBar.Icon(
+                        iconId = R.drawable.shuffle,
+                        onLongClick = {
+                            SmartMessage(
+                                context.resources.getString(R.string.shuffle),
+                                context = context
+                            )
+                        },
+                        onShortClick = {
+                            coroutineScope.launch {
+                                withContext(Dispatchers.IO) {
+                                    when (playlistType) {
+                                        PlaylistsType.Playlist -> {
+                                            Database.songsInAllPlaylists()
+                                                .collect {
+                                                    PlayShuffledSongs(
+                                                        songsList = it,
+                                                        binder = binder,
+                                                        context = context
+                                                    )
+                                                }
                                         }
-                                    )
-                                    MenuEntry(
-                                        icon = R.drawable.arrow_forward,
-                                        text = stringResource(R.string.medium),
-                                        onClick = {
-                                            itemSize = LibraryItemSize.Medium.size
-                                            menuState.hide()
+
+                                        PlaylistsType.PipedPlaylist -> {
+                                            Database.songsInAllPipedPlaylists()
+                                                .collect {
+                                                    PlayShuffledSongs(
+                                                        songsList = it,
+                                                        binder = binder,
+                                                        context = context
+                                                    )
+                                                }
                                         }
-                                    )
-                                    MenuEntry(
-                                        icon = R.drawable.arrow_forward,
-                                        text = stringResource(R.string.big),
-                                        onClick = {
-                                            itemSize = LibraryItemSize.Big.size
-                                            menuState.hide()
+
+                                        PlaylistsType.PinnedPlaylist -> {
+                                            Database.songsInAllPinnedPlaylists()
+                                                .collect {
+                                                    PlayShuffledSongs(
+                                                        songsList = it,
+                                                        binder = binder,
+                                                        context = context
+                                                    )
+                                                }
                                         }
-                                    )
+
+                                        PlaylistsType.MonthlyPlaylist -> {
+                                            Database.songsInAllMonthlyPlaylists()
+                                                .collect {
+                                                    PlayShuffledSongs(
+                                                        songsList = it,
+                                                        binder = binder,
+                                                        context = context
+                                                    )
+                                                }
+                                        }
+                                    }
+
                                 }
                             }
-                        },
-                        icon = R.drawable.resize,
-                        color = colorPalette().text,
-                        iconSize = 22.dp,
-                        modifier = Modifier
-                            .padding(horizontal = 4.dp)
+
+                        }
                     )
 
+                    TabToolBar.Icon(
+                        iconId =  R.drawable.add_in_playlist,
+                        onShortClick = { isCreatingANewPlaylist = true },
+                        onLongClick = {
+                            SmartMessage(
+                                context.resources.getString(R.string.create_new_playlist),
+                                context = context
+                            )
+                        }
+                    )
+
+                    TabToolBar.Icon(
+                        iconId = R.drawable.resource_import,
+                        size = 30.dp,
+                        onShortClick = {
+                            try {
+                                importLauncher.launch(
+                                    arrayOf(
+                                        "text/*"
+                                    )
+                                )
+                            } catch (e: ActivityNotFoundException) {
+                                SmartMessage(
+                                    context.resources.getString(R.string.info_not_find_app_open_doc),
+                                    type = PopupType.Warning, context = context
+                                )
+                            }
+                        },
+                        onLongClick = {
+                            SmartMessage(
+                                context.resources.getString(R.string.import_playlist),
+                                context = context
+                            )
+                        }
+                    )
+
+                    TabToolBar.Icon( R.drawable.resize ) {
+                        menuState.display {
+                            Menu {
+                                MenuEntry(
+                                    icon = R.drawable.arrow_forward,
+                                    text = stringResource(R.string.small),
+                                    onClick = {
+                                        itemSize = LibraryItemSize.Small.size
+                                        menuState.hide()
+                                    }
+                                )
+                                MenuEntry(
+                                    icon = R.drawable.arrow_forward,
+                                    text = stringResource(R.string.medium),
+                                    onClick = {
+                                        itemSize = LibraryItemSize.Medium.size
+                                        menuState.hide()
+                                    }
+                                )
+                                MenuEntry(
+                                    icon = R.drawable.arrow_forward,
+                                    text = stringResource(R.string.big),
+                                    onClick = {
+                                        itemSize = LibraryItemSize.Big.size
+                                        menuState.hide()
+                                    }
+                                )
+                            }
+                        }
+                    }
                 }
             }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -330,421 +331,408 @@ fun HomeLibraryModern(
                 else Dimensions.contentWidthRightBar
             )
     ) {
-        TabHeader( R.string.playlists ) {
-            HeaderInfo( items.size.toString(), R.drawable.playlist )
-        }
+        Column( Modifier.fillMaxSize() ) {
+            // Sticky tab's title
+            TabHeader( R.string.playlists ) {
+                HeaderInfo( items.size.toString(), R.drawable.playlist )
+            }
 
-        LazyVerticalGrid(
-            state = lazyGridState,
-            columns = GridCells.Adaptive(itemSize.dp + 24.dp),
-            modifier = Modifier
-                .padding( top = TabHeader.height() )
-                .align(Alignment.BottomStart)
-                .background(colorPalette().background0)
-
-        ) {
-            item(
-                key = "headerButtons",
-                contentType = 0,
-                span = { GridItemSpan(maxLineSpan) }
+            // Sticky tab's tool bar
+            Row(
+                horizontalArrangement = Arrangement.SpaceAround,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .padding(vertical = 4.dp)
+                    .fillMaxWidth()
             ) {
-
-                Row(
-                    horizontalArrangement = Arrangement.SpaceAround,
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .padding(horizontal = 12.dp)
-                        .padding(vertical = 4.dp)
-                        .fillMaxWidth()
-                ) {
-
-                    TabToolBar.Icon(
-                        iconId = R.drawable.arrow_up,
-                        onShortClick = { sortOrder = !sortOrder },
-                        onLongClick = {
-                            menuState.display {
-                                SortMenu(
-                                    title = stringResource(R.string.sorting_order),
-                                    onDismiss = menuState::hide,
-                                    onName = { sortBy = PlaylistSortBy.Name },
-                                    onSongNumber = {
-                                        sortBy = PlaylistSortBy.SongCount
-                                    },
-                                    onDateAdded = { sortBy = PlaylistSortBy.DateAdded },
-                                    onPlayTime = { sortBy = PlaylistSortBy.MostPlayed },
-                                )
-                            }
-                        }
-                    )
-
-                    TabToolBar.Icon(
-                        iconId = R.drawable.sync,
-                        tint = if (autosync) colorPalette().text else colorPalette().textDisabled,
-                        onShortClick = { autosync = !autosync },
-                        onLongClick = {
-                            SmartMessage(
-                                context.resources.getString(R.string.autosync),
-                                context = context
-                            )
-                        }
-                    )
-
-                    TabToolBar.Icon( iconId  = R.drawable.search_circle ) {
-                        searching = !searching
-                        isSearchInputFocused = searching
-                    }
-
-                    TabToolBar.Icon(
-                        iconId = R.drawable.shuffle,
-                        onLongClick = {
-                            SmartMessage(
-                                context.resources.getString(R.string.shuffle),
-                                context = context
-                            )
-                        },
-                        onShortClick = {
-                            coroutineScope.launch {
-                                withContext(Dispatchers.IO) {
-                                    when (playlistType) {
-                                        PlaylistsType.Playlist -> {
-                                            Database.songsInAllPlaylists()
-                                                .collect {
-                                                    PlayShuffledSongs(
-                                                        songsList = it,
-                                                        binder = binder,
-                                                        context = context
-                                                    )
-                                                }
-                                        }
-
-                                        PlaylistsType.PipedPlaylist -> {
-                                            Database.songsInAllPipedPlaylists()
-                                                .collect {
-                                                    PlayShuffledSongs(
-                                                        songsList = it,
-                                                        binder = binder,
-                                                        context = context
-                                                    )
-                                                }
-                                        }
-
-                                        PlaylistsType.PinnedPlaylist -> {
-                                            Database.songsInAllPinnedPlaylists()
-                                                .collect {
-                                                    PlayShuffledSongs(
-                                                        songsList = it,
-                                                        binder = binder,
-                                                        context = context
-                                                    )
-                                                }
-                                        }
-
-                                        PlaylistsType.MonthlyPlaylist -> {
-                                            Database.songsInAllMonthlyPlaylists()
-                                                .collect {
-                                                    PlayShuffledSongs(
-                                                        songsList = it,
-                                                        binder = binder,
-                                                        context = context
-                                                    )
-                                                }
-                                        }
-                                    }
-
-                                }
-                            }
-
-                        }
-                    )
-
-                    TabToolBar.Icon(
-                        iconId =  R.drawable.add_in_playlist,
-                        onShortClick = { isCreatingANewPlaylist = true },
-                        onLongClick = {
-                            SmartMessage(
-                                context.resources.getString(R.string.create_new_playlist),
-                                context = context
-                            )
-                        }
-                    )
-
-                    TabToolBar.Icon(
-                        iconId = R.drawable.resource_import,
-                        size = 30.dp,
-                        onShortClick = {
-                            try {
-                                importLauncher.launch(
-                                    arrayOf(
-                                        "text/*"
-                                    )
-                                )
-                            } catch (e: ActivityNotFoundException) {
-                                SmartMessage(
-                                    context.resources.getString(R.string.info_not_find_app_open_doc),
-                                    type = PopupType.Warning, context = context
-                                )
-                            }
-                        },
-                        onLongClick = {
-                            SmartMessage(
-                                context.resources.getString(R.string.import_playlist),
-                                context = context
-                            )
-                        }
-                    )
-
-                    TabToolBar.Icon( R.drawable.resize ) {
+                TabToolBar.Icon(
+                    iconId = R.drawable.arrow_up,
+                    onShortClick = { sortOrder = !sortOrder },
+                    onLongClick = {
                         menuState.display {
-                            Menu {
-                                MenuEntry(
-                                    icon = R.drawable.arrow_forward,
-                                    text = stringResource(R.string.small),
-                                    onClick = {
-                                        itemSize = LibraryItemSize.Small.size
-                                        menuState.hide()
+                            SortMenu(
+                                title = stringResource(R.string.sorting_order),
+                                onDismiss = menuState::hide,
+                                onName = { sortBy = PlaylistSortBy.Name },
+                                onSongNumber = {
+                                    sortBy = PlaylistSortBy.SongCount
+                                },
+                                onDateAdded = { sortBy = PlaylistSortBy.DateAdded },
+                                onPlayTime = { sortBy = PlaylistSortBy.MostPlayed },
+                            )
+                        }
+                    }
+                )
+
+                TabToolBar.Icon(
+                    iconId = R.drawable.sync,
+                    tint = if (autosync) colorPalette().text else colorPalette().textDisabled,
+                    onShortClick = { autosync = !autosync },
+                    onLongClick = {
+                        SmartMessage(
+                            context.resources.getString(R.string.autosync),
+                            context = context
+                        )
+                    }
+                )
+
+                TabToolBar.Icon( iconId  = R.drawable.search_circle ) {
+                    searching = !searching
+                    isSearchInputFocused = searching
+                }
+
+                TabToolBar.Icon(
+                    iconId = R.drawable.shuffle,
+                    onLongClick = {
+                        SmartMessage(
+                            context.resources.getString(R.string.shuffle),
+                            context = context
+                        )
+                    },
+                    onShortClick = {
+                        coroutineScope.launch {
+                            withContext(Dispatchers.IO) {
+                                when (playlistType) {
+                                    PlaylistsType.Playlist -> {
+                                        Database.songsInAllPlaylists()
+                                            .collect {
+                                                PlayShuffledSongs(
+                                                    songsList = it,
+                                                    binder = binder,
+                                                    context = context
+                                                )
+                                            }
                                     }
-                                )
-                                MenuEntry(
-                                    icon = R.drawable.arrow_forward,
-                                    text = stringResource(R.string.medium),
-                                    onClick = {
-                                        itemSize = LibraryItemSize.Medium.size
-                                        menuState.hide()
+
+                                    PlaylistsType.PipedPlaylist -> {
+                                        Database.songsInAllPipedPlaylists()
+                                            .collect {
+                                                PlayShuffledSongs(
+                                                    songsList = it,
+                                                    binder = binder,
+                                                    context = context
+                                                )
+                                            }
                                     }
-                                )
-                                MenuEntry(
-                                    icon = R.drawable.arrow_forward,
-                                    text = stringResource(R.string.big),
-                                    onClick = {
-                                        itemSize = LibraryItemSize.Big.size
-                                        menuState.hide()
+
+                                    PlaylistsType.PinnedPlaylist -> {
+                                        Database.songsInAllPinnedPlaylists()
+                                            .collect {
+                                                PlayShuffledSongs(
+                                                    songsList = it,
+                                                    binder = binder,
+                                                    context = context
+                                                )
+                                            }
                                     }
-                                )
+
+                                    PlaylistsType.MonthlyPlaylist -> {
+                                        Database.songsInAllMonthlyPlaylists()
+                                            .collect {
+                                                PlayShuffledSongs(
+                                                    songsList = it,
+                                                    binder = binder,
+                                                    context = context
+                                                )
+                                            }
+                                    }
+                                }
+
                             }
+                        }
+
+                    }
+                )
+
+                TabToolBar.Icon(
+                    iconId =  R.drawable.add_in_playlist,
+                    onShortClick = { isCreatingANewPlaylist = true },
+                    onLongClick = {
+                        SmartMessage(
+                            context.resources.getString(R.string.create_new_playlist),
+                            context = context
+                        )
+                    }
+                )
+
+                TabToolBar.Icon(
+                    iconId = R.drawable.resource_import,
+                    size = 30.dp,
+                    onShortClick = {
+                        try {
+                            importLauncher.launch(
+                                arrayOf(
+                                    "text/*"
+                                )
+                            )
+                        } catch (e: ActivityNotFoundException) {
+                            SmartMessage(
+                                context.resources.getString(R.string.info_not_find_app_open_doc),
+                                type = PopupType.Warning, context = context
+                            )
+                        }
+                    },
+                    onLongClick = {
+                        SmartMessage(
+                            context.resources.getString(R.string.import_playlist),
+                            context = context
+                        )
+                    }
+                )
+
+                TabToolBar.Icon( R.drawable.resize ) {
+                    menuState.display {
+                        Menu {
+                            MenuEntry(
+                                icon = R.drawable.arrow_forward,
+                                text = stringResource(R.string.small),
+                                onClick = {
+                                    itemSize = LibraryItemSize.Small.size
+                                    menuState.hide()
+                                }
+                            )
+                            MenuEntry(
+                                icon = R.drawable.arrow_forward,
+                                text = stringResource(R.string.medium),
+                                onClick = {
+                                    itemSize = LibraryItemSize.Medium.size
+                                    menuState.hide()
+                                }
+                            )
+                            MenuEntry(
+                                icon = R.drawable.arrow_forward,
+                                text = stringResource(R.string.big),
+                                onClick = {
+                                    itemSize = LibraryItemSize.Big.size
+                                    menuState.hide()
+                                }
+                            )
                         }
                     }
                 }
             }
 
+            // Sticky search bar
             if (searching)
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalAlignment = Alignment.Bottom,
+                    modifier = Modifier
+                        //.requiredHeight(30.dp)
+                        .padding(all = 10.dp)
+                        .fillMaxWidth()
+                ) {
+                    AnimatedVisibility(visible = searching) {
+                        val focusRequester = remember { FocusRequester() }
+                        val focusManager = LocalFocusManager.current
+
+                        LaunchedEffect(searching) {
+                            if (isSearchInputFocused) focusRequester.requestFocus()
+                        }
+
+                        var searchInput by remember { mutableStateOf(TextFieldValue(filter)) }
+                        BasicTextField(
+                            value = searchInput,
+                            onValueChange = {
+                                searchInput = it.copy(
+                                    selection = TextRange(it.text.length)
+                                )
+                                filter = it.text
+                            },
+                            textStyle = typography().xs.semiBold,
+                            singleLine = true,
+                            maxLines = 1,
+                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                            keyboardActions = KeyboardActions(onDone = {
+                                focusManager.clearFocus()
+                                searching = filter.isNotBlank()
+                            }),
+                            cursorBrush = SolidColor(colorPalette().text),
+                            decorationBox = { innerTextField ->
+                                Box(
+                                    contentAlignment = Alignment.CenterStart,
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(horizontal = 10.dp)
+                                ) {
+                                    IconButton(
+                                        onClick = {},
+                                        icon = R.drawable.search,
+                                        color = colorPalette().favoritesIcon,
+                                        modifier = Modifier
+                                            .align(Alignment.CenterStart)
+                                            .size(16.dp)
+                                    )
+                                }
+                                Box(
+                                    contentAlignment = Alignment.CenterStart,
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(horizontal = 30.dp)
+                                ) {
+                                    androidx.compose.animation.AnimatedVisibility(
+                                        visible = filter.isBlank(),
+                                        enter = fadeIn(tween(100)),
+                                        exit = fadeOut(tween(100)),
+                                    ) {
+                                        BasicText(
+                                            text = stringResource(R.string.search),
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                            style = typography().xs.semiBold.secondary.copy(
+                                                color = colorPalette().textDisabled
+                                            )
+                                        )
+                                    }
+
+                                    innerTextField()
+                                }
+                            },
+                            modifier = Modifier
+                                .height(30.dp)
+                                .fillMaxWidth()
+                                .background(
+                                    colorPalette().background4,
+                                    shape = thumbnailRoundness.shape()
+                                )
+                                .focusRequester(focusRequester)
+                        )
+                    }
+                }
+
+            LazyVerticalGrid(
+                state = lazyGridState,
+                columns = GridCells.Adaptive(itemSize.dp + 24.dp),
+                modifier = Modifier
+                    .background(colorPalette().background0)
+            ) {
                 item(
-                    key = "headerFilter",
+                    key = "separator",
+                    contentType = 0,
+                    span = { GridItemSpan(maxLineSpan) }) {
+                    ButtonsRow(
+                        chips = buttonsList,
+                        currentValue = playlistType,
+                        onValueUpdate = { playlistType = it },
+                        modifier = Modifier.padding(end = 12.dp)
+                    )
+                }
+
+                if (playlistType == PlaylistsType.Playlist) {
+                    items(items = items,
+                        /*
+                        .filter {
+                        !it.playlist.name.startsWith(PINNED_PREFIX, 0, true) &&
+                                !it.playlist.name.startsWith(MONTHLY_PREFIX, 0, true)
+                        }
+
+                         */
+                        key = { it.playlist.id }) { playlistPreview ->
+
+                        PlaylistItem(
+                            playlist = playlistPreview,
+                            thumbnailSizeDp = thumbnailSizeDp,
+                            thumbnailSizePx = thumbnailSizePx,
+                            alternative = true,
+                            modifier = Modifier
+                                .clickable(onClick = {
+                                    onPlaylistClick(playlistPreview.playlist)
+
+                                    if (searching)
+                                        if (filter.isBlank())
+                                            searching = false
+                                        else
+                                            isSearchInputFocused = false
+                                })
+                                .animateItem(fadeInSpec = null, fadeOutSpec = null)
+                                .fillMaxSize()
+                        )
+                    }
+                }
+
+                if (playlistType == PlaylistsType.PipedPlaylist)
+                    items(items = items.filter {
+                        it.playlist.name.startsWith(PIPED_PREFIX, 0, true)
+                    }, key = { it.playlist.id }) { playlistPreview ->
+                        PlaylistItem(
+                            playlist = playlistPreview,
+                            thumbnailSizeDp = thumbnailSizeDp,
+                            thumbnailSizePx = thumbnailSizePx,
+                            alternative = true,
+                            modifier = Modifier
+                                .clickable(onClick = {
+                                    onPlaylistClick(playlistPreview.playlist)
+
+                                    if (searching)
+                                        if (filter.isBlank())
+                                            searching = false
+                                        else
+                                            isSearchInputFocused = false
+                                })
+                                .animateItem(fadeInSpec = null, fadeOutSpec = null)
+                                .fillMaxSize()
+                        )
+                    }
+
+                if (playlistType == PlaylistsType.PinnedPlaylist)
+                    items(items = items.filter {
+                        it.playlist.name.startsWith(PINNED_PREFIX, 0, true)
+                    }, key = { it.playlist.id }) { playlistPreview ->
+                        PlaylistItem(
+                            playlist = playlistPreview,
+                            thumbnailSizeDp = thumbnailSizeDp,
+                            thumbnailSizePx = thumbnailSizePx,
+                            alternative = true,
+                            modifier = Modifier
+                                .clickable(onClick = {
+                                    onPlaylistClick(playlistPreview.playlist)
+
+                                    if (searching)
+                                        if (filter.isBlank())
+                                            searching = false
+                                        else
+                                            isSearchInputFocused = false
+                                })
+                                .animateItem(fadeInSpec = null, fadeOutSpec = null)
+                                .fillMaxSize()
+                        )
+                    }
+
+                if (playlistType == PlaylistsType.MonthlyPlaylist)
+                    items(items = items.filter {
+                        it.playlist.name.startsWith(MONTHLY_PREFIX, 0, true)
+                    }, key = { it.playlist.id }) { playlistPreview ->
+                        PlaylistItem(
+                            playlist = playlistPreview,
+                            thumbnailSizeDp = thumbnailSizeDp,
+                            thumbnailSizePx = thumbnailSizePx,
+                            alternative = true,
+                            modifier = Modifier
+                                .clickable(onClick = {
+                                    onPlaylistClick(playlistPreview.playlist)
+
+                                    if (searching)
+                                        if (filter.isBlank())
+                                            searching = false
+                                        else
+                                            isSearchInputFocused = false
+                                })
+                                .animateItem(fadeInSpec = null, fadeOutSpec = null)
+                                .fillMaxSize()
+                        )
+                    }
+
+
+                item(
+                    key = "footer",
                     contentType = 0,
                     span = { GridItemSpan(maxLineSpan) }
                 ) {
-                    /*        */
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(10.dp),
-                        verticalAlignment = Alignment.Bottom,
-                        modifier = Modifier
-                            //.requiredHeight(30.dp)
-                            .padding(all = 10.dp)
-                            .fillMaxWidth()
-                    ) {
-                        AnimatedVisibility(visible = searching) {
-                            val focusRequester = remember { FocusRequester() }
-                            val focusManager = LocalFocusManager.current
-
-                            LaunchedEffect(searching) {
-                                if (isSearchInputFocused) focusRequester.requestFocus()
-                            }
-
-                            var searchInput by remember { mutableStateOf(TextFieldValue(filter)) }
-                            BasicTextField(
-                                value = searchInput,
-                                onValueChange = {
-                                    searchInput = it.copy(
-                                        selection = TextRange(it.text.length)
-                                    )
-                                    filter = it.text
-                                },
-                                textStyle = typography().xs.semiBold,
-                                singleLine = true,
-                                maxLines = 1,
-                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                keyboardActions = KeyboardActions(onDone = {
-                                    focusManager.clearFocus()
-                                    searching = filter.isNotBlank()
-                                }),
-                                cursorBrush = SolidColor(colorPalette().text),
-                                decorationBox = { innerTextField ->
-                                    Box(
-                                        contentAlignment = Alignment.CenterStart,
-                                        modifier = Modifier
-                                            .weight(1f)
-                                            .padding(horizontal = 10.dp)
-                                    ) {
-                                        IconButton(
-                                            onClick = {},
-                                            icon = R.drawable.search,
-                                            color = colorPalette().favoritesIcon,
-                                            modifier = Modifier
-                                                .align(Alignment.CenterStart)
-                                                .size(16.dp)
-                                        )
-                                    }
-                                    Box(
-                                        contentAlignment = Alignment.CenterStart,
-                                        modifier = Modifier
-                                            .weight(1f)
-                                            .padding(horizontal = 30.dp)
-                                    ) {
-                                        androidx.compose.animation.AnimatedVisibility(
-                                            visible = filter.isBlank(),
-                                            enter = fadeIn(tween(100)),
-                                            exit = fadeOut(tween(100)),
-                                        ) {
-                                            BasicText(
-                                                text = stringResource(R.string.search),
-                                                maxLines = 1,
-                                                overflow = TextOverflow.Ellipsis,
-                                                style = typography().xs.semiBold.secondary.copy(
-                                                    color = colorPalette().textDisabled
-                                                )
-                                            )
-                                        }
-
-                                        innerTextField()
-                                    }
-                                },
-                                modifier = Modifier
-                                    .height(30.dp)
-                                    .fillMaxWidth()
-                                    .background(
-                                        colorPalette().background4,
-                                        shape = thumbnailRoundness.shape()
-                                    )
-                                    .focusRequester(focusRequester)
-                            )
-                        }
-                    }
+                    Spacer(modifier = Modifier.height(Dimensions.bottomSpacer))
                 }
 
-            item(
-                key = "separator",
-                contentType = 0,
-                span = { GridItemSpan(maxLineSpan) }) {
-                ButtonsRow(
-                    chips = buttonsList,
-                    currentValue = playlistType,
-                    onValueUpdate = { playlistType = it },
-                    modifier = Modifier.padding(end = 12.dp)
-                )
             }
-
-            if (playlistType == PlaylistsType.Playlist) {
-                items(items = items,
-                    /*
-                    .filter {
-                    !it.playlist.name.startsWith(PINNED_PREFIX, 0, true) &&
-                            !it.playlist.name.startsWith(MONTHLY_PREFIX, 0, true)
-                    }
-
-                     */
-                    key = { it.playlist.id }) { playlistPreview ->
-
-                    PlaylistItem(
-                        playlist = playlistPreview,
-                        thumbnailSizeDp = thumbnailSizeDp,
-                        thumbnailSizePx = thumbnailSizePx,
-                        alternative = true,
-                        modifier = Modifier
-                            .clickable(onClick = {
-                                onPlaylistClick(playlistPreview.playlist)
-
-                                if (searching)
-                                    if (filter.isBlank())
-                                        searching = false
-                                    else
-                                        isSearchInputFocused = false
-                            })
-                            .animateItem(fadeInSpec = null, fadeOutSpec = null)
-                            .fillMaxSize()
-                    )
-                }
-            }
-
-            if (playlistType == PlaylistsType.PipedPlaylist)
-                items(items = items.filter {
-                    it.playlist.name.startsWith(PIPED_PREFIX, 0, true)
-                }, key = { it.playlist.id }) { playlistPreview ->
-                    PlaylistItem(
-                        playlist = playlistPreview,
-                        thumbnailSizeDp = thumbnailSizeDp,
-                        thumbnailSizePx = thumbnailSizePx,
-                        alternative = true,
-                        modifier = Modifier
-                            .clickable(onClick = {
-                                onPlaylistClick(playlistPreview.playlist)
-
-                                if (searching)
-                                    if (filter.isBlank())
-                                        searching = false
-                                    else
-                                        isSearchInputFocused = false
-                            })
-                            .animateItem(fadeInSpec = null, fadeOutSpec = null)
-                            .fillMaxSize()
-                    )
-                }
-
-            if (playlistType == PlaylistsType.PinnedPlaylist)
-                items(items = items.filter {
-                    it.playlist.name.startsWith(PINNED_PREFIX, 0, true)
-                }, key = { it.playlist.id }) { playlistPreview ->
-                    PlaylistItem(
-                        playlist = playlistPreview,
-                        thumbnailSizeDp = thumbnailSizeDp,
-                        thumbnailSizePx = thumbnailSizePx,
-                        alternative = true,
-                        modifier = Modifier
-                            .clickable(onClick = {
-                                onPlaylistClick(playlistPreview.playlist)
-
-                                if (searching)
-                                    if (filter.isBlank())
-                                        searching = false
-                                    else
-                                        isSearchInputFocused = false
-                            })
-                            .animateItem(fadeInSpec = null, fadeOutSpec = null)
-                            .fillMaxSize()
-                    )
-                }
-
-            if (playlistType == PlaylistsType.MonthlyPlaylist)
-                items(items = items.filter {
-                    it.playlist.name.startsWith(MONTHLY_PREFIX, 0, true)
-                }, key = { it.playlist.id }) { playlistPreview ->
-                    PlaylistItem(
-                        playlist = playlistPreview,
-                        thumbnailSizeDp = thumbnailSizeDp,
-                        thumbnailSizePx = thumbnailSizePx,
-                        alternative = true,
-                        modifier = Modifier
-                            .clickable(onClick = {
-                                onPlaylistClick(playlistPreview.playlist)
-
-                                if (searching)
-                                    if (filter.isBlank())
-                                        searching = false
-                                    else
-                                        isSearchInputFocused = false
-                            })
-                            .animateItem(fadeInSpec = null, fadeOutSpec = null)
-                            .fillMaxSize()
-                    )
-                }
-
-
-            item(
-                key = "footer",
-                contentType = 0,
-                span = { GridItemSpan(maxLineSpan) }
-            ) {
-                Spacer(modifier = Modifier.height(Dimensions.bottomSpacer))
-            }
-
         }
 
         FloatingActionsContainerWithScrollToTop(lazyGridState = lazyGridState)
@@ -757,13 +745,5 @@ fun HomeLibraryModern(
                 onClickSettings = onSettingsClick,
                 onClickSearch = onSearchClick
             )
-
-        /*
-    FloatingActionsContainerWithScrollToTop(
-            lazyGridState = lazyGridState,
-            iconId = R.drawable.search,
-            onClick = onSearchClick
-        )
-         */
     }
 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -103,6 +104,7 @@ import it.fast4x.rimusic.utils.CheckMonthlyPlaylist
 import it.fast4x.rimusic.utils.ImportPipedPlaylists
 import it.fast4x.rimusic.utils.PlayShuffledSongs
 import it.fast4x.rimusic.utils.autosyncKey
+import it.fast4x.rimusic.utils.bold
 import it.fast4x.rimusic.utils.createPipedPlaylist
 import it.fast4x.rimusic.utils.enableCreateMonthlyPlaylistsKey
 import it.fast4x.rimusic.utils.getPipedSession
@@ -126,6 +128,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
+import me.knighthat.component.tab.TabHeader
 import me.knighthat.typography
 import timber.log.Timber
 
@@ -333,53 +336,19 @@ fun HomeLibraryModern(
                 else Dimensions.contentWidthRightBar
             )
     ) {
+        TabHeader( R.string.playlists ) {
+            HeaderInfo( items.size.toString(), R.drawable.playlist )
+        }
+
         LazyVerticalGrid(
             state = lazyGridState,
             columns = GridCells.Adaptive(itemSize.dp + 24.dp),
             modifier = Modifier
-                .fillMaxSize()
+                .padding( top = TabHeader.height() )
+                .align(Alignment.BottomStart)
                 .background(colorPalette().background0)
+
         ) {
-            item(key = "header", contentType = 0, span = { GridItemSpan(maxLineSpan) }) {
-
-                if ( UiType.ViMusic.isCurrent() )
-                    HeaderWithIcon(
-                        title = stringResource(R.string.playlists),
-                        iconId = R.drawable.search,
-                        enabled = true,
-                        showIcon = !showSearchTab,
-                        modifier = Modifier,
-                        onClick = onSearchClick
-                    )
-            }
-
-            item(key = "headerNew", contentType = 0, span = { GridItemSpan(maxLineSpan) }) {
-
-                Row(
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .padding(horizontal = 12.dp)
-                        .padding(top = 10.dp, bottom = 4.dp)
-                        .fillMaxWidth()
-
-                ) {
-                    if ( UiType.RiMusic.isCurrent() )
-                        TitleSection(title = stringResource(R.string.playlists))
-
-                    HeaderInfo(
-                        title = "${items.size}",
-                        iconId = R.drawable.playlist
-                    )
-                    Spacer(
-                        modifier = Modifier
-                            .weight(0.3f)
-                    )
-
-                }
-
-            }
-
             item(
                 key = "headerButtons",
                 contentType = 0,
@@ -456,26 +425,53 @@ fun HomeLibraryModern(
                         onClick = {},
                         modifier = Modifier
                             .padding(horizontal = 4.dp)
-                            .combinedClickable (
+                            .combinedClickable(
                                 onClick = {
                                     coroutineScope.launch {
                                         withContext(Dispatchers.IO) {
                                             when (playlistType) {
                                                 PlaylistsType.Playlist -> {
                                                     Database.songsInAllPlaylists()
-                                                        .collect { PlayShuffledSongs(songsList = it, binder = binder, context = context) }
+                                                        .collect {
+                                                            PlayShuffledSongs(
+                                                                songsList = it,
+                                                                binder = binder,
+                                                                context = context
+                                                            )
+                                                        }
                                                 }
+
                                                 PlaylistsType.PipedPlaylist -> {
                                                     Database.songsInAllPipedPlaylists()
-                                                        .collect { PlayShuffledSongs(songsList = it, binder = binder, context = context) }
+                                                        .collect {
+                                                            PlayShuffledSongs(
+                                                                songsList = it,
+                                                                binder = binder,
+                                                                context = context
+                                                            )
+                                                        }
                                                 }
+
                                                 PlaylistsType.PinnedPlaylist -> {
                                                     Database.songsInAllPinnedPlaylists()
-                                                        .collect { PlayShuffledSongs(songsList = it, binder = binder, context = context) }
+                                                        .collect {
+                                                            PlayShuffledSongs(
+                                                                songsList = it,
+                                                                binder = binder,
+                                                                context = context
+                                                            )
+                                                        }
                                                 }
+
                                                 PlaylistsType.MonthlyPlaylist -> {
                                                     Database.songsInAllMonthlyPlaylists()
-                                                        .collect { PlayShuffledSongs(songsList = it, binder = binder, context = context) }
+                                                        .collect {
+                                                            PlayShuffledSongs(
+                                                                songsList = it,
+                                                                binder = binder,
+                                                                context = context
+                                                            )
+                                                        }
                                                 }
                                             }
 
@@ -498,7 +494,7 @@ fun HomeLibraryModern(
                         onClick = { },
                         modifier = Modifier
                             .padding(horizontal = 4.dp)
-                            .combinedClickable (
+                            .combinedClickable(
                                 onClick = { isCreatingANewPlaylist = true },
                                 onLongClick = {
                                     SmartMessage(
@@ -600,15 +596,15 @@ fun HomeLibraryModern(
                             val focusManager = LocalFocusManager.current
 
                             LaunchedEffect(searching) {
-                                if( isSearchInputFocused ) focusRequester.requestFocus()
+                                if (isSearchInputFocused) focusRequester.requestFocus()
                             }
 
-                            var searchInput by remember { mutableStateOf( TextFieldValue( filter ) ) }
+                            var searchInput by remember { mutableStateOf(TextFieldValue(filter)) }
                             BasicTextField(
                                 value = searchInput,
                                 onValueChange = {
                                     searchInput = it.copy(
-                                        selection = TextRange( it.text.length )
+                                        selection = TextRange(it.text.length)
                                     )
                                     filter = it.text
                                 },
@@ -652,7 +648,9 @@ fun HomeLibraryModern(
                                                 text = stringResource(R.string.search),
                                                 maxLines = 1,
                                                 overflow = TextOverflow.Ellipsis,
-                                                style = typography().xs.semiBold.secondary.copy(color = colorPalette().textDisabled)
+                                                style = typography().xs.semiBold.secondary.copy(
+                                                    color = colorPalette().textDisabled
+                                                )
                                             )
                                         }
 
@@ -704,8 +702,8 @@ fun HomeLibraryModern(
                             .clickable(onClick = {
                                 onPlaylistClick(playlistPreview.playlist)
 
-                                if( searching )
-                                    if( filter.isBlank() )
+                                if (searching)
+                                    if (filter.isBlank())
                                         searching = false
                                     else
                                         isSearchInputFocused = false
@@ -729,8 +727,8 @@ fun HomeLibraryModern(
                             .clickable(onClick = {
                                 onPlaylistClick(playlistPreview.playlist)
 
-                                if( searching )
-                                    if( filter.isBlank() )
+                                if (searching)
+                                    if (filter.isBlank())
                                         searching = false
                                     else
                                         isSearchInputFocused = false
@@ -741,9 +739,9 @@ fun HomeLibraryModern(
                 }
 
             if (playlistType == PlaylistsType.PinnedPlaylist)
-                 items(items = items.filter {
-                     it.playlist.name.startsWith(PINNED_PREFIX, 0, true)
-                 }, key = { it.playlist.id }) { playlistPreview ->
+                items(items = items.filter {
+                    it.playlist.name.startsWith(PINNED_PREFIX, 0, true)
+                }, key = { it.playlist.id }) { playlistPreview ->
                     PlaylistItem(
                         playlist = playlistPreview,
                         thumbnailSizeDp = thumbnailSizeDp,
@@ -753,8 +751,8 @@ fun HomeLibraryModern(
                             .clickable(onClick = {
                                 onPlaylistClick(playlistPreview.playlist)
 
-                                if( searching )
-                                    if( filter.isBlank() )
+                                if (searching)
+                                    if (filter.isBlank())
                                         searching = false
                                     else
                                         isSearchInputFocused = false
@@ -777,8 +775,8 @@ fun HomeLibraryModern(
                             .clickable(onClick = {
                                 onPlaylistClick(playlistPreview.playlist)
 
-                                if( searching )
-                                    if( filter.isBlank() )
+                                if (searching)
+                                    if (filter.isBlank())
                                         searching = false
                                     else
                                         isSearchInputFocused = false
@@ -789,20 +787,20 @@ fun HomeLibraryModern(
                 }
 
 
-                item(
-                    key = "footer",
-                    contentType = 0,
-                    span = { GridItemSpan(maxLineSpan) }
-                ) {
-                    Spacer(modifier = Modifier.height(Dimensions.bottomSpacer))
-                }
+            item(
+                key = "footer",
+                contentType = 0,
+                span = { GridItemSpan(maxLineSpan) }
+            ) {
+                Spacer(modifier = Modifier.height(Dimensions.bottomSpacer))
+            }
 
         }
 
         FloatingActionsContainerWithScrollToTop(lazyGridState = lazyGridState)
 
         val showFloatingIcon by rememberPreference(showFloatingIconKey, false)
-        if( UiType.ViMusic.isCurrent() && showFloatingIcon )
+        if (UiType.ViMusic.isCurrent() && showFloatingIcon)
             MultiFloatingActionsContainer(
                 iconId = R.drawable.search,
                 onClick = onSearchClick,
@@ -817,7 +815,5 @@ fun HomeLibraryModern(
             onClick = onSearchClick
         )
          */
-
-
     }
 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -520,10 +520,10 @@ fun HomeLibraryModern(
                                    .fillMaxWidth()
             ) {
                 val focusRequester = remember { FocusRequester() }
-                val focusManager = LocalFocusManager.current
 
-                LaunchedEffect(searching) {
-                    if (isSearchInputFocused) focusRequester.requestFocus()
+                LaunchedEffect(searching, isSearchInputFocused) {
+                    if( searching && isSearchInputFocused )
+                        focusRequester.requestFocus()
                 }
 
                 var searchInput by remember { mutableStateOf(TextFieldValue(filter)) }
@@ -531,7 +531,7 @@ fun HomeLibraryModern(
                     value = searchInput,
                     onValueChange = {
                         searchInput = it.copy(
-                            selection = TextRange(it.text.length)
+                            selection = TextRange( it.text.length )
                         )
                         filter = it.text
                     },
@@ -540,8 +540,8 @@ fun HomeLibraryModern(
                     maxLines = 1,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = {
-                        focusManager.clearFocus()
                         searching = filter.isNotBlank()
+                        isSearchInputFocused = filter.isNotBlank()
                     }),
                     cursorBrush = SolidColor(colorPalette().text),
                     decorationBox = { innerTextField ->

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
@@ -348,6 +349,7 @@ fun HomeLibraryModern(
             ) {
                 TabToolBar.Icon(
                     iconId = R.drawable.arrow_up,
+                    modifier = Modifier.graphicsLayer { rotationZ = sortOrderIconRotation },
                     onShortClick = { sortOrder = !sortOrder },
                     onLongClick = {
                         menuState.display {
@@ -355,9 +357,7 @@ fun HomeLibraryModern(
                                 title = stringResource(R.string.sorting_order),
                                 onDismiss = menuState::hide,
                                 onName = { sortBy = PlaylistSortBy.Name },
-                                onSongNumber = {
-                                    sortBy = PlaylistSortBy.SongCount
-                                },
+                                onSongNumber = { sortBy = PlaylistSortBy.SongCount },
                                 onDateAdded = { sortBy = PlaylistSortBy.DateAdded },
                                 onPlayTime = { sortBy = PlaylistSortBy.MostPlayed },
                             )

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -48,10 +48,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
@@ -520,10 +522,18 @@ fun HomeLibraryModern(
                                    .fillMaxWidth()
             ) {
                 val focusRequester = remember { FocusRequester() }
+                val focusManager = LocalFocusManager.current
+                val keyboardController = LocalSoftwareKeyboardController.current
 
                 LaunchedEffect(searching, isSearchInputFocused) {
-                    if( searching && isSearchInputFocused )
+                    if( !searching ) return@LaunchedEffect
+
+                    if( isSearchInputFocused )
                         focusRequester.requestFocus()
+                    else {
+                        keyboardController?.hide()
+                        focusManager.clearFocus()
+                    }
                 }
 
                 var searchInput by remember { mutableStateOf(TextFieldValue(filter)) }
@@ -541,7 +551,7 @@ fun HomeLibraryModern(
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = {
                         searching = filter.isNotBlank()
-                        isSearchInputFocused = filter.isNotBlank()
+                        isSearchInputFocused = false
                     }),
                     cursorBrush = SolidColor(colorPalette().text),
                     decorationBox = { innerTextField ->

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -19,13 +19,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -51,13 +48,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
@@ -65,17 +59,14 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.UnstableApi
-import androidx.room.util.copy
 import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
 import it.fast4x.compose.persist.persistList
 import it.fast4x.rimusic.Database
-import it.fast4x.rimusic.LocalPlayerAwareWindowInsets
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.MONTHLY_PREFIX
 import it.fast4x.rimusic.PINNED_PREFIX
 import it.fast4x.rimusic.PIPED_PREFIX
 import it.fast4x.rimusic.R
-import it.fast4x.rimusic.enums.BuiltInPlaylist
 import it.fast4x.rimusic.enums.LibraryItemSize
 import it.fast4x.rimusic.enums.NavigationBarPosition
 import it.fast4x.rimusic.enums.PlaylistSortBy
@@ -378,7 +369,7 @@ fun HomeLibraryModern(
 
                     HeaderInfo(
                         title = "${items.size}",
-                        icon = painterResource(R.drawable.playlist)
+                        iconId = R.drawable.playlist
                     )
                     Spacer(
                         modifier = Modifier

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -67,7 +67,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.input.ImeAction
@@ -100,7 +99,6 @@ import it.fast4x.rimusic.enums.TopPlaylistPeriod
 import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.models.Folder
 import it.fast4x.rimusic.models.OnDeviceSong
-import it.fast4x.rimusic.models.Playlist
 import it.fast4x.rimusic.models.Song
 import it.fast4x.rimusic.models.SongEntity
 import it.fast4x.rimusic.models.SongPlaylistMap
@@ -178,7 +176,6 @@ import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import it.fast4x.rimusic.utils.topPlaylistPeriodKey
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -790,7 +787,7 @@ fun HomeSongsModern(
 
                         HeaderInfo(
                             title = if (builtInPlaylist == BuiltInPlaylist.OnDevice) "${filteredSongs.size}" else "${items.size}",
-                            icon = painterResource(R.drawable.musical_notes)
+                            iconId = R.drawable.musical_notes
                         )
                         Spacer(
                             modifier = Modifier

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -19,7 +19,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -115,7 +114,6 @@ import it.fast4x.rimusic.ui.components.themed.FloatingActionsContainerWithScroll
 import it.fast4x.rimusic.ui.components.themed.FolderItemMenu
 import it.fast4x.rimusic.ui.components.themed.HeaderIconButton
 import it.fast4x.rimusic.ui.components.themed.HeaderInfo
-import it.fast4x.rimusic.ui.components.themed.HeaderWithIcon
 import it.fast4x.rimusic.ui.components.themed.IconButton
 import it.fast4x.rimusic.ui.components.themed.InHistoryMediaItemMenu
 import it.fast4x.rimusic.ui.components.themed.InputTextDialog
@@ -126,7 +124,6 @@ import it.fast4x.rimusic.ui.components.themed.PlaylistsItemMenu
 import it.fast4x.rimusic.ui.components.themed.SecondaryTextButton
 import it.fast4x.rimusic.ui.components.themed.SmartMessage
 import it.fast4x.rimusic.ui.components.themed.SortMenu
-import it.fast4x.rimusic.ui.components.themed.TitleSection
 import it.fast4x.rimusic.ui.items.FolderItem
 import it.fast4x.rimusic.ui.items.SongItem
 import it.fast4x.rimusic.ui.screens.ondevice.musicFilesAsFlow
@@ -180,6 +177,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import me.knighthat.colorPalette
+import me.knighthat.component.header.TabToolBar
 import me.knighthat.component.tab.TabHeader
 import me.knighthat.thumbnailShape
 import me.knighthat.typography
@@ -798,187 +796,151 @@ fun HomeSongsModern(
                             .fillMaxWidth()
                     ) {
 
-                        if (builtInPlaylist != BuiltInPlaylist.Top) {
-                            HeaderIconButton(
-                                icon = R.drawable.arrow_up,
-                                color = colorPalette().text,
-                                onClick = {},
-                                modifier = Modifier
-                                    .padding(horizontal = 2.dp)
-                                    .graphicsLayer {
-                                        rotationZ =
-                                            sortOrderIconRotation
-                                    }
-                                    .combinedClickable(
-                                        onClick = {
-                                            if (builtInPlaylist != BuiltInPlaylist.OnDevice)
-                                                sortOrder = !sortOrder
-                                            else sortOrderOnDevice = !sortOrderOnDevice
-                                        },
-                                        onLongClick = {
-                                            menuState.display {
-                                                when (builtInPlaylist) {
-                                                    BuiltInPlaylist.OnDevice -> {
-                                                        if (!showFolders)
-                                                            SortMenu(
-                                                                title = stringResource(R.string.sorting_order),
-                                                                onDismiss = menuState::hide,
-                                                                onTitle = {
-                                                                    sortByOnDevice =
-                                                                        OnDeviceSongSortBy.Title
-                                                                },
-                                                                onDateAdded = {
-                                                                    sortByOnDevice =
-                                                                        OnDeviceSongSortBy.DateAdded
-                                                                },
-                                                                onArtist = {
-                                                                    sortByOnDevice =
-                                                                        OnDeviceSongSortBy.Artist
-                                                                },
-                                                                onAlbum = {
-                                                                    sortByOnDevice =
-                                                                        OnDeviceSongSortBy.Album
-                                                                },
-                                                            )
-                                                        else
-                                                            SortMenu(
-                                                                title = stringResource(R.string.sorting_order),
-                                                                onDismiss = menuState::hide,
-                                                                onTitle = {
-                                                                    sortByFolderOnDevice =
-                                                                        OnDeviceFolderSortBy.Title
-                                                                },
-                                                                onArtist = {
-                                                                    sortByFolderOnDevice =
-                                                                        OnDeviceFolderSortBy.Artist
-                                                                },
-                                                                onDuration = {
-                                                                    sortByFolderOnDevice =
-                                                                        OnDeviceFolderSortBy.Duration
-                                                                },
-                                                            )
-                                                    }
-
-                                                    else -> {
-                                                        SortMenu(
-                                                            title = stringResource(R.string.sorting_order),
-                                                            onDismiss = menuState::hide,
-                                                            onTitle = { sortBy = SongSortBy.Title },
-                                                            onDatePlayed = {
-                                                                sortBy = SongSortBy.DatePlayed
-                                                            },
-                                                            onDateAdded = {
-                                                                sortBy = SongSortBy.DateAdded
-                                                            },
-                                                            onPlayTime = {
-                                                                sortBy = SongSortBy.PlayTime
-                                                            },
-                                                            onDateLiked = {
-                                                                sortBy = SongSortBy.DateLiked
-                                                            },
-                                                            onArtist = {
-                                                                sortBy = SongSortBy.Artist
-                                                            },
-                                                            onDuration = {
-                                                                sortBy = SongSortBy.Duration
-                                                            },
-                                                            onAlbum = {
-                                                                sortBy = SongSortBy.AlbumName
-                                                            },
-                                                        )
-                                                    }
-                                                }
-
+                        if (builtInPlaylist != BuiltInPlaylist.Top)
+                            TabToolBar.Icon(
+                                iconId = R.drawable.arrow_up,
+                                modifier = Modifier.graphicsLayer { rotationZ = sortOrderIconRotation },
+                                onShortClick = {
+                                    if (builtInPlaylist != BuiltInPlaylist.OnDevice)
+                                        sortOrder = !sortOrder
+                                    else
+                                        sortOrderOnDevice = !sortOrderOnDevice
+                                },
+                                onLongClick = {
+                                    menuState.display {
+                                        when (builtInPlaylist) {
+                                            BuiltInPlaylist.OnDevice -> {
+                                                if (!showFolders)
+                                                    SortMenu(
+                                                        title = stringResource(R.string.sorting_order),
+                                                        onDismiss = menuState::hide,
+                                                        onTitle = {
+                                                            sortByOnDevice =
+                                                                OnDeviceSongSortBy.Title
+                                                        },
+                                                        onDateAdded = {
+                                                            sortByOnDevice =
+                                                                OnDeviceSongSortBy.DateAdded
+                                                        },
+                                                        onArtist = {
+                                                            sortByOnDevice =
+                                                                OnDeviceSongSortBy.Artist
+                                                        },
+                                                        onAlbum = {
+                                                            sortByOnDevice =
+                                                                OnDeviceSongSortBy.Album
+                                                        },
+                                                    )
+                                                else
+                                                    SortMenu(
+                                                        title = stringResource(R.string.sorting_order),
+                                                        onDismiss = menuState::hide,
+                                                        onTitle = {
+                                                            sortByFolderOnDevice =
+                                                                OnDeviceFolderSortBy.Title
+                                                        },
+                                                        onArtist = {
+                                                            sortByFolderOnDevice =
+                                                                OnDeviceFolderSortBy.Artist
+                                                        },
+                                                        onDuration = {
+                                                            sortByFolderOnDevice =
+                                                                OnDeviceFolderSortBy.Duration
+                                                        },
+                                                    )
                                             }
-                                        }
-                                    )
-                            )
-                        }
-                        if (builtInPlaylist == BuiltInPlaylist.Top) {
-                            HeaderIconButton(
-                                icon = R.drawable.stat,
-                                color = colorPalette().text,
-                                onClick = {},
-                                modifier = Modifier
-                                    .padding(horizontal = 2.dp)
-                                    .clickable(
-                                        onClick = {
-                                            menuState.display {
-                                                PeriodMenu(
-                                                    onDismiss = {
-                                                        topPlaylistPeriod = it
-                                                        menuState.hide()
-                                                    }
+
+                                            else -> {
+                                                SortMenu(
+                                                    title = stringResource(R.string.sorting_order),
+                                                    onDismiss = menuState::hide,
+                                                    onTitle = { sortBy = SongSortBy.Title },
+                                                    onDatePlayed = {
+                                                        sortBy = SongSortBy.DatePlayed
+                                                    },
+                                                    onDateAdded = {
+                                                        sortBy = SongSortBy.DateAdded
+                                                    },
+                                                    onPlayTime = {
+                                                        sortBy = SongSortBy.PlayTime
+                                                    },
+                                                    onDateLiked = {
+                                                        sortBy = SongSortBy.DateLiked
+                                                    },
+                                                    onArtist = {
+                                                        sortBy = SongSortBy.Artist
+                                                    },
+                                                    onDuration = {
+                                                        sortBy = SongSortBy.Duration
+                                                    },
+                                                    onAlbum = {
+                                                        sortBy = SongSortBy.AlbumName
+                                                    },
                                                 )
                                             }
                                         }
-                                    )
-                            )
-                        }
 
-                        HeaderIconButton(
-                            onClick = { searching = !searching },
-                            icon = R.drawable.search_circle,
-                            color = colorPalette().text,
-                            iconSize = 24.dp,
-                            modifier = Modifier
-                                .padding(horizontal = 2.dp)
-                        )
-
-                        HeaderIconButton(
-                            modifier = Modifier
-                                .padding(horizontal = 5.dp)
-                                .combinedClickable(
-                                    onClick = {
-                                        nowPlayingItem = -1
-                                        scrollToNowPlaying = false
-                                        items
-                                            .forEachIndexed { index, song ->
-                                                if (song.song.asMediaItem.mediaId == binder?.player?.currentMediaItem?.mediaId)
-                                                    nowPlayingItem = index
-                                            }
-
-                                        if (nowPlayingItem > -1)
-                                            scrollToNowPlaying = true
-                                    },
-                                    onLongClick = {
-                                        SmartMessage(
-                                            context.resources.getString(R.string.info_find_the_song_that_is_playing),
-                                            context = context
-                                        )
                                     }
-                                ),
-                            icon = R.drawable.locate,
+                                }
+                            )
+
+                        if (builtInPlaylist == BuiltInPlaylist.Top)
+                            TabToolBar.Icon(iconId = R.drawable.stat) {
+                                menuState.display {
+                                    PeriodMenu(
+                                        onDismiss = {
+                                            topPlaylistPeriod = it
+                                            menuState.hide()
+                                        }
+                                    )
+                                }
+                            }
+
+                        TabToolBar.Icon( R.drawable.search_circle ) { searching = !searching }
+
+                        TabToolBar.Icon(
+                            iconId = R.drawable.locate,
+                            tint = if (songs.isNotEmpty()) colorPalette().text else colorPalette().textDisabled,
                             enabled = songs.isNotEmpty(),
-                            color = if (songs.isNotEmpty()) colorPalette().text else colorPalette().textDisabled,
-                            onClick = {}
+                            onShortClick = {
+                                nowPlayingItem = -1
+                                scrollToNowPlaying = false
+                                items
+                                    .forEachIndexed { index, song ->
+                                        if (song.song.asMediaItem.mediaId == binder?.player?.currentMediaItem?.mediaId)
+                                            nowPlayingItem = index
+                                    }
+
+                                if (nowPlayingItem > -1)
+                                    scrollToNowPlaying = true
+                            },
+                            onLongClick = {
+                                SmartMessage(
+                                    context.resources.getString(R.string.info_find_the_song_that_is_playing),
+                                    context = context
+                                )
+                            }
                         )
+
                         LaunchedEffect(scrollToNowPlaying) {
                             if (scrollToNowPlaying)
                                 lazyListState.scrollToItem(nowPlayingItem, 1)
                             scrollToNowPlaying = false
                         }
 
-                        if (builtInPlaylist == BuiltInPlaylist.Favorites) {
-                            HeaderIconButton(
-                                icon = R.drawable.downloaded,
+                        if (builtInPlaylist == BuiltInPlaylist.Favorites)
+                            TabToolBar.Icon(
+                                iconId = R.drawable.downloaded,
+                                tint = if (songs.isNotEmpty()) colorPalette().text else colorPalette().textDisabled,
                                 enabled = songs.isNotEmpty(),
-                                color = if (songs.isNotEmpty()) colorPalette().text else colorPalette().textDisabled,
-                                onClick = {},
-                                modifier = Modifier
-                                    .combinedClickable(
-                                        onClick = {
-                                            showConfirmDownloadAllDialog = true
-                                        },
-                                        onLongClick = {
-                                            SmartMessage(
-                                                context.resources.getString(R.string.info_download_all_songs),
-                                                context = context
-                                            )
-                                        }
+                                onShortClick ={ showConfirmDownloadAllDialog = true },
+                                onLongClick = {
+                                    SmartMessage(
+                                        context.resources.getString(R.string.info_download_all_songs),
+                                        context = context
                                     )
+                                }
                             )
-                        }
 
                         if (showConfirmDownloadAllDialog) {
                             ConfirmationDialog(
@@ -1017,23 +979,17 @@ fun HomeSongsModern(
                         }
 
                         if (builtInPlaylist == BuiltInPlaylist.Favorites || builtInPlaylist == BuiltInPlaylist.Downloaded) {
-                            HeaderIconButton(
-                                icon = R.drawable.download,
+                            TabToolBar.Icon(
+                                iconId = R.drawable.download,
+                                tint = if (songs.isNotEmpty()) colorPalette().text else colorPalette().textDisabled,
                                 enabled = songs.isNotEmpty(),
-                                color = if (songs.isNotEmpty()) colorPalette().text else colorPalette().textDisabled,
-                                onClick = {},
-                                modifier = Modifier
-                                    .combinedClickable(
-                                        onClick = {
-                                            showConfirmDeleteDownloadDialog = true
-                                        },
-                                        onLongClick = {
-                                            SmartMessage(
-                                                context.resources.getString(R.string.info_remove_all_downloaded_songs),
-                                                context = context
-                                            )
-                                        }
+                                onShortClick = { showConfirmDeleteDownloadDialog = true },
+                                onLongClick = {
+                                    SmartMessage(
+                                        context.resources.getString(R.string.info_remove_all_downloaded_songs),
+                                        context = context
                                     )
+                                }
                             )
 
                             if (showConfirmDeleteDownloadDialog) {
@@ -1071,106 +1027,78 @@ fun HomeSongsModern(
                             }
                         }
 
-                        //if (builtInPlaylist == BuiltInPlaylist.All)
-                            HeaderIconButton(
-                                onClick = {},
-                                icon = if (showHiddenSongs == 0) R.drawable.eye_off else R.drawable.eye,
-                                color = colorPalette().text,
-                                modifier = Modifier
-                                    .padding(horizontal = 2.dp)
-                                    .combinedClickable(
-                                        onClick = {
-                                            showHiddenSongs = if (showHiddenSongs == 0) -1 else 0
-                                        },
-                                        onLongClick = {
-                                            SmartMessage(
-                                                context.resources.getString(R.string.info_show_hide_hidden_songs),
-                                                context = context
-                                            )
-                                        }
-                                    )
-                            )
-
-                        HeaderIconButton(
-                            icon = R.drawable.shuffle,
-                            enabled = items.isNotEmpty(),
-                            color = if (items.isNotEmpty()) colorPalette().text else colorPalette().textDisabled,
-                            onClick = {},
-                            modifier = Modifier
-                                .padding(horizontal = 2.dp)
-                                .combinedClickable(
-                                    onClick = {
-                                        if (builtInPlaylist == BuiltInPlaylist.OnDevice) items =
-                                            filteredSongs
-                                        if (items.isNotEmpty()) {
-                                            val itemsLimited =
-                                                if (items.size > maxSongsInQueue.number) items
-                                                    .shuffled()
-                                                    .take(maxSongsInQueue.number.toInt()) else items
-                                            binder?.stopRadio()
-                                            binder?.player?.forcePlayFromBeginning(
-                                                itemsLimited
-                                                    .shuffled()
-                                                    .map(SongEntity::asMediaItem)
-                                            )
-                                        }
-                                    },
-                                    onLongClick = {
-                                        SmartMessage(
-                                            context.resources.getString(R.string.info_shuffle),
-                                            context = context
-                                        )
-                                    }
+                        TabToolBar.Toggleable(
+                            onIconId = R.drawable.eye,
+                            offIconId = R.drawable.eye_off,
+                            toggleCondition = showHiddenSongs != 0,
+                            onShortClick = {
+                                showHiddenSongs = if (showHiddenSongs == 0) -1 else 0
+                            },
+                            onLongClick = {
+                                SmartMessage(
+                                    context.resources.getString(R.string.info_show_hide_hidden_songs),
+                                    context = context
                                 )
+                            }
+                        )
+
+                        TabToolBar.Icon(
+                            iconId = R.drawable.shuffle,
+                            tint = if (items.isNotEmpty()) colorPalette().text else colorPalette().textDisabled,
+                            enabled = items.isNotEmpty(),
+                            onShortClick = {
+                                if (builtInPlaylist == BuiltInPlaylist.OnDevice) items =
+                                    filteredSongs
+                                if (items.isNotEmpty()) {
+                                    val itemsLimited =
+                                        if (items.size > maxSongsInQueue.number) items
+                                            .shuffled()
+                                            .take(maxSongsInQueue.number.toInt()) else items
+                                    binder?.stopRadio()
+                                    binder?.player?.forcePlayFromBeginning(
+                                        itemsLimited
+                                            .shuffled()
+                                            .map(SongEntity::asMediaItem)
+                                    )
+                                }
+                            },
+                            onLongClick = {
+                                SmartMessage(
+                                    context.resources.getString(R.string.info_shuffle),
+                                    context = context
+                                )
+                            }
                         )
 
                         if (builtInPlaylist == BuiltInPlaylist.Favorites)
-                            HeaderIconButton(
-                                icon = R.drawable.random,
-                                enabled = true,
-                                color = if (autoShuffle) colorPalette().text else colorPalette().textDisabled,
-                                onClick = {},
-                                modifier = Modifier
-                                    .combinedClickable(
-                                        onClick = {
-                                            autoShuffle = !autoShuffle
-                                        },
-                                        onLongClick = {
-                                            SmartMessage("Random sorting", context = context)
-                                        }
-                                    )
+                            TabToolBar.Icon(
+                                iconId = R.drawable.random,
+                                tint = if (autoShuffle) colorPalette().text else colorPalette().textDisabled,
+                                onShortClick = { autoShuffle = !autoShuffle },
+                                // TODO: Add string to language pack
+                                onLongClick = { SmartMessage( "Random sorting", context = context) }
                             )
-
-                        if (builtInPlaylist != BuiltInPlaylist.Favorites)
-                            HeaderIconButton(
-                                icon = R.drawable.resource_import,
-                                color = colorPalette().text,
-                                //iconSize = 22.dp,
-                                onClick = {},
-                                modifier = Modifier
-                                    .padding(horizontal = 2.dp)
-                                    .combinedClickable(
-                                        onClick = {
-                                            try {
-                                                importLauncher.launch(
-                                                    arrayOf(
-                                                        "text/*"
-                                                    )
-                                                )
-                                            } catch (e: ActivityNotFoundException) {
-                                                SmartMessage(
-                                                    context.resources.getString(R.string.info_not_find_app_open_doc),
-                                                    type = PopupType.Warning, context = context
-                                                )
-                                            }
-                                        },
-                                        onLongClick = {
-                                            SmartMessage(
-                                                context.resources.getString(R.string.import_favorites),
-                                                context = context
-                                            )
-                                        }
+                        else
+                            TabToolBar.Icon(
+                                iconId = R.drawable.resource_import,
+                                onShortClick = {
+                                    try {
+                                        importLauncher.launch(
+                                            arrayOf( "text/*" )
+                                        )
+                                    } catch (e: ActivityNotFoundException) {
+                                        SmartMessage(
+                                            context.resources.getString(R.string.info_not_find_app_open_doc),
+                                            type = PopupType.Warning, context = context
+                                        )
+                                    }
+                                },
+                                onLongClick = {
+                                    SmartMessage(
+                                        context.resources.getString(R.string.import_favorites),
+                                        context = context
                                     )
+                                }
                             )
 
                         HeaderIconButton(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -180,6 +180,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import me.knighthat.colorPalette
+import me.knighthat.component.tab.TabHeader
 import me.knighthat.thumbnailShape
 import me.knighthat.typography
 import timber.log.Timber
@@ -752,10 +753,18 @@ fun HomeSongsModern(
                     1f
             )
     ) {
+        TabHeader( R.string.songs ) {
+            val size =
+                if( builtInPlaylist == BuiltInPlaylist.OnDevice )
+                    filteredSongs.size
+                else
+                    items.size
+            HeaderInfo( size.toString(), R.drawable.musical_notes )
+        }
+
         LazyColumn(
             state = lazyListState,
-            modifier = Modifier
-
+            modifier = Modifier.padding( top = TabHeader.height() )
         ) {
 
             stickyHeader {
@@ -764,37 +773,6 @@ fun HomeSongsModern(
                         .fillMaxWidth()
                         .background(colorPalette().background0)
                 ) {
-                    if ( UiType.ViMusic.isCurrent() )
-                        HeaderWithIcon(
-                            title = stringResource(R.string.songs),
-                            iconId = R.drawable.search,
-                            enabled = true,
-                            showIcon = !showSearchTab,
-                            modifier = Modifier,
-                            onClick = onSearchClick
-                        )
-
-                    Row(
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier
-                            .padding(horizontal = 12.dp)
-                            .padding(vertical = 4.dp)
-                            .fillMaxWidth()
-                    ) {
-                        if ( UiType.RiMusic.isCurrent() )
-                            TitleSection(title = stringResource(R.string.songs))
-
-                        HeaderInfo(
-                            title = if (builtInPlaylist == BuiltInPlaylist.OnDevice) "${filteredSongs.size}" else "${items.size}",
-                            iconId = R.drawable.musical_notes
-                        )
-                        Spacer(
-                            modifier = Modifier
-                                .weight(1f)
-                        )
-                    }
-
                     Row(
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -615,7 +615,7 @@ fun HomeSongsModern(
                 it.name.contains( filter, true )
             }
         } else
-            items.filter {
+            items = items.filter {
                 it.song.title.contains( filter, true )
                         || it.song.artistsText?.contains( filter, true ) ?: false
                         || it.albumTitle?.contains( filter, true ) ?: false

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -1177,93 +1177,87 @@ fun HomeSongsModern(
             }
 
             // Sticky search bar
-            AnimatedVisibility(visible = searching) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalAlignment = Alignment.Bottom,
-                    modifier = Modifier
-                        //.requiredHeight(30.dp)
-                        .padding(all = 10.dp)
-                        .fillMaxWidth()
-                ) {
-                    val focusRequester = remember { FocusRequester() }
-                    val focusManager = LocalFocusManager.current
-                    val keyboardController = LocalSoftwareKeyboardController.current
+            AnimatedVisibility(
+                visible = searching,
+                modifier = Modifier.padding( all = 10.dp )
+                                   .fillMaxWidth()
+            ) {
+                val focusRequester = remember { FocusRequester() }
+                val focusManager = LocalFocusManager.current
+                val keyboardController = LocalSoftwareKeyboardController.current
 
-                    LaunchedEffect(searching) {
-                        focusRequester.requestFocus()
-                    }
-
-                    BasicTextField(
-                        value = filter ?: "",
-                        onValueChange = { filter = it },
-                        textStyle = typography().xs.semiBold,
-                        singleLine = true,
-                        maxLines = 1,
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                        keyboardActions = KeyboardActions(onDone = {
-                            if (filter.isNullOrBlank()) filter = ""
-                            focusManager.clearFocus()
-                        }),
-                        cursorBrush = SolidColor(colorPalette().text),
-                        decorationBox = { innerTextField ->
-                            Box(
-                                contentAlignment = Alignment.CenterStart,
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .padding(horizontal = 10.dp)
-                            ) {
-                                IconButton(
-                                    onClick = {},
-                                    icon = R.drawable.search,
-                                    color = colorPalette().favoritesIcon,
-                                    modifier = Modifier
-                                        .align(Alignment.CenterStart)
-                                        .size(16.dp)
-                                )
-                            }
-                            Box(
-                                contentAlignment = Alignment.CenterStart,
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .padding(horizontal = 30.dp)
-                            ) {
-                                androidx.compose.animation.AnimatedVisibility(
-                                    visible = filter?.isEmpty() ?: true,
-                                    enter = fadeIn(tween(100)),
-                                    exit = fadeOut(tween(100)),
-                                ) {
-                                    BasicText(
-                                        text = stringResource(R.string.search),
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                        style = typography().xs.semiBold.secondary.copy(color = colorPalette().textDisabled)
-                                    )
-                                }
-
-                                innerTextField()
-                            }
-                        },
-                        modifier = Modifier
-                            .height(30.dp)
-                            .fillMaxWidth()
-                            .background(
-                                colorPalette().background4,
-                                shape = thumbnailRoundness.shape()
-                            )
-                            .focusRequester(focusRequester)
-                            .onFocusChanged {
-                                if (!it.hasFocus) {
-                                    keyboardController?.hide()
-                                    if (filter?.isBlank() == true) {
-                                        filter = null
-                                        searching = false
-                                    }
-                                }
-                            }
-                    )
+                LaunchedEffect(searching) {
+                    focusRequester.requestFocus()
                 }
 
+                BasicTextField(
+                    value = filter ?: "",
+                    onValueChange = { filter = it },
+                    textStyle = typography().xs.semiBold,
+                    singleLine = true,
+                    maxLines = 1,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(onDone = {
+                        if (filter.isNullOrBlank()) filter = ""
+                        focusManager.clearFocus()
+                    }),
+                    cursorBrush = SolidColor(colorPalette().text),
+                    decorationBox = { innerTextField ->
+                        Box(
+                            contentAlignment = Alignment.CenterStart,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 10.dp)
+                        ) {
+                            IconButton(
+                                onClick = {},
+                                icon = R.drawable.search,
+                                color = colorPalette().favoritesIcon,
+                                modifier = Modifier
+                                    .align(Alignment.CenterStart)
+                                    .size(16.dp)
+                            )
+                        }
+                        Box(
+                            contentAlignment = Alignment.CenterStart,
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = 30.dp)
+                        ) {
+                            androidx.compose.animation.AnimatedVisibility(
+                                visible = filter?.isEmpty() ?: true,
+                                enter = fadeIn(tween(100)),
+                                exit = fadeOut(tween(100)),
+                            ) {
+                                BasicText(
+                                    text = stringResource(R.string.search),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    style = typography().xs.semiBold.secondary.copy(color = colorPalette().textDisabled)
+                                )
+                            }
+
+                            innerTextField()
+                        }
+                    },
+                    modifier = Modifier
+                        .height(30.dp)
+                        .fillMaxWidth()
+                        .background(
+                            colorPalette().background4,
+                            shape = thumbnailRoundness.shape()
+                        )
+                        .focusRequester(focusRequester)
+                        .onFocusChanged {
+                            if (!it.hasFocus) {
+                                keyboardController?.hide()
+                                if (filter?.isBlank() == true) {
+                                    filter = null
+                                    searching = false
+                                }
+                            }
+                        }
+                )
             }
 
             LazyColumn(

--- a/composeApp/src/androidMain/kotlin/me/knighthat/component/header/TabToolBar.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/component/header/TabToolBar.kt
@@ -1,0 +1,111 @@
+package me.knighthat.component.header
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import me.knighthat.colorPalette
+
+object TabToolBar {
+
+    private val TOOLBAR_ICON_SIZE = 32.dp
+
+    @Composable
+    fun Icon(
+        @DrawableRes iconId: Int,
+        tint: Color = colorPalette().text,
+        size: Dp = TOOLBAR_ICON_SIZE,
+        enabled: Boolean = true,
+        modifier: Modifier = Modifier,
+        onClick: () -> Unit
+    ) {
+        IconButton(
+            onClick = onClick,
+            enabled = enabled
+        ) {
+            androidx.compose.material3.Icon(
+                painter = painterResource( iconId ),
+                tint = tint,
+                contentDescription = null,
+                modifier = modifier
+                    .size(size)
+                    .padding(horizontal = 4.dp)
+            )
+        }
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    @Composable
+    fun Icon(
+        @DrawableRes iconId: Int,
+        tint: Color = colorPalette().text,
+        size: Dp = TOOLBAR_ICON_SIZE,
+        modifier: Modifier = Modifier,
+        enabled: Boolean = true,
+        onShortClick: () -> Unit ,
+        onLongClick: () -> Unit
+    ) {
+        Icon(
+            iconId,
+            tint,
+            size,
+            enabled,
+            modifier.combinedClickable (
+                onClick = onShortClick,
+                onLongClick = onLongClick
+            )
+        ) { }
+    }
+
+    @Composable
+    fun Toggleable(
+        @DrawableRes onIconId: Int,
+        @DrawableRes offIconId: Int,
+        toggleCondition: Boolean,
+        tint: Color = colorPalette().text,
+        size: Dp = TOOLBAR_ICON_SIZE,
+        modifier: Modifier = Modifier,
+        onClick: () -> Unit
+    ) {
+        Icon(
+            iconId = if( toggleCondition ) onIconId else offIconId,
+            tint = tint,
+            size = size,
+            modifier = modifier,
+            onClick = onClick
+        )
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    @Composable
+    fun Toggleable(
+        @DrawableRes onIconId: Int,
+        @DrawableRes offIconId: Int,
+        toggleCondition: Boolean,
+        tint: Color = colorPalette().text,
+        size: Dp = TOOLBAR_ICON_SIZE,
+        modifier: Modifier = Modifier,
+        onShortClick: () -> Unit,
+        onLongClick: () -> Unit
+    ) {
+        Toggleable(
+            onIconId,
+            offIconId,
+            toggleCondition,
+            tint,
+            size,
+            modifier.combinedClickable (
+                onClick = onShortClick,
+                onLongClick = onLongClick
+            )
+        ) { }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/me/knighthat/component/tab/TabHeader.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/component/tab/TabHeader.kt
@@ -1,0 +1,113 @@
+package me.knighthat.component.tab
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import it.fast4x.rimusic.enums.UiType
+import it.fast4x.rimusic.utils.bold
+import me.knighthat.colorPalette
+import me.knighthat.typography
+
+@Composable
+private fun Title( titleId: Int ) {
+    val fontStyle = TabHeader.style()
+    val sPadding: Dp
+    val ePadding: Dp
+    val alignment: TextAlign
+
+    when( UiType.current() ) {
+        UiType.RiMusic -> {
+            sPadding = Dp.Hairline
+            ePadding = 12.dp
+            alignment = TextAlign.Start
+        }
+        UiType.ViMusic -> {
+            sPadding = 12.dp
+            ePadding = Dp.Hairline
+            alignment = TextAlign.End
+        }
+    }
+
+    Text(
+        text = stringResource( titleId ),
+        style = TextStyle(
+            fontSize = fontStyle.fontSize,
+            fontWeight = fontStyle.fontWeight,
+            color = colorPalette().text,
+            textAlign = alignment
+        ),
+        modifier = Modifier.padding( start = sPadding, end = ePadding )
+    )
+}
+
+@Composable
+private fun ViMusicHeader( titleId: Int, additionalContent: @Composable () -> Unit ) {
+    additionalContent()
+    Title( titleId )
+}
+
+@Composable
+private fun RiMusicHeader( titleId: Int, additionalContent: @Composable () -> Unit ) {
+    Title( titleId )
+    additionalContent()
+}
+
+interface TabHeader {
+
+    companion object {
+
+        @Composable
+        fun style(): TextStyle =
+            when( UiType.current() ) {
+                UiType.RiMusic -> typography().xl.bold
+                UiType.ViMusic -> typography().xxxl.bold
+            }
+
+        @Composable
+        fun height(): Dp = style().fontSize.value.dp + 14.dp
+    }
+}
+
+/**
+ * Display tab's header depends on current theme
+ * For instance:
+ *  - RiMusic theme has header aligned to the left
+ *  - ViMusic theme has header aligned to the right
+ *  and slightly bigger than RiMusic
+ */
+@Composable
+fun TabHeader(
+    titleId: Int,
+    additionalContent: @Composable () -> Unit
+) {
+    // Align left if RiMusic, right if ViMusic
+    val arrangement =
+        if( UiType.ViMusic.isCurrent() )
+            Arrangement.End
+        else
+            Arrangement.Start
+
+    Row(
+        horizontalArrangement = arrangement,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .padding(horizontal = 12.dp)
+            .padding(top = 10.dp, bottom = 4.dp)
+            .fillMaxWidth()
+    ) {
+        when( UiType.current() ) {
+            UiType.RiMusic -> RiMusicHeader( titleId, additionalContent )
+            UiType.ViMusic -> ViMusicHeader( titleId, additionalContent )
+        }
+    }
+}


### PR DESCRIPTION
# Keyboard handler

- Keyboard will now close once when search bar is out of focus.
- Back button from other screen will not re-enable keyboard
- Keyboard will close on certain (intended) actions.

# Tab's header rearrangement 

> Before

<p float="left">
  <img src="https://github.com/user-attachments/assets/1ec5bb42-f11a-42dd-a4fe-af8fa729c1ac" width="150" />
  <img src="https://github.com/user-attachments/assets/78265137-61bd-4b7c-af24-74593eefdbb2" width="150" />
  <img src="https://github.com/user-attachments/assets/766aa981-1584-42e3-91c4-5ccad98261c9" width="150" />
  <img src="https://github.com/user-attachments/assets/5a1534c2-55dc-453c-9374-ded63b3021c4" width="150" />
</p>

> After

<p float="left">
  <img src="https://github.com/user-attachments/assets/9e88ec85-32e1-4b66-9919-d8fa680d3a76" width="150" />
  <img src="https://github.com/user-attachments/assets/8e9a58a6-fa8f-4e73-9612-743354fa3c00" width="150" />
  <img src="https://github.com/user-attachments/assets/ca110200-00d8-4b48-a8aa-f597c7a7cd96" width="150" />
  <img src="https://github.com/user-attachments/assets/ad03e34e-0479-400c-b38a-910bbd212f95" width="150" />
</p>

# Sticky header

### Before

Only `Songs` tab has sticky header

https://github.com/user-attachments/assets/665808bc-e23c-4560-9d42-21a6bbb3a3cf

### After

Now all tabs have sticky header

https://github.com/user-attachments/assets/6820dd97-efd8-421a-ad87-295ad04dd73d





