### PR TITLE
Better Player fetch

### DIFF
--- a/extensions/innertube/src/main/kotlin/it/fast4x/innertube/Innertube.kt
+++ b/extensions/innertube/src/main/kotlin/it/fast4x/innertube/Innertube.kt
@@ -11,6 +11,7 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
+import io.ktor.http.append
 import io.ktor.serialization.kotlinx.json.json
 import it.fast4x.innertube.models.MusicNavigationButtonRenderer
 import it.fast4x.innertube.models.NavigationEndpoint
@@ -23,9 +24,27 @@ import java.net.InetSocketAddress
 import java.net.Proxy
 
 object Innertube {
-    val client = HttpClient(OkHttp) {
-        BrowserUserAgent()
 
+    const val BASE_URL = "music.youtube.com"
+    const val ORIGIN = "https://music.youtube.com"
+
+    private val HEADERS = mapOf(
+        HttpHeaders.Accept to "*/*",
+        HttpHeaders.Host to BASE_URL,
+        HttpHeaders.ContentType to ContentType.Application.Json.toString(),
+        /*
+            This UserAgent requires frequent update
+            This may reduce the chance of being block by a tiny bit
+            But anything at this point should be taken for advantage.
+
+            The example below is "Chrome 129.0.0, Windows' @ https://useragents.me/
+         */
+        HttpHeaders.UserAgent to "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.3",
+        HttpHeaders.Origin to ORIGIN,
+        HttpHeaders.Referrer to ORIGIN
+    )
+
+    val client = HttpClient(OkHttp) {
         expectSuccess = true
 
         install(ContentNegotiation) {
@@ -54,9 +73,8 @@ object Innertube {
         }
 
         defaultRequest {
-            url(scheme = "https", host ="music.youtube.com") {
-                headers.append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-                headers.append("X-Goog-Api-Key", "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8")
+            url(scheme = "https", host = BASE_URL ) {
+                HEADERS.forEach( headers::append )
                 parameters.append("prettyPrint", "false")
             }
         }

--- a/extensions/innertube/src/main/kotlin/it/fast4x/innertube/models/bodies/PlayerBody.kt
+++ b/extensions/innertube/src/main/kotlin/it/fast4x/innertube/models/bodies/PlayerBody.kt
@@ -1,12 +1,28 @@
 package it.fast4x.innertube.models.bodies
 
-import it.fast4x.innertube.models.Context
 import kotlinx.serialization.Serializable
+import me.knighthat.innertube.body.Context
+import me.knighthat.innertube.body.PlaybackContext
 
 @Serializable
 data class PlayerBody(
-    val context: Context = Context.DefaultAndroid,
-    //val context: Context = Context.DefaultWeb,
     val videoId: String,
-    val playlistId: String? = null
-)
+    val playlistId: String? = null,
+    val context: Context = Context.DEFAULT_ANDROID,
+    val playbackContext: PlaybackContext = PlaybackContext.DEFAULT
+) {
+
+    /**
+     * Required parameter as mentioned in
+     * [#3](https://github.com/zerodytrash/YouTube-Internal-Clients/issues/3)
+     */
+    val racyCheckOk: Boolean
+        get() = true
+
+    /**
+     * Required parameter as mentioned in
+     * [#3](https://github.com/zerodytrash/YouTube-Internal-Clients/issues/3)
+     */
+    val contentCheckOk: Boolean
+        get() = true
+}

--- a/extensions/innertube/src/main/kotlin/it/fast4x/innertube/requests/Player.kt
+++ b/extensions/innertube/src/main/kotlin/it/fast4x/innertube/requests/Player.kt
@@ -4,11 +4,11 @@ import io.ktor.client.call.body
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import it.fast4x.innertube.Innertube
-import it.fast4x.innertube.models.Context
 import it.fast4x.innertube.models.PlayerResponse
 import it.fast4x.innertube.models.bodies.PlayerBody
 import it.fast4x.innertube.utils.runCatchingNonCancellable
 import it.fast4x.piped.models.Session
+import me.knighthat.innertube.body.Context
 
 suspend fun Innertube.player(
     body: PlayerBody,
@@ -29,7 +29,7 @@ suspend fun Innertube.player(
             val safePlayerResponse = client.post(player) {
                 setBody(
                     body.copy(
-                        context = Context.DefaultAndroid.copy(
+                        context = Context.DEFAULT_ANDROID.copy(
                             thirdParty = Context.ThirdParty(
                                 embedUrl = "https://www.youtube.com/watch?v=${body.videoId}"
                             )

--- a/extensions/innertube/src/main/kotlin/me/knighthat/innertube/body/Context.kt
+++ b/extensions/innertube/src/main/kotlin/me/knighthat/innertube/body/Context.kt
@@ -1,0 +1,36 @@
+package me.knighthat.innertube.body
+
+import kotlinx.serialization.Serializable
+import me.knighthat.innertube.client.AndroidMusic
+
+@Serializable
+data class Context(
+    val client: Client,
+    val thirdParty: ThirdParty = ThirdParty()
+) {
+
+    companion object {
+
+        val DEFAULT_ANDROID = Context(
+            client = Client(
+                clientName = AndroidMusic.CLIENT_NAME,
+                clientVersion = AndroidMusic.CLIENT_VERSION
+            )
+        )
+    }
+
+    @Serializable
+    data class Client(
+        val hl: String = "en",
+        val gl: String = "US",
+        val clientName: String,
+        val clientVersion: String,
+        val clientScreen: String = "WATCH",
+        val androidSdkVersion: Int = 24
+    )
+
+    @Serializable
+    data class ThirdParty(
+        val embedUrl: String = "https://music.youtube.com"
+    )
+}

--- a/extensions/innertube/src/main/kotlin/me/knighthat/innertube/body/Context.kt
+++ b/extensions/innertube/src/main/kotlin/me/knighthat/innertube/body/Context.kt
@@ -2,6 +2,7 @@ package me.knighthat.innertube.body
 
 import kotlinx.serialization.Serializable
 import me.knighthat.innertube.client.AndroidMusic
+import me.knighthat.innertube.client.IOSMusic
 
 @Serializable
 data class Context(
@@ -15,6 +16,13 @@ data class Context(
             client = Client(
                 clientName = AndroidMusic.CLIENT_NAME,
                 clientVersion = AndroidMusic.CLIENT_VERSION
+            )
+        )
+
+        val DEFAULT_IOS = Context (
+            client = Client(
+                clientName = IOSMusic.CLIENT_NAME,
+                clientVersion = IOSMusic.CLIENT_VERSION
             )
         )
     }

--- a/extensions/innertube/src/main/kotlin/me/knighthat/innertube/body/PlaybackContext.kt
+++ b/extensions/innertube/src/main/kotlin/me/knighthat/innertube/body/PlaybackContext.kt
@@ -1,0 +1,27 @@
+package me.knighthat.innertube.body
+
+import kotlinx.serialization.Serializable
+import java.time.LocalDate
+
+@Serializable
+data class PlaybackContext(
+    val contextPlaybackContext: ContentPlaybackContext
+) {
+
+    companion object {
+
+        val DEFAULT = PlaybackContext(
+            ContentPlaybackContext( ContentPlaybackContext.getTimeStamp() )
+        )
+    }
+
+    @Serializable
+    data class ContentPlaybackContext( val signatureTimestamp: Long ) {
+
+        companion object {
+
+            fun getTimeStamp(): Long =
+                LocalDate.now().toEpochDay() - LocalDate.ofEpochDay(0).toEpochDay()
+        }
+    }
+}

--- a/extensions/innertube/src/main/kotlin/me/knighthat/innertube/client/AndroidMusic.kt
+++ b/extensions/innertube/src/main/kotlin/me/knighthat/innertube/client/AndroidMusic.kt
@@ -1,0 +1,7 @@
+package me.knighthat.innertube.client
+
+object AndroidMusic {
+
+    const val CLIENT_NAME = "ANDROID_MUSIC"
+    const val CLIENT_VERSION = "6.33.52"
+}

--- a/extensions/innertube/src/main/kotlin/me/knighthat/innertube/client/AndroidMusic.kt
+++ b/extensions/innertube/src/main/kotlin/me/knighthat/innertube/client/AndroidMusic.kt
@@ -2,6 +2,8 @@ package me.knighthat.innertube.client
 
 object AndroidMusic {
 
+    const val API_KEY = "AIzaSyAOghZGza2MQSZkY_zfZ370N-PUdXEo8AI"
+
     const val CLIENT_NAME = "ANDROID_MUSIC"
     const val CLIENT_VERSION = "6.33.52"
 }

--- a/extensions/innertube/src/main/kotlin/me/knighthat/innertube/client/IOSMusic.kt
+++ b/extensions/innertube/src/main/kotlin/me/knighthat/innertube/client/IOSMusic.kt
@@ -1,0 +1,9 @@
+package me.knighthat.innertube.client
+
+object IOSMusic {
+
+    const val API_KEY = "AIzaSyBAETezhkwP0ZWA02RsqT1zu78Fpt0bC_s"
+
+    const val CLIENT_NAME = "IOS_MUSIC"
+    const val CLIENT_VERSION = "6.33.52"
+}


### PR DESCRIPTION
I have done some rework on the request side of this app (Innertube)

# Request headers

First of all, I update it to match [YouTube Internal Clients](https://github.com/zerodytrash/YouTube-Internal-Clients)'s example

Then, I removed api key from default request. This is reserved for retires

# Player body

As reported in **_YouTube Internal Clients[#3](https://github.com/zerodytrash/YouTube-Internal-Clients/issues/3)_**. YouTube may request `androidSdkVersion`, `racyCheckOk`, as well as `contentCheckOk` in the body so I went a head and added them with default values

# Conclusion

**This is not a fix, just a workaround**. As I observed, it only reduce the chance of getting "LOGIN_REQUIRED" but I think the result is really biased. Thus, I need more feedback to draw real conclusion.

Also, this only prevent YouTube from blocking from accessing the song at the beginning. \
As far as my understanding, we are using Player with fetch song's stream by giving it the URL. \
This makes it harder to hack since we don't have control of the data stream. In order to workaround this, we need a new Player that can give us direct access to the data stream.

# What's next

I'm planing to do some rework with the response templates. Right now it's overwhelmed with nullable values.

My initial idea is that we return every request as an interface `Response`. Then we have classes like `ErrorResponse` or more specific `LoginRequiredResponse` etc. and `PayloadResponse` or `PlayerResponse`.

Each response only carries needed values and they are less likely to be null.

It's also easier to debug since we can check if Response falls into what category to take appropriate action