### PR TITLE
Fixes scrolling of long text

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/AlbumsItemGridMenu.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/AlbumsItemGridMenu.kt
@@ -74,7 +74,7 @@ fun AlbumsItemGridMenu(
     onPlayNext: (() -> Unit)? = null,
     onEnqueue: (() -> Unit)? = null,
     onAddToPlaylist: ((PlaylistPreview) -> Unit)? = null,
-
+    disableScrollingText: Boolean
 ) {
     val density = LocalDensity.current
 
@@ -260,7 +260,8 @@ fun AlbumsItemGridMenu(
                             album = album,
                             thumbnailSizePx = thumbnailSizePx,
                             thumbnailSizeDp = thumbnailSizeDp,
-                            yearCentered = false
+                            yearCentered = false,
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 ) {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/AlbumsItemMenu.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/AlbumsItemMenu.kt
@@ -77,6 +77,7 @@ fun AlbumsItemMenu(
     onPlayNext: (() -> Unit)? = null,
     onEnqueue: (() -> Unit)? = null,
     onAddToPlaylist: ((PlaylistPreview) -> Unit)? = null,
+    disableScrollingText: Boolean
 ) {
     val density = LocalDensity.current
 
@@ -104,7 +105,8 @@ fun AlbumsItemMenu(
             onDownloadAlbumCover = onDownloadAlbumCover,
             onPlayNext = onPlayNext,
             onEnqueue = onEnqueue,
-            onAddToPlaylist = onAddToPlaylist
+            onAddToPlaylist = onAddToPlaylist,
+            disableScrollingText = disableScrollingText
         )
     } else {
         AnimatedContent(
@@ -278,7 +280,8 @@ fun AlbumsItemMenu(
                             album = album,
                             thumbnailSizePx = thumbnailSizePx,
                             thumbnailSizeDp = thumbnailSizeDp,
-                            yearCentered = false
+                            yearCentered = false,
+                            disableScrollingText = disableScrollingText
                         )
 
                         /*

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/Header.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/Header.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -34,6 +35,7 @@ import it.fast4x.rimusic.enums.UiType
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.shimmer
 import it.fast4x.rimusic.utils.bold
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.medium
 import it.fast4x.rimusic.utils.semiBold
 import me.knighthat.colorPalette
@@ -45,6 +47,7 @@ fun Header(
     title: String,
     modifier: Modifier = Modifier,
     actionsContent: @Composable RowScope.() -> Unit = {},
+    disableScrollingText: Boolean
 ) {
     Header(
         modifier = modifier,
@@ -53,7 +56,8 @@ fun Header(
                 text = title,
                 style = typography().xxl.medium,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
             )
         },
         actionsContent = actionsContent

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/MediaItemGridMenu.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/MediaItemGridMenu.kt
@@ -105,6 +105,7 @@ fun NonQueuedMediaItemGridMenu(
     onHideFromDatabase: (() -> Unit)? = null,
     onRemoveFromQuickPicks: (() -> Unit)? = null,
     onDownload: (() -> Unit)? = null,
+    disableScrollingText: Boolean
 ) {
     val binder = LocalPlayerServiceBinder.current
     val context = LocalContext.current
@@ -129,7 +130,8 @@ fun NonQueuedMediaItemGridMenu(
         onRemoveFromPlaylist = onRemoveFromPlaylist,
         onHideFromDatabase = onHideFromDatabase,
         onRemoveFromQuickPicks = onRemoveFromQuickPicks,
-        modifier = modifier
+        modifier = modifier,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -153,6 +155,7 @@ fun BaseMediaItemGridMenu(
     onClosePlayer: (() -> Unit)? = null,
     onGoToPlaylist: ((Long) -> Unit)? = null,
     onAddToPreferites: (() -> Unit)? = null,
+    disableScrollingText: Boolean
 ) {
     //val context = LocalContext.current
 
@@ -213,7 +216,8 @@ fun BaseMediaItemGridMenu(
         onGoToPlaylist = {
             navController.navigate(route = "${NavRoutes.localPlaylist.name}/$it")
         },
-        modifier = modifier
+        modifier = modifier,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -224,8 +228,8 @@ fun MiniMediaItemGridMenu(
     mediaItem: MediaItem,
     onGoToPlaylist: ((Long) -> Unit)? = null,
     onAddToPreferites: (() -> Unit)? = null,
-
     modifier: Modifier = Modifier,
+    disableScrollingText: Boolean
 ) {
 
     MediaItemGridMenu(
@@ -252,7 +256,8 @@ fun MiniMediaItemGridMenu(
             }
         },
         onAddToPreferites = onAddToPreferites,
-        modifier = modifier
+        modifier = modifier,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -279,7 +284,8 @@ fun MediaItemGridMenu (
     onGoToAlbum: ((String) -> Unit)? = null,
     onGoToArtist: ((String) -> Unit)? = null,
     onRemoveFromQuickPicks: (() -> Unit)? = null,
-    onGoToPlaylist: ((Long) -> Unit)?
+    onGoToPlaylist: ((Long) -> Unit)?,
+    disableScrollingText: Boolean
 ) {
     val binder = LocalPlayerServiceBinder.current
     val uriHandler = LocalUriHandler.current
@@ -424,7 +430,8 @@ fun MediaItemGridMenu (
                 thumbnailSizeDp = thumbnailSizeDp,
                 modifier = Modifier
                     .weight(1f),
-                mediaId = mediaItem.mediaId
+                mediaId = mediaItem.mediaId,
+                disableScrollingText = disableScrollingText
             )
 
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/MediaItemMenu.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/MediaItemMenu.kt
@@ -130,7 +130,8 @@ fun InHistoryMediaItemMenu(
     song: Song,
     onHideFromDatabase: (() -> Unit)? = {},
     onDeleteFromDatabase: (() -> Unit)? = {},
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    disableScrollingText: Boolean
 ) {
     //val binder = LocalPlayerServiceBinder.current
 
@@ -166,7 +167,8 @@ fun InHistoryMediaItemMenu(
                 Database.like(song.id, System.currentTimeMillis())
             }
         },
-        modifier = modifier
+        modifier = modifier,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -181,7 +183,8 @@ fun InPlaylistMediaItemMenu(
     playlistId: Long,
     positionInPlaylist: Int,
     song: Song,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    disableScrollingText: Boolean
 ) {
     val isPipedEnabled by rememberPreference(isPipedEnabledKey, false)
     val coroutineScope = rememberCoroutineScope()
@@ -214,7 +217,8 @@ fun InPlaylistMediaItemMenu(
                 Database.like(song.id, System.currentTimeMillis())
             }
         },
-        modifier = modifier
+        modifier = modifier,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -230,6 +234,7 @@ fun NonQueuedMediaItemMenuLibrary(
     onRemoveFromPlaylist: (() -> Unit)? = null,
     onRemoveFromQuickPicks: (() -> Unit)? = null,
     onDownload: (() -> Unit)? = null,
+    disableScrollingText: Boolean
 ) {
     val binder = LocalPlayerServiceBinder.current
     val context = LocalContext.current
@@ -290,7 +295,8 @@ fun NonQueuedMediaItemMenuLibrary(
                     )
                 }
             },
-            modifier = modifier
+            modifier = modifier,
+            disableScrollingText = disableScrollingText
         )
     } else {
 
@@ -322,7 +328,8 @@ fun NonQueuedMediaItemMenuLibrary(
                     )
                 }
             },
-            modifier = modifier
+            modifier = modifier,
+            disableScrollingText = disableScrollingText
         )
     }
 }
@@ -341,7 +348,8 @@ fun NonQueuedMediaItemMenu(
     onDeleteFromDatabase: (() -> Unit)? = null,
     onRemoveFromQuickPicks: (() -> Unit)? = null,
     onDownload: (() -> Unit)? = null,
-    onAddToPreferites: (() -> Unit)? = null
+    onAddToPreferites: (() -> Unit)? = null,
+    disableScrollingText: Boolean
 ) {
     val binder = LocalPlayerServiceBinder.current
     val context = LocalContext.current
@@ -376,7 +384,8 @@ fun NonQueuedMediaItemMenu(
             onDeleteFromDatabase = onDeleteFromDatabase,
             onRemoveFromQuickPicks = onRemoveFromQuickPicks,
             onAddToPreferites = onAddToPreferites,
-            modifier = modifier
+            modifier = modifier,
+            disableScrollingText = disableScrollingText
         )
     } else {
 
@@ -402,7 +411,8 @@ fun NonQueuedMediaItemMenu(
             onDeleteFromDatabase = onDeleteFromDatabase,
             onRemoveFromQuickPicks = onRemoveFromQuickPicks,
             onAddToPreferites = onAddToPreferites,
-            modifier = modifier
+            modifier = modifier,
+            disableScrollingText = disableScrollingText
         )
     }
 }
@@ -417,7 +427,8 @@ fun QueuedMediaItemMenu(
     onDownload: (() -> Unit)?,
     mediaItem: MediaItem,
     indexInQueue: Int?,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    disableScrollingText: Boolean
 ) {
     val binder = LocalPlayerServiceBinder.current
     val context = LocalContext.current
@@ -459,6 +470,7 @@ fun QueuedMediaItemMenu(
                     )
                 }
             },
+            disableScrollingText = disableScrollingText
         )
     } else {
         BaseMediaItemMenu(
@@ -492,6 +504,7 @@ fun QueuedMediaItemMenu(
                     )
                 }
             },
+            disableScrollingText = disableScrollingText
         )
     }
 }
@@ -518,7 +531,8 @@ fun BaseMediaItemMenu(
     onRemoveFromQuickPicks: (() -> Unit)? = null,
     onClosePlayer: (() -> Unit)? = null,
     onGoToPlaylist: ((Long) -> Unit)? = null,
-    onAddToPreferites: (() -> Unit)?
+    onAddToPreferites: (() -> Unit)?,
+    disableScrollingText: Boolean
 ) {
     val context = LocalContext.current
 
@@ -597,7 +611,8 @@ fun BaseMediaItemMenu(
         onGoToPlaylist = {
             navController.navigate(route = "${NavRoutes.localPlaylist.name}/$it")
         },
-        modifier = modifier
+        modifier = modifier,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -612,6 +627,7 @@ fun MiniMediaItemMenu(
     onGoToPlaylist: ((Long) -> Unit)? = null,
     onAddToPreferites: (() -> Unit)?,
     modifier: Modifier = Modifier,
+    disableScrollingText: Boolean
 ) {
     val context = LocalContext.current
 
@@ -651,7 +667,8 @@ fun MiniMediaItemMenu(
             context.startActivity(Intent.createChooser(sendIntent, null))
         },
         onAddToPreferites = onAddToPreferites,
-        modifier = modifier
+        modifier = modifier,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -739,7 +756,8 @@ fun MediaItemMenu(
     onGoToArtist: ((String) -> Unit)? = null,
     onRemoveFromQuickPicks: (() -> Unit)? = null,
     onShare: () -> Unit,
-    onGoToPlaylist: ((Long) -> Unit)? = null
+    onGoToPlaylist: ((Long) -> Unit)? = null,
+    disableScrollingText: Boolean
 ) {
     val density = LocalDensity.current
 
@@ -1111,7 +1129,8 @@ fun MediaItemMenu(
                         thumbnailSizeDp = thumbnailSizeDp,
                         modifier = Modifier
                             .weight(1f),
-                        mediaId = mediaItem.mediaId
+                        mediaId = mediaItem.mediaId,
+                        disableScrollingText = disableScrollingText
                     )
 
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/MediaItemMenu.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/MediaItemMenu.kt
@@ -90,6 +90,7 @@ import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.addToPipedPlaylist
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.cleanPrefix
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.enqueue
 import it.fast4x.rimusic.utils.forcePlay
@@ -662,6 +663,7 @@ fun FolderItemMenu(
     thumbnailSizeDp: Dp,
     onDismiss: () -> Unit,
     onEnqueue: () -> Unit,
+    disableScrollingText: Boolean
 ) {
     val density = LocalDensity.current
 
@@ -691,7 +693,7 @@ fun FolderItemMenu(
             modifier = Modifier
                 .padding(end = 12.dp)
         ) {
-            FolderItem(folder, thumbnailSizeDp)
+            FolderItem(folder, thumbnailSizeDp, disableScrollingText = disableScrollingText)
 
         }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/PlayerMenu.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/PlayerMenu.kt
@@ -35,6 +35,7 @@ fun PlayerMenu(
     mediaItem: MediaItem,
     onDismiss: () -> Unit,
     onClosePlayer: () -> Unit,
+    disableScrollingText: Boolean
     ) {
 
     val menuStyle by rememberPreference(
@@ -106,7 +107,8 @@ fun PlayerMenu(
             },
              */
             onHideFromDatabase = { isHiding = true },
-            onClosePlayer = onClosePlayer
+            onClosePlayer = onClosePlayer,
+            disableScrollingText = disableScrollingText
         )
     } else {
         BaseMediaItemMenu(
@@ -129,7 +131,8 @@ fun PlayerMenu(
                     )
                 }
             },
-            onClosePlayer = onClosePlayer
+            onClosePlayer = onClosePlayer,
+            disableScrollingText = disableScrollingText
         )
     }
 
@@ -146,6 +149,7 @@ fun MiniPlayerMenu(
     mediaItem: MediaItem,
     onDismiss: () -> Unit,
     onClosePlayer: () -> Unit,
+    disableScrollingText: Boolean
 ) {
 
     val menuStyle by rememberPreference(
@@ -168,7 +172,8 @@ fun MiniPlayerMenu(
                     )
                 }
             },
-            onDismiss = onDismiss
+            onDismiss = onDismiss,
+            disableScrollingText = disableScrollingText
         )
     } else {
         MiniMediaItemMenu(
@@ -185,7 +190,8 @@ fun MiniPlayerMenu(
                     )
                 }
             },
-            onDismiss = onDismiss
+            onDismiss = onDismiss,
+            disableScrollingText = disableScrollingText
         )
     }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/Playlist.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/Playlist.kt
@@ -26,7 +26,8 @@ fun Playlist(
     thumbnailSizeDp: Dp,
     modifier: Modifier = Modifier,
     alternative: Boolean = false,
-    showName: Boolean = true
+    showName: Boolean = true,
+    disableScrollingText: Boolean
 ) {
     var songs by persistList<Song>("playlist${playlist.playlist.id}/songsThumbnails")
     LaunchedEffect(playlist.playlist.id) {
@@ -76,6 +77,7 @@ fun Playlist(
         thumbnailSizeDp = thumbnailSizeDp,
         modifier = modifier,
         alternative = alternative,
-        showName = showName
+        showName = showName,
+        disableScrollingText = disableScrollingText
     )
 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/PlaylistsItemGridMenu.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/PlaylistsItemGridMenu.kt
@@ -89,7 +89,8 @@ fun PlaylistsItemGridMenu(
     onListenToYT: (() -> Unit)? = null,
     onExport: (() -> Unit)? = null,
     onImport: (() -> Unit)? = null,
-    onGoToPlaylist: ((Long) -> Unit)? = null
+    onGoToPlaylist: ((Long) -> Unit)? = null,
+    disableScrollingText: Boolean
     ) {
     var isViewingPlaylists by remember {
         mutableStateOf(false)
@@ -316,7 +317,8 @@ fun PlaylistsItemGridMenu(
                             playlist = playlist,
                             thumbnailSizePx = thumbnailSizePx,
                             thumbnailSizeDp = thumbnailSizeDp,
-                            modifier = Modifier.height(90.dp)
+                            modifier = Modifier.height(90.dp),
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/PlaylistsItemMenu.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/PlaylistsItemMenu.kt
@@ -86,7 +86,8 @@ fun PlaylistsItemMenu(
     onListenToYT: (() -> Unit)? = null,
     onExport: (() -> Unit)? = null,
     onImport: (() -> Unit)? = null,
-    onGoToPlaylist: ((Long) -> Unit)? = null
+    onGoToPlaylist: ((Long) -> Unit)? = null,
+    disableScrollingText: Boolean
 ) {
     var isViewingPlaylists by remember {
         mutableStateOf(false)
@@ -122,7 +123,8 @@ fun PlaylistsItemMenu(
             onListenToYT = onListenToYT,
             onExport = onExport,
             onImport = onImport,
-            onGoToPlaylist = onGoToPlaylist
+            onGoToPlaylist = onGoToPlaylist,
+            disableScrollingText = disableScrollingText
         )
     } else {
 
@@ -339,7 +341,8 @@ fun PlaylistsItemMenu(
                             PlaylistItem(
                                 playlist = playlist,
                                 thumbnailSizePx = thumbnailSizePx,
-                                thumbnailSizeDp = thumbnailSizeDp
+                                thumbnailSizeDp = thumbnailSizeDp,
+                                disableScrollingText = disableScrollingText
                             )
                         }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/AlbumItem.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/AlbumItem.kt
@@ -20,6 +20,7 @@ import it.fast4x.rimusic.cleanPrefix
 import it.fast4x.rimusic.models.Album
 import it.fast4x.rimusic.ui.components.themed.TextPlaceholder
 import it.fast4x.rimusic.ui.styling.shimmer
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.secondary
 import it.fast4x.rimusic.utils.semiBold
 import it.fast4x.rimusic.utils.thumbnail
@@ -35,7 +36,8 @@ fun AlbumItem(
     modifier: Modifier = Modifier,
     alternative: Boolean = false,
     yearCentered: Boolean = true,
-    showAuthors: Boolean = false
+    showAuthors: Boolean = false,
+    disableScrollingText: Boolean
 ) {
     AlbumItem(
         thumbnailUrl = album.thumbnailUrl,
@@ -47,7 +49,8 @@ fun AlbumItem(
         thumbnailSizeDp = thumbnailSizeDp,
         alternative = alternative,
         showAuthors = showAuthors,
-        modifier = modifier
+        modifier = modifier,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -59,7 +62,8 @@ fun AlbumItem(
     modifier: Modifier = Modifier,
     alternative: Boolean = false,
     yearCentered: Boolean? = true,
-    showAuthors: Boolean? = false
+    showAuthors: Boolean? = false,
+    disableScrollingText: Boolean
 ) {
     AlbumItem(
         thumbnailUrl = album.thumbnail?.url,
@@ -70,7 +74,8 @@ fun AlbumItem(
         thumbnailSizePx = thumbnailSizePx,
         thumbnailSizeDp = thumbnailSizeDp,
         alternative = alternative,
-        modifier = modifier
+        modifier = modifier,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -85,7 +90,8 @@ fun AlbumItem(
     thumbnailSizeDp: Dp,
     modifier: Modifier = Modifier,
     alternative: Boolean = false,
-    showAuthors: Boolean? = false
+    showAuthors: Boolean? = false,
+    disableScrollingText: Boolean
 ) {
     ItemContainer(
         alternative = alternative,
@@ -109,7 +115,7 @@ fun AlbumItem(
                 maxLines = 1, //if (alternative) 1 else 2,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
-                    .basicMarquee(iterations = Int.MAX_VALUE)
+                    .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
             )
 
             if (!alternative || showAuthors == true) {
@@ -120,7 +126,7 @@ fun AlbumItem(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
-                            .basicMarquee(iterations = Int.MAX_VALUE)
+                            .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                             .align(
                                 if (yearCentered == true) Alignment.CenterHorizontally else Alignment.Start)
                     )

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/ArtistItem.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/ArtistItem.kt
@@ -20,6 +20,7 @@ import it.fast4x.innertube.Innertube
 import it.fast4x.rimusic.models.Artist
 import it.fast4x.rimusic.ui.components.themed.TextPlaceholder
 import it.fast4x.rimusic.ui.styling.shimmer
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.secondary
 import it.fast4x.rimusic.utils.semiBold
 import it.fast4x.rimusic.utils.thumbnail
@@ -34,7 +35,8 @@ fun ArtistItem(
     thumbnailSizeDp: Dp,
     modifier: Modifier = Modifier,
     alternative: Boolean = false,
-    showName: Boolean = true
+    showName: Boolean = true,
+    disableScrollingText: Boolean
 ) {
     ArtistItem(
         thumbnailUrl = artist.thumbnailUrl,
@@ -44,7 +46,8 @@ fun ArtistItem(
         thumbnailSizeDp = thumbnailSizeDp,
         modifier = modifier,
         alternative = alternative,
-        showName = showName
+        showName = showName,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -55,6 +58,7 @@ fun ArtistItem(
     thumbnailSizeDp: Dp,
     modifier: Modifier = Modifier,
     alternative: Boolean = false,
+    disableScrollingText: Boolean
 ) {
     ArtistItem(
         thumbnailUrl = artist.thumbnail?.url,
@@ -63,7 +67,8 @@ fun ArtistItem(
         thumbnailSizePx = thumbnailSizePx,
         thumbnailSizeDp = thumbnailSizeDp,
         modifier = modifier,
-        alternative = alternative
+        alternative = alternative,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -76,7 +81,8 @@ fun ArtistItem(
     thumbnailSizeDp: Dp,
     modifier: Modifier = Modifier,
     alternative: Boolean = false,
-    showName: Boolean = true
+    showName: Boolean = true,
+    disableScrollingText: Boolean
 ) {
     ItemContainer(
         alternative = alternative,
@@ -103,7 +109,7 @@ fun ArtistItem(
                 maxLines = 1, //if (alternative) 1 else 2,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
-                    .basicMarquee(iterations = Int.MAX_VALUE)
+                    .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
             )
 
             subscribersCount?.let {
@@ -114,7 +120,7 @@ fun ArtistItem(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier
                         .padding(top = 4.dp)
-                        .basicMarquee(iterations = Int.MAX_VALUE)
+                        .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                 )
             }
         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/FolderItem.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/FolderItem.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.UnstableApi
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.models.Folder
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.semiBold
 import me.knighthat.colorPalette
 import me.knighthat.typography
@@ -28,7 +29,8 @@ fun FolderItem(
     folder: Folder,
     thumbnailSizeDp: Dp,
     modifier: Modifier = Modifier,
-    icon: Int = R.drawable.folder
+    icon: Int = R.drawable.folder,
+    disableScrollingText: Boolean
 ) {
     ItemContainer(
         alternative = false,
@@ -58,7 +60,7 @@ fun FolderItem(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier
-                        .basicMarquee(iterations = Int.MAX_VALUE)
+                        .conditional(!disableScrollingText){ basicMarquee(iterations = Int.MAX_VALUE) }
                 )
             }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/PlaylistItem.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/PlaylistItem.kt
@@ -42,6 +42,7 @@ import it.fast4x.rimusic.ui.styling.overlay
 import it.fast4x.rimusic.ui.styling.shimmer
 import it.fast4x.rimusic.MONTHLY_PREFIX
 import it.fast4x.rimusic.utils.color
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.getTitleMonthlyPlaylist
 import it.fast4x.rimusic.utils.medium
 import it.fast4x.rimusic.utils.secondary
@@ -65,7 +66,8 @@ fun PlaylistItem(
     modifier: Modifier = Modifier,
     alternative: Boolean = false,
     showName: Boolean = true,
-    iconSize: Dp = 34.dp
+    iconSize: Dp = 34.dp,
+    disableScrollingText: Boolean
 ) {
     PlaylistItem(
         thumbnailContent = {
@@ -84,7 +86,8 @@ fun PlaylistItem(
         thumbnailSizeDp = thumbnailSizeDp,
         modifier = modifier,
         alternative = alternative,
-        showName = showName
+        showName = showName,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -95,7 +98,8 @@ fun PlaylistItem(
     thumbnailSizeDp: Dp,
     modifier: Modifier = Modifier,
     alternative: Boolean = false,
-    showName: Boolean = true
+    showName: Boolean = true,
+    disableScrollingText: Boolean
 ) {
     val thumbnails by remember {
         Database.playlistThumbnailUrls(playlist.playlist.id).distinctUntilChanged().map {
@@ -157,7 +161,8 @@ fun PlaylistItem(
         thumbnailSizeDp = thumbnailSizeDp,
         modifier = modifier,
         alternative = alternative,
-        showName = showName
+        showName = showName,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -168,7 +173,8 @@ fun PlaylistItem(
     thumbnailSizeDp: Dp,
     modifier: Modifier = Modifier,
     alternative: Boolean = false,
-    showSongsCount: Boolean = true
+    showSongsCount: Boolean = true,
+    disableScrollingText: Boolean
 ) {
     PlaylistItem(
         thumbnailUrl = playlist.thumbnail?.url,
@@ -179,7 +185,8 @@ fun PlaylistItem(
         thumbnailSizePx = thumbnailSizePx,
         thumbnailSizeDp = thumbnailSizeDp,
         modifier = modifier,
-        alternative = alternative
+        alternative = alternative,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -193,7 +200,8 @@ fun PlaylistItem(
     thumbnailSizeDp: Dp,
     modifier: Modifier = Modifier,
     alternative: Boolean = false,
-    showSongsCount: Boolean = true
+    showSongsCount: Boolean = true,
+    disableScrollingText: Boolean
 ) {
     PlaylistItem(
         thumbnailContent = {
@@ -210,6 +218,7 @@ fun PlaylistItem(
         thumbnailSizeDp = thumbnailSizeDp,
         modifier = modifier,
         alternative = alternative,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -225,7 +234,8 @@ fun PlaylistItem(
     modifier: Modifier = Modifier,
     alternative: Boolean = false,
     showName: Boolean = true,
-    showSongsCount: Boolean = true
+    showSongsCount: Boolean = true,
+    disableScrollingText: Boolean
 ) {
     ItemContainer(
         alternative = alternative,
@@ -320,7 +330,7 @@ fun PlaylistItem(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
-                            .basicMarquee(iterations = Int.MAX_VALUE)
+                            .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                     )
                 }
 
@@ -331,7 +341,7 @@ fun PlaylistItem(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier
-                        .basicMarquee(iterations = Int.MAX_VALUE)
+                        .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                 )
             }
         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/SongItem.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/SongItem.kt
@@ -47,6 +47,7 @@ import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.ui.styling.shimmer
 import it.fast4x.rimusic.cleanPrefix
 import it.fast4x.rimusic.utils.asSong
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.getLikeState
 import it.fast4x.rimusic.utils.medium
 import it.fast4x.rimusic.utils.playlistindicatorKey
@@ -74,7 +75,8 @@ fun SongItem(
     isDownloaded: Boolean,
     onDownloadClick: () -> Unit,
     downloadState: Int,
-    thumbnailContent: (@Composable BoxScope.() -> Unit)? = null
+    thumbnailContent: (@Composable BoxScope.() -> Unit)? = null,
+    disableScrollingText: Boolean
 ) {
     SongItem(
         thumbnailUrl = song.thumbnail?.size(thumbnailSizePx),
@@ -93,7 +95,8 @@ fun SongItem(
         downloadState = downloadState,
         isExplicit = song.explicit,
         mediaId = song.key,
-        onThumbnailContent = thumbnailContent
+        onThumbnailContent = thumbnailContent,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -110,7 +113,8 @@ fun SongItem(
     onDownloadClick: () -> Unit,
     downloadState: Int,
     isRecommended: Boolean = false,
-    duration: String? = ""
+    duration: String? = "",
+    disableScrollingText: Boolean
 ) {
     SongItem(
         thumbnailUrl = song.mediaMetadata.artworkUri.thumbnail(thumbnailSizePx)?.toString(),
@@ -130,7 +134,8 @@ fun SongItem(
         },
         downloadState = downloadState,
         isRecommended = isRecommended,
-        mediaId = song.mediaId
+        mediaId = song.mediaId,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -145,7 +150,8 @@ fun SongItem(
     trailingContent: (@Composable () -> Unit)? = null,
     isDownloaded: Boolean,
     onDownloadClick: () -> Unit,
-    downloadState: Int
+    downloadState: Int,
+    disableScrollingText: Boolean
 ) {
     SongItem(
         thumbnailUrl = song.thumbnailUrl?.thumbnail(thumbnailSizePx),
@@ -165,7 +171,8 @@ fun SongItem(
             onDownloadClick()
         },
         downloadState = downloadState,
-        mediaId = song.id
+        mediaId = song.id,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -186,7 +193,8 @@ fun SongItem(
     downloadState: Int,
     isRecommended: Boolean = false,
     isExplicit: Boolean = false,
-    mediaId: String
+    mediaId: String,
+    disableScrollingText: Boolean
 ) {
     SongItem(
         title = title,
@@ -213,7 +221,8 @@ fun SongItem(
         downloadState = downloadState,
         isRecommended = isRecommended,
         isExplicit = isExplicit,
-        mediaId = mediaId
+        mediaId = mediaId,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -227,7 +236,8 @@ fun SongItem(
     modifier: Modifier = Modifier,
     trailingContent: @Composable (() -> Unit)? = null,
     isDownloaded: Boolean,
-    onDownloadClick: () -> Unit
+    onDownloadClick: () -> Unit,
+    disableScrollingText: Boolean
 ) {
     ItemContainer(
         alternative = false,
@@ -251,7 +261,7 @@ fun SongItem(
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
                             .weight(1f)
-                            .basicMarquee(iterations = Int.MAX_VALUE)
+                            .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                     )
 
                     it()
@@ -262,7 +272,7 @@ fun SongItem(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
-                    .basicMarquee(iterations = Int.MAX_VALUE)
+                    .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
             )
 
 
@@ -285,7 +295,7 @@ fun SongItem(
                     overflow = TextOverflow.Clip,
                     modifier = Modifier
                         .weight(1f)
-                        .basicMarquee(iterations = Int.MAX_VALUE)
+                        .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                 )
 
                 duration?.let {
@@ -320,7 +330,8 @@ fun SongItem(
     downloadState: Int,
     isRecommended: Boolean = false,
     isExplicit: Boolean = false,
-    mediaId: String
+    mediaId: String,
+    disableScrollingText: Boolean
 ) {
     var songPlaylist by remember {
         mutableStateOf(0)
@@ -448,7 +459,7 @@ fun SongItem(
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
                             .weight(1f)
-                            .basicMarquee(iterations = Int.MAX_VALUE)
+                            .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                     )
 
                     /*
@@ -497,7 +508,7 @@ fun SongItem(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
-                            .basicMarquee(iterations = Int.MAX_VALUE)
+                            .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                             .weight(1f)
                     )
                 if (playlistindicator && (songPlaylist > 0)) {
@@ -582,7 +593,7 @@ fun SongItem(
                     overflow = TextOverflow.Clip,
                     modifier = Modifier
                         .weight(1f)
-                        .basicMarquee(iterations = Int.MAX_VALUE)
+                        .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                 )
 
                 duration?.let {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/VideoItem.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/VideoItem.kt
@@ -23,6 +23,7 @@ import it.fast4x.rimusic.ui.styling.onOverlay
 import it.fast4x.rimusic.ui.styling.overlay
 import it.fast4x.rimusic.ui.styling.shimmer
 import it.fast4x.rimusic.utils.color
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.medium
 import it.fast4x.rimusic.utils.secondary
 import it.fast4x.rimusic.utils.semiBold
@@ -35,7 +36,8 @@ fun VideoItem(
     video: Innertube.VideoItem,
     thumbnailHeightDp: Dp,
     thumbnailWidthDp: Dp,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    disableScrollingText: Boolean
 ) {
     VideoItem(
         thumbnailUrl = video.thumbnail?.url,
@@ -45,7 +47,8 @@ fun VideoItem(
         views = video.viewsText,
         thumbnailHeightDp = thumbnailHeightDp,
         thumbnailWidthDp = thumbnailWidthDp,
-        modifier = modifier
+        modifier = modifier,
+        disableScrollingText = disableScrollingText
     )
 }
 
@@ -58,7 +61,8 @@ fun VideoItem(
     views: String?,
     thumbnailHeightDp: Dp,
     thumbnailWidthDp: Dp,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    disableScrollingText: Boolean
 ) {
     ItemContainer(
         alternative = false,
@@ -83,7 +87,10 @@ fun VideoItem(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier
                         .padding(all = 4.dp)
-                        .background(color = colorPalette().overlay, shape = RoundedCornerShape(2.dp))
+                        .background(
+                            color = colorPalette().overlay,
+                            shape = RoundedCornerShape(2.dp)
+                        )
                         .padding(horizontal = 4.dp, vertical = 2.dp)
                         .align(Alignment.BottomEnd)
                 )
@@ -97,7 +104,7 @@ fun VideoItem(
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
-                    .basicMarquee(iterations = Int.MAX_VALUE)
+                    .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
             )
 
             BasicText(
@@ -106,7 +113,7 @@ fun VideoItem(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
-                    .basicMarquee(iterations = Int.MAX_VALUE)
+                    .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
             )
 
             views?.let {
@@ -117,7 +124,7 @@ fun VideoItem(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier
                         .padding(top = 4.dp)
-                        .basicMarquee(iterations = Int.MAX_VALUE)
+                        .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                 )
             }
         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumDetailsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumDetailsModern.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -105,6 +106,7 @@ import it.fast4x.rimusic.utils.align
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.center
 import it.fast4x.rimusic.utils.color
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.durationTextToMillis
@@ -508,6 +510,7 @@ fun AlbumDetailsModern(
                                 modifier = Modifier
                                     .align(Alignment.BottomCenter)
                                     .padding(horizontal = 30.dp)
+                                    .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                                 //.padding(bottom = 20.dp)
                             )
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumDetailsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumDetailsModern.kt
@@ -980,6 +980,7 @@ fun AlbumDetailsModern(
                                                 navController = navController,
                                                 onDismiss = menuState::hide,
                                                 mediaItem = song.asMediaItem,
+                                                disableScrollingText = disableScrollingText
                                             )
                                         };
                                         hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -1014,7 +1015,8 @@ fun AlbumDetailsModern(
                                     )
                                 else checkedState.value = false
                             },
-                            mediaId = song.asMediaItem.mediaId
+                            mediaId = song.asMediaItem.mediaId,
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumDetailsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumDetailsModern.kt
@@ -105,6 +105,7 @@ import it.fast4x.rimusic.utils.align
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.center
 import it.fast4x.rimusic.utils.color
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.durationTextToMillis
 import it.fast4x.rimusic.utils.enqueue
@@ -155,6 +156,7 @@ fun AlbumDetailsModern(
     var album by persist<Album?>("album/$browseId")
     //val albumPage by persist<Innertube.PlaylistOrAlbumPage?>("album/$browseId/albumPage")
     val parentalControlEnabled by rememberPreference(parentalControlEnabledKey, false)
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     LaunchedEffect(Unit) {
         Database.albumSongs(browseId).collect {
@@ -880,6 +882,7 @@ fun AlbumDetailsModern(
                                                     selectItems = false
                                                 }
                                             },
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
                                 }
@@ -1055,7 +1058,8 @@ fun AlbumDetailsModern(
                                     .clickable {
                                         //albumRoute(album.key)
                                         navController.navigate(route = "${NavRoutes.album.name}/${album.key}")
-                                    }
+                                    },
+                                disableScrollingText = disableScrollingText
                             )
                         },
                         itemPlaceholderContent = {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreen.kt
@@ -185,56 +185,57 @@ fun AlbumScreen(
                         Header(
                             //title = album?.title ?: "Unknown"
                             title = "",
-                            modifier = Modifier.padding(horizontal = 12.dp)
-                        ) {
-                            textButton?.invoke()
+                            modifier = Modifier.padding(horizontal = 12.dp),
+                            actionsContent = {
+                                textButton?.invoke()
 
+                                Spacer(
+                                    modifier = Modifier
+                                        .weight(1f)
+                                )
 
-                            Spacer(
-                                modifier = Modifier
-                                    .weight(1f)
-                            )
+                                HeaderIconButton(
+                                    icon = if (album?.bookmarkedAt == null) {
+                                        R.drawable.bookmark_outline
+                                    } else {
+                                        R.drawable.bookmark
+                                    },
+                                    color = colorPalette().accent,
+                                    onClick = {
+                                        val bookmarkedAt =
+                                            if (album?.bookmarkedAt == null) System.currentTimeMillis() else null
 
-                            HeaderIconButton(
-                                icon = if (album?.bookmarkedAt == null) {
-                                    R.drawable.bookmark_outline
-                                } else {
-                                    R.drawable.bookmark
-                                },
-                                color = colorPalette().accent,
-                                onClick = {
-                                    val bookmarkedAt =
-                                        if (album?.bookmarkedAt == null) System.currentTimeMillis() else null
-
-                                    query {
-                                        album
-                                            ?.copy(bookmarkedAt = bookmarkedAt)
-                                            ?.let(Database::update)
-                                    }
-                                }
-                            )
-
-                            HeaderIconButton(
-                                icon = R.drawable.share_social,
-                                color = colorPalette().text,
-                                onClick = {
-                                    album?.shareUrl?.let { url ->
-                                        val sendIntent = Intent().apply {
-                                            action = Intent.ACTION_SEND
-                                            type = "text/plain"
-                                            putExtra(Intent.EXTRA_TEXT, url)
+                                        query {
+                                            album
+                                                ?.copy(bookmarkedAt = bookmarkedAt)
+                                                ?.let(Database::update)
                                         }
-
-                                        context.startActivity(
-                                            Intent.createChooser(
-                                                sendIntent,
-                                                null
-                                            )
-                                        )
                                     }
-                                }
-                            )
-                        }
+                                )
+
+                                HeaderIconButton(
+                                    icon = R.drawable.share_social,
+                                    color = colorPalette().text,
+                                    onClick = {
+                                        album?.shareUrl?.let { url ->
+                                            val sendIntent = Intent().apply {
+                                                action = Intent.ACTION_SEND
+                                                type = "text/plain"
+                                                putExtra(Intent.EXTRA_TEXT, url)
+                                            }
+
+                                            context.startActivity(
+                                                Intent.createChooser(
+                                                    sendIntent,
+                                                    null
+                                                )
+                                            )
+                                        }
+                                    }
+                                )
+                            },
+                            disableScrollingText = disableScrollingText
+                        )
                     }
                 }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreen.kt
@@ -53,6 +53,7 @@ import it.fast4x.rimusic.ui.screens.globalRoutes
 import it.fast4x.rimusic.ui.screens.searchresult.ItemsPage
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.asMediaItem
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.thumbnailRoundnessKey
 import kotlinx.coroutines.Dispatchers
@@ -92,6 +93,7 @@ fun AlbumScreen(
     var album by persist<Album?>("album/$browseId/album")
     var albumPage by persist<Innertube.PlaylistOrAlbumPage?>("album/$browseId/albumPage")
 
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     PersistMapCleanup(tagPrefix = "album/$browseId/")
 
@@ -317,7 +319,8 @@ fun AlbumScreen(
                                             .clickable {
                                                 //albumRoute(album.key)
                                                 navController.navigate(route = "${NavRoutes.album.name}/${album.key}")
-                                            }
+                                            },
+                                        disableScrollingText = disableScrollingText
                                     )
                                 },
                                 itemPlaceholderContent = {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreenWithoutNavBar.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreenWithoutNavBar.kt
@@ -214,56 +214,58 @@ fun AlbumScreenWithoutNavBar(
                         Header(
                             //title = album?.title ?: "Unknown"
                             title = "",
-                            modifier = Modifier.padding(horizontal = 12.dp)
-                        ) {
-                            textButton?.invoke()
+                            modifier = Modifier.padding(horizontal = 12.dp),
+                            actionsContent = {
+                                textButton?.invoke()
 
 
-                            Spacer(
-                                modifier = Modifier
-                                    .weight(1f)
-                            )
+                                Spacer(
+                                    modifier = Modifier
+                                        .weight(1f)
+                                )
 
-                            HeaderIconButton(
-                                icon = if (album?.bookmarkedAt == null) {
-                                    R.drawable.bookmark_outline
-                                } else {
-                                    R.drawable.bookmark
-                                },
-                                color = colorPalette().accent,
-                                onClick = {
-                                    val bookmarkedAt =
-                                        if (album?.bookmarkedAt == null) System.currentTimeMillis() else null
+                                HeaderIconButton(
+                                    icon = if (album?.bookmarkedAt == null) {
+                                        R.drawable.bookmark_outline
+                                    } else {
+                                        R.drawable.bookmark
+                                    },
+                                    color = colorPalette().accent,
+                                    onClick = {
+                                        val bookmarkedAt =
+                                            if (album?.bookmarkedAt == null) System.currentTimeMillis() else null
 
-                                    query {
-                                        album
-                                            ?.copy(bookmarkedAt = bookmarkedAt)
-                                            ?.let(Database::update)
-                                    }
-                                }
-                            )
-
-                            HeaderIconButton(
-                                icon = R.drawable.share_social,
-                                color = colorPalette().text,
-                                onClick = {
-                                    album?.shareUrl?.let { url ->
-                                        val sendIntent = Intent().apply {
-                                            action = Intent.ACTION_SEND
-                                            type = "text/plain"
-                                            putExtra(Intent.EXTRA_TEXT, url)
+                                        query {
+                                            album
+                                                ?.copy(bookmarkedAt = bookmarkedAt)
+                                                ?.let(Database::update)
                                         }
-
-                                        context.startActivity(
-                                            Intent.createChooser(
-                                                sendIntent,
-                                                null
-                                            )
-                                        )
                                     }
-                                }
-                            )
-                        }
+                                )
+
+                                HeaderIconButton(
+                                    icon = R.drawable.share_social,
+                                    color = colorPalette().text,
+                                    onClick = {
+                                        album?.shareUrl?.let { url ->
+                                            val sendIntent = Intent().apply {
+                                                action = Intent.ACTION_SEND
+                                                type = "text/plain"
+                                                putExtra(Intent.EXTRA_TEXT, url)
+                                            }
+
+                                            context.startActivity(
+                                                Intent.createChooser(
+                                                    sendIntent,
+                                                    null
+                                                )
+                                            )
+                                        }
+                                    }
+                                )
+                            },
+                            disableScrollingText = disableScrollingText
+                        )
                     }
                 }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreenWithoutNavBar.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreenWithoutNavBar.kt
@@ -78,6 +78,7 @@ import it.fast4x.rimusic.ui.screens.globalRoutes
 import it.fast4x.rimusic.ui.screens.searchresult.ItemsPage
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.asMediaItem
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.playerPositionKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.thumbnailRoundnessKey
@@ -121,6 +122,7 @@ fun AlbumScreenWithoutNavBar(
     var album by persist<Album?>("album/$browseId/album")
     var albumPage by persist<Innertube.PlaylistOrAlbumPage?>("album/$browseId/albumPage")
 
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     PersistMapCleanup(tagPrefix = "album/$browseId/")
 
@@ -412,7 +414,8 @@ fun AlbumScreenWithoutNavBar(
                                                         .clickable {
                                                             //albumRoute(album.key)
                                                             navController.navigate(route = "${NavRoutes.album.name}/${album.key}")
-                                                        }
+                                                        },
+                                                    disableScrollingText = disableScrollingText
                                                 )
                                             },
                                             itemPlaceholderContent = {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreenWithoutScaffold.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreenWithoutScaffold.kt
@@ -221,7 +221,8 @@ fun AlbumScreenWithoutScaffold(
                     } else {
                         val context = LocalContext.current
 
-                        Header(title = album?.title ?: "Unknown") {
+                        Header(title = album?.title ?: "Unknown",
+                            actionsContent = {
 
                             if ( NavigationBarPosition.Left.isCurrent() || NavigationBarPosition.Top.isCurrent() ) {
                                 IconButton(
@@ -242,17 +243,17 @@ fun AlbumScreenWithoutScaffold(
                                 modifier = Modifier
                                     .weight(1f)
                             )
-/*
-                            HeaderIconButton(
-                                icon = R.drawable.image,
-                                enabled = album?.thumbnailUrl?.isNotEmpty() == true,
-                                color = if (album?.thumbnailUrl?.isNotEmpty() == true) colorPalette.text else colorPalette.textDisabled,
-                                onClick = {
-                                    if (album?.thumbnailUrl?.isNotEmpty() == true)
-                                        uriHandler.openUri(album?.thumbnailUrl.toString())
-                                    }
-                            )
- */
+                            /*
+                                                        HeaderIconButton(
+                                                            icon = R.drawable.image,
+                                                            enabled = album?.thumbnailUrl?.isNotEmpty() == true,
+                                                            color = if (album?.thumbnailUrl?.isNotEmpty() == true) colorPalette.text else colorPalette.textDisabled,
+                                                            onClick = {
+                                                                if (album?.thumbnailUrl?.isNotEmpty() == true)
+                                                                    uriHandler.openUri(album?.thumbnailUrl.toString())
+                                                                }
+                                                        )
+                             */
 
 
 
@@ -306,7 +307,8 @@ fun AlbumScreenWithoutScaffold(
                                         .size(24.dp)
                                 )
                             }
-                        }
+                        },
+                            disableScrollingText = disableScrollingText)
                     }
                 }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreenWithoutScaffold.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumScreenWithoutScaffold.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.UnstableApi
 import androidx.navigation.NavController
 import com.valentinilk.shimmer.shimmer
+import io.ktor.util.valuesOf
 import it.fast4x.compose.persist.PersistMapCleanup
 import it.fast4x.compose.persist.persist
 import it.fast4x.compose.routing.RouteHandler
@@ -61,6 +62,7 @@ import it.fast4x.rimusic.ui.screens.settingsRoute
 import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.asMediaItem
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.pauseSearchHistoryKey
 import it.fast4x.rimusic.utils.preferences
 import it.fast4x.rimusic.utils.rememberPreference
@@ -104,6 +106,8 @@ fun AlbumScreenWithoutScaffold(
     var changeShape by remember {
         mutableStateOf(false)
     }
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     PersistMapCleanup(tagPrefix = "album/$browseId/")
 
@@ -355,7 +359,8 @@ fun AlbumScreenWithoutScaffold(
                                 thumbnailSizePx = thumbnailSizePx,
                                 thumbnailSizeDp = thumbnailSizeDp,
                                 modifier = Modifier
-                                    .clickable { albumRoute(album.key) }
+                                    .clickable { albumRoute(album.key) },
+                                disableScrollingText = disableScrollingText
                             )
                         },
                         itemPlaceholderContent = {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumSongs.kt
@@ -756,6 +756,7 @@ fun AlbumSongs(
                                                         navController = navController,
                                                         onDismiss = menuState::hide,
                                                         mediaItem = song.asMediaItem,
+                                                        disableScrollingText = disableScrollingText
                                                     )
                                                 }
                                             },
@@ -787,7 +788,8 @@ fun AlbumSongs(
                                             )
                                         else checkedState.value = false
                                     },
-                                    mediaId = song.asMediaItem.mediaId
+                                    mediaId = song.asMediaItem.mediaId,
+                                    disableScrollingText = disableScrollingText
                                 )
                             }
                         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/album/AlbumSongs.kt
@@ -90,6 +90,7 @@ import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.center
 import it.fast4x.rimusic.utils.color
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.durationTextToMillis
 import it.fast4x.rimusic.utils.enqueue
@@ -130,6 +131,7 @@ fun AlbumSongs(
     var album by persist<Album?>("album/$browseId")
 
     val parentalControlEnabled by rememberPreference(parentalControlEnabledKey, false)
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     LaunchedEffect(Unit) {
         Database.albumSongs(browseId).collect {
@@ -635,6 +637,7 @@ fun AlbumSongs(
                                                             selectItems = false
                                                         }
                                                     },
+                                                    disableScrollingText = disableScrollingText
                                                 )
                                             }
                                         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistLocalSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistLocalSongs.kt
@@ -49,6 +49,7 @@ import it.fast4x.rimusic.ui.items.SongItemPlaceholder
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.asMediaItem
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.enqueue
 import it.fast4x.rimusic.utils.forcePlayAtIndex
@@ -83,6 +84,8 @@ fun ArtistLocalSongs(
     }
 
     val context = LocalContext.current
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     LaunchedEffect(Unit) {
         Database.artistSongs(browseId).collect { songs = it }
@@ -315,6 +318,7 @@ fun ArtistLocalSongs(
                                                 navController = navController,
                                                 onDismiss = menuState::hide,
                                                 mediaItem = song.asMediaItem,
+                                                disableScrollingText = disableScrollingText
                                             )
                                         }
                                     },
@@ -325,7 +329,8 @@ fun ArtistLocalSongs(
                                             index
                                         )
                                     }
-                                )
+                                ),
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 } ?: item(key = "loading") {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
@@ -568,6 +568,7 @@ fun ArtistOverviewModern(
                                                         navController = navController,
                                                         onDismiss = menuState::hide,
                                                         mediaItem = song.asMediaItem,
+                                                        disableScrollingText = disableScrollingText
                                                     )
                                                 };
                                                 hapticFeedback.performHapticFeedback(
@@ -590,7 +591,8 @@ fun ArtistOverviewModern(
                                              */
                                             }
                                         )
-                                        .padding(endPaddingValues)
+                                        .padding(endPaddingValues),
+                                    disableScrollingText = disableScrollingText
                                 )
                             }
                         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
@@ -137,6 +137,7 @@ fun ArtistOverviewModern(
     onSettingsClick: () -> Unit,
     thumbnailContent: @Composable () -> Unit,
     headerContent: @Composable (textButton: (@Composable () -> Unit)?) -> Unit,
+    disableScrollingText: Boolean
 ) {
     val binder = LocalPlayerServiceBinder.current
     val menuState = LocalMenuState.current
@@ -690,7 +691,8 @@ fun ArtistOverviewModern(
                                     thumbnailSizeDp = albumThumbnailSizeDp,
                                     alternative = true,
                                     modifier = Modifier
-                                        .clickable(onClick = { onAlbumClick(album.key) })
+                                        .clickable(onClick = { onAlbumClick(album.key) }),
+                                    disableScrollingText = disableScrollingText
                                 )
                             }
                         }
@@ -745,7 +747,8 @@ fun ArtistOverviewModern(
                                     thumbnailSizeDp = albumThumbnailSizeDp,
                                     alternative = true,
                                     modifier = Modifier
-                                        .clickable(onClick = { onAlbumClick(album.key) })
+                                        .clickable(onClick = { onAlbumClick(album.key) }),
+                                    disableScrollingText = disableScrollingText
                                 )
                             }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -93,6 +94,7 @@ import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.align
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.color
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.enqueue
 import it.fast4x.rimusic.utils.fadingEdge
@@ -252,6 +254,7 @@ fun ArtistOverviewModern(
                             modifier = Modifier
                                 .align(Alignment.BottomCenter)
                                 .padding(horizontal = 30.dp)
+                                .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE)}
                                 //.padding(bottom = 5.dp)
                         )
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistOverviewModern.kt
@@ -629,7 +629,8 @@ fun ArtistOverviewModern(
                                     thumbnailSizeDp = albumThumbnailSizeDp,
                                     alternative = true,
                                     modifier = Modifier
-                                        .clickable(onClick = { onPlaylistClick(playlist.key) })
+                                        .clickable(onClick = { onPlaylistClick(playlist.key) }),
+                                    disableScrollingText = disableScrollingText
                                 )
                             }
                         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
@@ -528,6 +528,7 @@ fun ArtistScreen(
                                                                 navController = navController,
                                                                 onDismiss = menuState::hide,
                                                                 mediaItem = song.asMediaItem,
+                                                                disableScrollingText = disableScrollingText
                                                             )
                                                         };
                                                         hapticFeedback.performHapticFeedback(
@@ -547,7 +548,8 @@ fun ArtistScreen(
                                                     binder?.setupRadio(song.info?.endpoint)
                                                      */
                                                     }
-                                                )
+                                                ),
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
                                 },

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
@@ -221,26 +221,46 @@ fun ArtistScreen(
                     } else {
                         val context = LocalContext.current
 
-                        Header(title = artist?.name ?: "Unknown") {
-
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier
-                                    .padding(top = 50.dp)
-                                    .padding(horizontal = 12.dp)
-                            ) {
-                                textButton?.invoke()
-
-                                Spacer(
+                        Header(title = artist?.name ?: "Unknown", actionsContent = {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
                                     modifier = Modifier
-                                        .weight(0.2f)
-                                )
+                                        .padding(top = 50.dp)
+                                        .padding(horizontal = 12.dp)
+                                ) {
+                                    textButton?.invoke()
 
-                                SecondaryTextButton(
-                                    text = if (artist?.bookmarkedAt == null) stringResource(R.string.follow) else stringResource(
-                                        R.string.following
-                                    ),
+                                    Spacer(
+                                        modifier = Modifier
+                                            .weight(0.2f)
+                                    )
+
+                                    SecondaryTextButton(
+                                        text = if (artist?.bookmarkedAt == null) stringResource(R.string.follow) else stringResource(
+                                            R.string.following
+                                        ),
+                                        onClick = {
+                                            val bookmarkedAt =
+                                                if (artist?.bookmarkedAt == null) System.currentTimeMillis() else null
+
+                                            query {
+                                                artist
+                                                    ?.copy(bookmarkedAt = bookmarkedAt)
+                                                    ?.let(Database::update)
+                                            }
+                                        },
+                                        alternative = artist?.bookmarkedAt == null
+                                    )
+
+                                    /*
+                                HeaderIconButton(
+                                    icon = if (artist?.bookmarkedAt == null) {
+                                        R.drawable.bookmark_outline
+                                    } else {
+                                        R.drawable.bookmark
+                                    },
+                                    color = colorPalette.accent,
                                     onClick = {
                                         val bookmarkedAt =
                                             if (artist?.bookmarkedAt == null) System.currentTimeMillis() else null
@@ -250,54 +270,34 @@ fun ArtistScreen(
                                                 ?.copy(bookmarkedAt = bookmarkedAt)
                                                 ?.let(Database::update)
                                         }
-                                    },
-                                    alternative = artist?.bookmarkedAt == null
-                                )
-
-                                /*
-                            HeaderIconButton(
-                                icon = if (artist?.bookmarkedAt == null) {
-                                    R.drawable.bookmark_outline
-                                } else {
-                                    R.drawable.bookmark
-                                },
-                                color = colorPalette.accent,
-                                onClick = {
-                                    val bookmarkedAt =
-                                        if (artist?.bookmarkedAt == null) System.currentTimeMillis() else null
-
-                                    query {
-                                        artist
-                                            ?.copy(bookmarkedAt = bookmarkedAt)
-                                            ?.let(Database::update)
                                     }
-                                }
-                            )
-                             */
+                                )
+                                 */
 
-                                HeaderIconButton(
-                                    icon = R.drawable.share_social,
-                                    color = colorPalette().text,
-                                    onClick = {
-                                        val sendIntent = Intent().apply {
-                                            action = Intent.ACTION_SEND
-                                            type = "text/plain"
-                                            putExtra(
-                                                Intent.EXTRA_TEXT,
-                                                "https://music.youtube.com/channel/$browseId"
+                                    HeaderIconButton(
+                                        icon = R.drawable.share_social,
+                                        color = colorPalette().text,
+                                        onClick = {
+                                            val sendIntent = Intent().apply {
+                                                action = Intent.ACTION_SEND
+                                                type = "text/plain"
+                                                putExtra(
+                                                    Intent.EXTRA_TEXT,
+                                                    "https://music.youtube.com/channel/$browseId"
+                                                )
+                                            }
+
+                                            context.startActivity(
+                                                Intent.createChooser(
+                                                    sendIntent,
+                                                    null
+                                                )
                                             )
                                         }
-
-                                        context.startActivity(
-                                            Intent.createChooser(
-                                                sendIntent,
-                                                null
-                                            )
-                                        )
-                                    }
-                                )
-                            }
-                        }
+                                    )
+                                }
+                            },
+                            disableScrollingText = disableScrollingText)
                     }
                 }
 
@@ -311,7 +311,8 @@ fun ArtistScreen(
                     } else {
                         val context = LocalContext.current
 
-                        Header(title = artist?.name ?: "Unknown") {
+                        Header(title = artist?.name ?: "Unknown",
+                            actionsContent = {
                             textButton?.invoke()
 
 
@@ -392,7 +393,8 @@ fun ArtistScreen(
                                     context.startActivity(Intent.createChooser(sendIntent, null))
                                 }
                             )
-                        }
+                        },
+                            disableScrollingText = disableScrollingText)
                     }
                 }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
@@ -71,6 +71,7 @@ import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.asMediaItem
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.enqueue
 import it.fast4x.rimusic.utils.forcePlayAtIndex
@@ -128,6 +129,8 @@ fun ArtistScreen(
     }
     val hapticFeedback = LocalHapticFeedback.current
     val parentalControlEnabled by rememberPreference(parentalControlEnabledKey, false)
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     LaunchedEffect(Unit) {
         Database
@@ -438,7 +441,8 @@ fun ArtistScreen(
                                 },
                                 onSettingsClick = {
                                     navController.navigate(NavRoutes.settings.name)
-                                }
+                                },
+                                disableScrollingText = disableScrollingText
                             )
                         }
 
@@ -598,7 +602,8 @@ fun ArtistScreen(
                                                 //albumRoute(album.key)
                                                 navController.navigate(route = "${NavRoutes.album.name}/${album.key}")
                                             }),
-                                        yearCentered = false
+                                        yearCentered = false,
+                                        disableScrollingText = disableScrollingText
                                     )
                                 },
                                 itemPlaceholderContent = {
@@ -652,7 +657,8 @@ fun ArtistScreen(
                                                 //albumRoute(album.key)
                                                 navController.navigate(route = "${NavRoutes.album.name}/${album.key}")
                                             }),
-                                        yearCentered = false
+                                        yearCentered = false,
+                                        disableScrollingText = disableScrollingText
                                     )
                                 },
                                 itemPlaceholderContent = {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/builtinplaylist/BuiltInPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/builtinplaylist/BuiltInPlaylistSongs.kt
@@ -1159,8 +1159,8 @@ fun BuiltInPlaylistSongs(
                                 .clickable {
                                     binder?.stopRadio()
                                     binder?.player?.forcePlay(it)
-                                }
-
+                                },
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 }
@@ -1273,13 +1273,15 @@ fun BuiltInPlaylistSongs(
                                                 BuiltInPlaylist.Top -> NonQueuedMediaItemMenuLibrary(
                                                     navController = navController,
                                                     mediaItem = song.asMediaItem,
-                                                    onDismiss = menuState::hide
+                                                    onDismiss = menuState::hide,
+                                                    disableScrollingText = disableScrollingText
                                                 )
 
                                                 BuiltInPlaylist.Offline -> InHistoryMediaItemMenu(
                                                     navController = navController,
                                                     song = song,
-                                                    onDismiss = menuState::hide
+                                                    onDismiss = menuState::hide,
+                                                    disableScrollingText = disableScrollingText
                                                 )
 
                                                 BuiltInPlaylist.OnDevice, BuiltInPlaylist.All -> {}
@@ -1303,7 +1305,8 @@ fun BuiltInPlaylistSongs(
                                     }
                                 )
                                 .background(color = colorPalette().background0)
-                                .animateItemPlacement()
+                                .animateItemPlacement(),
+                            disableScrollingText = disableScrollingText
                         )
                     /*
                     },

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/builtinplaylist/BuiltInPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/builtinplaylist/BuiltInPlaylistSongs.kt
@@ -122,6 +122,7 @@ import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.autoShuffleKey
 import it.fast4x.rimusic.utils.center
 import it.fast4x.rimusic.utils.color
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.durationTextToMillis
 import it.fast4x.rimusic.utils.enqueue
@@ -171,6 +172,8 @@ fun BuiltInPlaylistSongs(
     var sortBy by rememberPreference(songSortByKey, SongSortBy.DateAdded)
     var sortOrder by rememberPreference(songSortOrderKey, SortOrder.Descending)
     var autoShuffle by rememberPreference(autoShuffleKey, false)
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     var filter: String? by rememberSaveable { mutableStateOf(null) }
 
@@ -553,7 +556,8 @@ fun BuiltInPlaylistSongs(
                         thumbnailSizeDp = playlistThumbnailSizeDp,
                         alternative = false,
                         modifier = Modifier
-                            .padding(top = 14.dp)
+                            .padding(top = 14.dp),
+                        disableScrollingText = disableScrollingText
                     )
 
                     if (songs.isNotEmpty())
@@ -596,7 +600,8 @@ fun BuiltInPlaylistSongs(
                         alternative = true,
                         showName = false,
                         modifier = Modifier
-                            .padding(top = 14.dp)
+                            .padding(top = 14.dp),
+                        disableScrollingText = disableScrollingText
                     )
 
 
@@ -964,7 +969,8 @@ fun BuiltInPlaylistSongs(
                                     },
                                     onGoToPlaylist = {
                                         navController.navigate("${NavRoutes.localPlaylist.name}/$it")
-                                    }
+                                    },
+                                    disableScrollingText = disableScrollingText
                                 )
                             }
                         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/history/HistoryList.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/history/HistoryList.kt
@@ -54,6 +54,7 @@ import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.favoritesOverlay
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.asMediaItem
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.forcePlay
 import it.fast4x.rimusic.utils.getDownloadState
@@ -91,6 +92,7 @@ fun HistoryList(
     val thisMonday = today.with(DayOfWeek.MONDAY)
     val lastMonday = thisMonday.minusDays(7)
     val parentalControlEnabled by rememberPreference(parentalControlEnabledKey, false)
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     val events = Database.events()
         .map { events ->
@@ -273,7 +275,8 @@ fun HistoryList(
                                                 NonQueuedMediaItemMenuLibrary(
                                                     navController = navController,
                                                     mediaItem = event.song.asMediaItem,
-                                                    onDismiss = menuState::hide
+                                                    onDismiss = menuState::hide,
+                                                    disableScrollingText = disableScrollingText
                                                 )
                                             }
                                         },
@@ -282,7 +285,8 @@ fun HistoryList(
                                         }
                                     )
                                     .background(color = colorPalette().background0)
-                                    .animateItemPlacement()
+                                    .animateItemPlacement(),
+                                disableScrollingText = disableScrollingText
                             )
                         /*
                         },

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
@@ -65,6 +65,7 @@ import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.albumSortByKey
 import it.fast4x.rimusic.utils.albumSortOrderKey
 import it.fast4x.rimusic.utils.asMediaItem
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.enqueue
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.showFloatingIconKey
@@ -97,6 +98,8 @@ fun HomeAlbumsModern(
     val context = LocalContext.current
     val binder = LocalPlayerServiceBinder.current
     val lazyGridState = rememberLazyGridState()
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     // Search states
     val visibleState = rememberSaveable { mutableStateOf(false) }
@@ -342,7 +345,8 @@ fun HomeAlbumsModern(
                                                     //Log.d("mediaItemPos", "added position ${position + index}")
                                                 }
                                                 //}
-                                            }
+                                            },
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
                                 },
@@ -356,7 +360,8 @@ fun HomeAlbumsModern(
                                     onAlbumClick( album )
                                 }
                             )
-                            .clip(thumbnailShape())
+                            .clip(thumbnailShape()),
+                        disableScrollingText = disableScrollingText
                     )
                 }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
@@ -57,6 +57,7 @@ import it.fast4x.rimusic.ui.items.ArtistItem
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.utils.artistSortByKey
 import it.fast4x.rimusic.utils.artistSortOrderKey
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.showFloatingIconKey
 import kotlinx.coroutines.flow.Flow
@@ -97,6 +98,9 @@ fun HomeArtistsModern(
     // Sort states
     val sortBy = rememberPreference(artistSortByKey, ArtistSortBy.DateAdded)
     val sortOrder = rememberPreference(artistSortOrderKey, SortOrder.Descending)
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
+
     // Size state
     val sizeState = Preference.remember( HOME_ARTIST_ITEM_SIZE )
     // Randomizer states
@@ -226,7 +230,8 @@ fun HomeArtistsModern(
                                                        isSearchBarFocused = false
 
                                                onArtistClick( artist )
-                                           })
+                                           }),
+                        disableScrollingText = disableScrollingText
                     )
                 }
                 item(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeDiscovery.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeDiscovery.kt
@@ -70,6 +70,7 @@ import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.ui.styling.shimmer
 import it.fast4x.rimusic.utils.center
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.isLandscape
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.secondary
@@ -121,6 +122,8 @@ fun HomeDiscovery(
     val showSearchTab by rememberPreference(showSearchTabKey, false)
 
     //Log.d("mediaItemArtists",preferitesArtists.toString())
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     BoxWithConstraints {
 
@@ -193,7 +196,8 @@ fun HomeDiscovery(
                                                 onNewReleaseAlbumClick(
                                                     it.key
                                                 )
-                                            })
+                                            }),
+                                            disableScrollingText = disableScrollingText
                                         )
                                // }
 
@@ -216,7 +220,8 @@ fun HomeDiscovery(
                                 thumbnailSizePx = thumbnailPx,
                                 thumbnailSizeDp = thumbnailDp,
                                 alternative = true,
-                                modifier = Modifier.clickable(onClick = { onNewReleaseAlbumClick(it.key) })
+                                modifier = Modifier.clickable(onClick = { onNewReleaseAlbumClick(it.key) }),
+                                disableScrollingText = disableScrollingText
                             )
                         }
                     }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -68,6 +68,7 @@ import it.fast4x.rimusic.utils.CheckMonthlyPlaylist
 import it.fast4x.rimusic.utils.ImportPipedPlaylists
 import it.fast4x.rimusic.utils.autosyncKey
 import it.fast4x.rimusic.utils.createPipedPlaylist
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.enableCreateMonthlyPlaylistsKey
 import it.fast4x.rimusic.utils.getPipedSession
 import it.fast4x.rimusic.utils.isPipedEnabledKey
@@ -119,6 +120,7 @@ fun HomeLibraryModern(
     var autosync by rememberPreference(autosyncKey, false)
     var playlistType by rememberPreference(playlistTypeKey, PlaylistsType.Playlist)
     val isPipedEnabled by rememberPreference(isPipedEnabledKey, false)
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     var items by persistList<PlaylistPreview>("home/playlists")
 
@@ -378,7 +380,8 @@ fun HomeLibraryModern(
                                                        isSearchBarFocused = false
 
                                                onPlaylistClick( preview.playlist )
-                                           })
+                                           }),
+                        disableScrollingText = disableScrollingText
                     )
                 }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSearch.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSearch.kt
@@ -38,7 +38,8 @@ import me.knighthat.thumbnailShape
 @ExperimentalFoundationApi
 @Composable
 fun HomeSearch(
-    onSearchType: (SearchType) -> Unit
+    onSearchType: (SearchType) -> Unit,
+    disableScrollingText: Boolean
 ) {
     val thumbnailSizeDp = 108.dp
     val thumbnailSizePx = thumbnailSizeDp.px
@@ -93,8 +94,8 @@ fun HomeSearch(
                     modifier = Modifier
                         .clip(thumbnailShape())
                         .clickable(onClick = { onSearchType(SearchType.Online) })
-                        .animateItemPlacement()
-
+                        .animateItemPlacement(),
+                    disableScrollingText = disableScrollingText
                 )
             }
 
@@ -109,8 +110,8 @@ fun HomeSearch(
                     modifier = Modifier
                         .clip(thumbnailShape())
                         .clickable(onClick = { onSearchType(SearchType.Library) })
-                        .animateItemPlacement()
-
+                        .animateItemPlacement(),
+                    disableScrollingText = disableScrollingText
                 )
             }
 
@@ -125,7 +126,8 @@ fun HomeSearch(
                     songCount = null,
                     thumbnailSizeDp = thumbnailSizeDp,
                     alternative = true,
-                    modifier = Modifier.animateItem(fadeInSpec = null, fadeOutSpec = null)
+                    modifier = Modifier.animateItem(fadeInSpec = null, fadeOutSpec = null),
+                    disableScrollingText = disableScrollingText
                 )
             }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -1124,7 +1124,8 @@ fun HomeSongsModern(
                                                     InHistoryMediaItemMenu(
                                                         navController = navController,
                                                         song = song.song,
-                                                        onDismiss = menuState::hide
+                                                        onDismiss = menuState::hide,
+                                                        disableScrollingText = disableScrollingText
                                                     )
                                                 }
                                                 hapticFeedback.performHapticFeedback(
@@ -1150,7 +1151,8 @@ fun HomeSongsModern(
                                         .animateItem(
                                             fadeInSpec = null,
                                             fadeOutSpec = null
-                                        )
+                                        ),
+                                    disableScrollingText = disableScrollingText
                                 )
                             }
                         }
@@ -1283,7 +1285,8 @@ fun HomeSongsModern(
                                                     onDeleteFromDatabase = {
                                                         deleteSongDialog.song = Optional.of( song )
                                                         deleteSongToggleState.value = true
-                                                    }
+                                                    },
+                                                    disableScrollingText = disableScrollingText
                                                 )
                                             }
                                             hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -1357,7 +1360,8 @@ fun HomeSongsModern(
                                             )
                                         }
                                     )
-                                    .animateItemPlacement()
+                                    .animateItemPlacement(),
+                                disableScrollingText = disableScrollingText
                             )
                         }
                     }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -116,6 +116,7 @@ import it.fast4x.rimusic.utils.builtInPlaylistKey
 import it.fast4x.rimusic.utils.center
 import it.fast4x.rimusic.utils.color
 import it.fast4x.rimusic.utils.defaultFolderKey
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.durationTextToMillis
 import it.fast4x.rimusic.utils.enqueue
@@ -189,6 +190,7 @@ fun HomeSongsModern(
     val thumbnailSizePx = thumbnailSizeDp.px
 
     val parentalControlEnabled by rememberPreference(parentalControlEnabledKey, false)
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     var items by persistList<SongEntity>("home/songs")
     var listMediaItems = remember { mutableListOf<MediaItem>() }
@@ -1015,6 +1017,7 @@ fun HomeSongsModern(
                                                     currentFolderPath = currentFolderPath.removeSuffix("/").substringBeforeLast("/") + "/"
                                                 }
                                             ),
+                                        disableScrollingText = disableScrollingText
                                     )
                                 }
                             }
@@ -1039,7 +1042,8 @@ fun HomeSongsModern(
                                                                     .map { it.toSong().asMediaItem }
                                                                 binder?.player?.enqueue(allSongs, context)
                                                             },
-                                                            thumbnailSizeDp = thumbnailSizeDp
+                                                            thumbnailSizeDp = thumbnailSizeDp,
+                                                            disableScrollingText = disableScrollingText
                                                         )
                                                     };
                                                     hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -1054,6 +1058,7 @@ fun HomeSongsModern(
                                                             isSearchBarFocused = false
                                                 }
                                             ),
+                                        disableScrollingText = disableScrollingText
                                     )
                                 }
                             } else {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -916,7 +916,8 @@ fun HomeSongsModern(
                                     )
                                 }
                             },
-                            onExport = { exportToggleState.value = true }
+                            onExport = { exportToggleState.value = true },
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeStatistics.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeStatistics.kt
@@ -47,6 +47,7 @@ import it.fast4x.rimusic.ui.components.themed.InputTextDialog
 import it.fast4x.rimusic.ui.items.PlaylistItem
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.favoritesIcon
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.playlistSortByKey
 import it.fast4x.rimusic.utils.playlistSortOrderKey
 import it.fast4x.rimusic.utils.rememberPreference
@@ -97,6 +98,8 @@ fun HomeStatistics(
 
     var sortBy by rememberPreference(playlistSortByKey, PlaylistSortBy.DateAdded)
     var sortOrder by rememberPreference(playlistSortOrderKey, SortOrder.Descending)
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     var items by persistList<PlaylistPreview>("home/playlists")
 
@@ -163,8 +166,8 @@ fun HomeStatistics(
                     modifier = Modifier
                         .clip(thumbnailShape())
                         .clickable(onClick = { onStatisticsType(StatisticsType.Today) })
-                        .animateItemPlacement()
-
+                        .animateItemPlacement(),
+                    disableScrollingText = disableScrollingText
                 )
             }
 
@@ -179,8 +182,8 @@ fun HomeStatistics(
                     modifier = Modifier
                         .clip(thumbnailShape())
                         .clickable(onClick = { onStatisticsType(StatisticsType.OneWeek) })
-                        .animateItemPlacement()
-
+                        .animateItemPlacement(),
+                    disableScrollingText = disableScrollingText
                 )
             }
 
@@ -195,7 +198,8 @@ fun HomeStatistics(
                     modifier = Modifier
                         .clip(thumbnailShape())
                         .clickable(onClick = { onStatisticsType(StatisticsType.OneMonth) })
-                        .animateItemPlacement()
+                        .animateItemPlacement(),
+                    disableScrollingText = disableScrollingText
                 )
             }
 
@@ -210,7 +214,8 @@ fun HomeStatistics(
                     modifier = Modifier
                         .clip(thumbnailShape())
                         .clickable(onClick = { onStatisticsType(StatisticsType.ThreeMonths) })
-                        .animateItemPlacement()
+                        .animateItemPlacement(),
+                    disableScrollingText = disableScrollingText
                 )
             }
 
@@ -225,7 +230,8 @@ fun HomeStatistics(
                     modifier = Modifier
                         .clip(thumbnailShape())
                         .clickable(onClick = { onStatisticsType(StatisticsType.SixMonths) })
-                        .animateItemPlacement()
+                        .animateItemPlacement(),
+                    disableScrollingText = disableScrollingText
                 )
             }
 
@@ -240,7 +246,8 @@ fun HomeStatistics(
                     modifier = Modifier
                         .clip(thumbnailShape())
                         .clickable(onClick = { onStatisticsType(StatisticsType.OneYear) })
-                        .animateItemPlacement()
+                        .animateItemPlacement(),
+                    disableScrollingText = disableScrollingText
                 )
             }
 
@@ -255,7 +262,8 @@ fun HomeStatistics(
                     modifier = Modifier
                         .clip(thumbnailShape())
                         .clickable(onClick = { onStatisticsType(StatisticsType.All) })
-                        .animateItemPlacement()
+                        .animateItemPlacement(),
+                    disableScrollingText = disableScrollingText
                 )
             }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
@@ -782,7 +782,8 @@ fun QuickPicksModern(
                                         alternative = true,
                                         showSongsCount = false,
                                         modifier = Modifier
-                                            .clickable(onClick = { onPlaylistClick(playlist.key) })
+                                            .clickable(onClick = { onPlaylistClick(playlist.key) }),
+                                        disableScrollingText = disableScrollingText
                                     )
                                 }
                             }
@@ -854,7 +855,8 @@ fun QuickPicksModern(
                                             fadeOutSpec = null
                                         )
                                             .fillMaxSize()
-                                            .clickable(onClick = { navController.navigate(route = "${NavRoutes.localPlaylist.name}/${playlist.playlist.id}") })
+                                            .clickable(onClick = { navController.navigate(route = "${NavRoutes.localPlaylist.name}/${playlist.playlist.id}") }),
+                                        disableScrollingText = disableScrollingText
                                     )
                                 }
                             }
@@ -907,7 +909,8 @@ fun QuickPicksModern(
                                         alternative = true,
                                         showSongsCount = false,
                                         modifier = Modifier
-                                            .clickable(onClick = { onPlaylistClick(playlist.key) })
+                                            .clickable(onClick = { onPlaylistClick(playlist.key) }),
+                                        disableScrollingText = disableScrollingText
                                     )
                                 }
                             }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
@@ -516,8 +516,8 @@ fun QuickPicksModern(
                                                                 mediaItem = song.asMediaItem,
                                                                 downloadState = isDownloaded
                                                             )
-                                                        }
-
+                                                        },
+                                                        disableScrollingText = disableScrollingText
                                                     )
                                                 };
                                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -535,7 +535,8 @@ fun QuickPicksModern(
                                         fadeInSpec = null,
                                         fadeOutSpec = null
                                         )
-                                        .width(itemInHorizontalGridWidth)
+                                        .width(itemInHorizontalGridWidth),
+                                    disableScrollingText = disableScrollingText
                                 )
                             }
                         }
@@ -610,7 +611,7 @@ fun QuickPicksModern(
                                                                 downloadState = isDownloaded
                                                             )
                                                         },
-
+                                                        disableScrollingText = disableScrollingText
                                                         )
                                                 }
                                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -625,7 +626,8 @@ fun QuickPicksModern(
                                             }
                                         )
                                         .animateItemPlacement()
-                                        .width(itemInHorizontalGridWidth)
+                                        .width(itemInHorizontalGridWidth),
+                                    disableScrollingText = disableScrollingText
                                 )
                             }
                         }
@@ -964,7 +966,8 @@ fun QuickPicksModern(
                                                         binder?.player?.forcePlay(mediaItem)
                                                         binder?.player?.addMediaItems(songs.map { it.asMediaItem })
                                                     })
-                                                    .width(itemWidth)
+                                                    .width(itemWidth),
+                                                disableScrollingText = disableScrollingText
                                             )
                                         }
                                     }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
@@ -104,6 +104,7 @@ import it.fast4x.rimusic.utils.asSong
 import it.fast4x.rimusic.utils.bold
 import it.fast4x.rimusic.utils.center
 import it.fast4x.rimusic.utils.color
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.forcePlay
 import it.fast4x.rimusic.utils.getDownloadState
@@ -315,6 +316,8 @@ fun QuickPicksModern(
     //val enableCreateMonthlyPlaylists by rememberPreference(enableCreateMonthlyPlaylistsKey, true)
     //if (enableCreateMonthlyPlaylists)
     //    CheckMonthlyPlaylist()
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     PullToRefreshBox(
         refreshing = refreshing,
@@ -673,7 +676,8 @@ fun QuickPicksModern(
                                             alternative = true,
                                             modifier = Modifier.clickable(onClick = {
                                                 onAlbumClick(it.key)
-                                            })
+                                            }),
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
                                 }
@@ -696,7 +700,8 @@ fun QuickPicksModern(
                                         alternative = true,
                                         modifier = Modifier.clickable(onClick = {
                                             onAlbumClick(it.key)
-                                        })
+                                        }),
+                                        disableScrollingText = disableScrollingText
                                     )
                                 }
                             }
@@ -722,7 +727,8 @@ fun QuickPicksModern(
                                         thumbnailSizeDp = albumThumbnailSizeDp,
                                         alternative = true,
                                         modifier = Modifier
-                                            .clickable(onClick = { onAlbumClick(album.key) })
+                                            .clickable(onClick = { onAlbumClick(album.key) }),
+                                        disableScrollingText = disableScrollingText
                                     )
                                 }
                             }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/QuickPicksModern.kt
@@ -753,7 +753,8 @@ fun QuickPicksModern(
                                         thumbnailSizeDp = artistThumbnailSizeDp,
                                         alternative = true,
                                         modifier = Modifier
-                                            .clickable(onClick = { onArtistClick(artist.key) })
+                                            .clickable(onClick = { onArtistClick(artist.key) }),
+                                        disableScrollingText = disableScrollingText
                                     )
                                 }
                             }
@@ -1007,7 +1008,8 @@ fun QuickPicksModern(
                                                 alternative = false,
                                                 modifier = Modifier
                                                     .width(200.dp)
-                                                    .clickable(onClick = { onArtistClick(artist.key) })
+                                                    .clickable(onClick = { onArtistClick(artist.key) }),
+                                                disableScrollingText = disableScrollingText
                                             )
                                         }
                                     }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
@@ -1090,8 +1090,8 @@ fun LocalPlaylistSongs(
                                     .clickable {
                                         binder?.stopRadio()
                                         binder?.player?.forcePlay(it)
-                                    }
-
+                                    },
+                                disableScrollingText = disableScrollingText
                             )
                         }
                     }
@@ -1286,7 +1286,8 @@ fun LocalPlaylistSongs(
                                                     playlistId = playlistId,
                                                     positionInPlaylist = index,
                                                     song = song.song,
-                                                    onDismiss = menuState::hide
+                                                    onDismiss = menuState::hide,
+                                                    disableScrollingText = disableScrollingText
                                                 )
                                             }
                                             hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -1321,7 +1322,8 @@ fun LocalPlaylistSongs(
 
  */
                                     .background(color = colorPalette().background0)
-                                    .zIndex(2f)
+                                    .zIndex(2f),
+                                disableScrollingText = disableScrollingText
                             )
                         }
                     }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
@@ -117,6 +117,7 @@ import it.fast4x.rimusic.utils.center
 import it.fast4x.rimusic.utils.color
 import it.fast4x.rimusic.utils.completed
 import it.fast4x.rimusic.utils.deletePipedPlaylist
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.durationTextToMillis
 import it.fast4x.rimusic.utils.enqueue
@@ -192,6 +193,7 @@ fun LocalPlaylistSongs(
     // Non-vital
     val parentalControlEnabled by rememberPreference(parentalControlEnabledKey, false)
     val isPipedEnabled by rememberPreference(isPipedEnabledKey, false)
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
     val pipedSession = getPipedSession()
     var isRecommendationEnabled by rememberPreference(isRecommendationEnabledKey, false)
     var downloadState = remember { mutableIntStateOf( Download.STATE_STOPPED ) }
@@ -651,7 +653,8 @@ fun LocalPlaylistSongs(
                                 alternative = true,
                                 showName = false,
                                 modifier = Modifier
-                                    .padding(top = 14.dp)
+                                    .padding(top = 14.dp),
+                                disableScrollingText = disableScrollingText
                             )
                         }
 
@@ -985,7 +988,8 @@ fun LocalPlaylistSongs(
                                             },
                                             onGoToPlaylist = {
                                                 navController.navigate("${NavRoutes.localPlaylist.name}/$it")
-                                            }
+                                            },
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodList.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodList.kt
@@ -164,7 +164,8 @@ fun MoodList(
                                                 //artistRoute.global(it)
                                                 navController.navigate(route = "${NavRoutes.artist.name}/$it")
                                             }
-                                        }
+                                        },
+                                        disableScrollingText = disableScrollingText
                                     )
 
                                     is Innertube.PlaylistItem -> PlaylistItem(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodList.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodList.kt
@@ -51,6 +51,8 @@ import it.fast4x.rimusic.ui.items.PlaylistItem
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.center
+import it.fast4x.rimusic.utils.disableScrollingTextKey
+import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.secondary
 import it.fast4x.rimusic.utils.semiBold
 import me.knighthat.colorPalette
@@ -85,6 +87,8 @@ fun MoodList(
         .padding(horizontal = 16.dp)
         .padding(top = 24.dp, bottom = 8.dp)
         .padding(endPaddingValues)
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     Column (
         modifier = Modifier
@@ -146,7 +150,8 @@ fun MoodList(
                                                 //albumRoute.global(it)
                                                 navController.navigate(route = "${NavRoutes.album.name}/$it")
                                             }
-                                        }
+                                        },
+                                        disableScrollingText = disableScrollingText
                                     )
 
                                     is Innertube.ArtistItem -> ArtistItem(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodList.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/mood/MoodList.kt
@@ -193,7 +193,8 @@ fun MoodList(
                                                 )
                                             }
                                              */
-                                        }
+                                        },
+                                        disableScrollingText = disableScrollingText
                                     )
 
                                     else -> {}

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/newreleases/NewAlbums.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/newreleases/NewAlbums.kt
@@ -35,6 +35,7 @@ import it.fast4x.rimusic.ui.components.themed.HeaderWithIcon
 import it.fast4x.rimusic.ui.items.AlbumItem
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.px
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.navigationBarPositionKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.showSearchTabKey
@@ -65,6 +66,8 @@ fun NewAlbums(
     val showSearchTab by rememberPreference(showSearchTabKey, false)
 
     val lazyGridState = rememberLazyGridState()
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
 
     Column(
@@ -117,7 +120,8 @@ fun NewAlbums(
                         alternative = true,
                         modifier = Modifier.clickable(onClick = {
                             navController.navigate(route = "${NavRoutes.album.name}/${it.key}")
-                        })
+                        }),
+                        disableScrollingText = disableScrollingText
                     )
                 }
                 item(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/newreleases/NewAlbumsFromArtists.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/newreleases/NewAlbumsFromArtists.kt
@@ -42,6 +42,7 @@ import it.fast4x.rimusic.ui.items.AlbumItem
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.center
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.navigationBarPositionKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.secondary
@@ -79,6 +80,8 @@ fun NewAlbumsFromArtists(
     val showSearchTab by rememberPreference(showSearchTabKey, false)
 
     val lazyGridState = rememberLazyGridState()
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
 
     Column(
@@ -141,7 +144,8 @@ fun NewAlbumsFromArtists(
                             alternative = true,
                             modifier = Modifier.clickable(onClick = {
                                 navController.navigate(route = "${NavRoutes.album.name}/${it.key}")
-                            })
+                            }),
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 } else {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongs.kt
@@ -115,6 +115,7 @@ import it.fast4x.rimusic.utils.OnDeviceOrganize
 import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.defaultFolderKey
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.durationTextToMillis
 import it.fast4x.rimusic.utils.enqueue
 import it.fast4x.rimusic.utils.forcePlayAtIndex
@@ -219,7 +220,8 @@ fun DeviceListSongs(
 
         }
 
-    } else {
+    }
+    else {
 
         val backButtonFolder = Folder(stringResource(R.string.back))
         val binder = LocalPlayerServiceBinder.current
@@ -231,6 +233,8 @@ fun DeviceListSongs(
         var sortOrder by rememberPreference(songSortOrderKey, SortOrder.Descending)
 
         val defaultFolder by rememberPreference(defaultFolderKey, "/")
+
+        val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
         var songsDevice by remember(sortBy, sortOrder) {
             mutableStateOf<List<OnDeviceSong>>(emptyList())
@@ -836,6 +840,7 @@ fun DeviceListSongs(
                                         currentFolderPath = currentFolderPath.removeSuffix("/").substringBeforeLast("/") + "/"
                                     }
                                 ),
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 }
@@ -861,7 +866,8 @@ fun DeviceListSongs(
                                                             .map { it.toSong().asMediaItem }
                                                         binder?.player?.enqueue(allSongs, context)
                                                     },
-                                                    thumbnailSizeDp = thumbnailSizeDp
+                                                    thumbnailSizeDp = thumbnailSizeDp,
+                                                    disableScrollingText = disableScrollingText
                                                 )
                                             }
                                         }
@@ -870,6 +876,7 @@ fun DeviceListSongs(
                                         currentFolderPath += folder.name + "/"
                                     }
                                 ),
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 } else {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongs.kt
@@ -938,7 +938,8 @@ fun DeviceListSongs(
                                         DeviceLists.LocalSongs -> InHistoryMediaItemMenu(
                                             navController = navController,
                                             song = song.song,
-                                            onDismiss = menuState::hide
+                                            onDismiss = menuState::hide,
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
                                 }
@@ -955,7 +956,8 @@ fun DeviceListSongs(
                                 }
                             }
                         )
-                        .animateItemPlacement()
+                        .animateItemPlacement(),
+                    disableScrollingText = disableScrollingText
                 )
             }
         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/ondevice/DeviceListSongs.kt
@@ -390,7 +390,8 @@ fun DeviceListSongs(
                             thumbnailSizeDp = playlistThumbnailSizeDp,
                             alternative = false,
                             modifier = Modifier
-                                .padding(top = 14.dp)
+                                .padding(top = 14.dp),
+                            disableScrollingText = disableScrollingText
                         )
 
                     if (filteredSongs.isNotEmpty())
@@ -433,7 +434,8 @@ fun DeviceListSongs(
                             alternative = true,
                             showName = false,
                             modifier = Modifier
-                                .padding(top = 14.dp)
+                                .padding(top = 14.dp),
+                            disableScrollingText = disableScrollingText
                         )
 
 
@@ -730,7 +732,8 @@ fun DeviceListSongs(
                                     },
                                     onGoToPlaylist = {
                                         navController.navigate("${NavRoutes.localPlaylist.name}/$it")
-                                    }
+                                    },
+                                    disableScrollingText = disableScrollingText
                                 )
                             }
                         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Controls.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Controls.kt
@@ -51,13 +51,12 @@ import it.fast4x.rimusic.ui.screens.player.components.controls.InfoAlbumAndArtis
 import it.fast4x.rimusic.utils.GetControls
 import it.fast4x.rimusic.utils.GetSeekBar
 import it.fast4x.rimusic.utils.buttonzoomoutKey
-import it.fast4x.rimusic.utils.controlsExpandedKey
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.effectRotationKey
 import it.fast4x.rimusic.utils.isCompositionLaunched
 import it.fast4x.rimusic.utils.isLandscape
-import it.fast4x.rimusic.utils.miniQueueExpandedKey
 import it.fast4x.rimusic.utils.playerControlsTypeKey
 import it.fast4x.rimusic.utils.playerInfoTypeKey
 import it.fast4x.rimusic.utils.playerPlayButtonTypeKey
@@ -65,12 +64,9 @@ import it.fast4x.rimusic.utils.playerSwapControlsWithTimelineKey
 import it.fast4x.rimusic.utils.playerTimelineSizeKey
 import it.fast4x.rimusic.utils.playerTimelineTypeKey
 import it.fast4x.rimusic.utils.playerTypeKey
-import it.fast4x.rimusic.utils.queueDurationExpandedKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.showlyricsthumbnailKey
 import it.fast4x.rimusic.utils.showthumbnailKey
-import it.fast4x.rimusic.utils.timelineExpandedKey
-import it.fast4x.rimusic.utils.titleExpandedKey
 import it.fast4x.rimusic.utils.transparentBackgroundPlayerActionBarKey
 import kotlinx.coroutines.flow.distinctUntilChanged
 
@@ -519,14 +515,6 @@ fun Modifier.bounceClick() = composed {
                 }
             }
         }
-}
-
-fun Modifier.conditional(condition : Boolean, modifier : Modifier.() -> Modifier) : Modifier {
-    return if (condition) {
-        then(modifier(Modifier))
-    } else {
-        this
-    }
 }
 
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/MiniPlayer.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/MiniPlayer.kt
@@ -76,7 +76,9 @@ import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.DisposableListener
 import it.fast4x.rimusic.utils.backgroundProgressKey
 import it.fast4x.rimusic.cleanPrefix
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.disableClosingPlayerSwipingDownKey
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.effectRotationKey
 import it.fast4x.rimusic.utils.forceSeekToNext
 import it.fast4x.rimusic.utils.forceSeekToPrevious
@@ -103,7 +105,7 @@ import kotlin.math.absoluteValue
 fun MiniPlayer(
     showPlayer: () -> Unit,
     hidePlayer: () -> Unit,
-    navController: NavController? = null
+    navController: NavController? = null,
 ) {
     val binder = LocalPlayerServiceBinder.current
     binder?.player ?: return
@@ -198,6 +200,8 @@ fun MiniPlayer(
         animationSpec = tween(durationMillis = 200), label = ""
     )
     val disableClosingPlayerSwipingDown by rememberPreference(disableClosingPlayerSwipingDownKey, true)
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     SwipeToDismissBox(
         modifier = Modifier
@@ -341,7 +345,7 @@ fun MiniPlayer(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
-                            .basicMarquee(iterations = Int.MAX_VALUE)
+                            .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                     )
                 }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/MiniPlayer.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/MiniPlayer.kt
@@ -278,7 +278,10 @@ fun MiniPlayer(
                                     binder.player.clearMediaItems()
                                     hidePlayer()
                                 } else
-                                    SmartMessage(context.resources.getString(R.string.player_swiping_down_is_disabled), context = context)
+                                    SmartMessage(
+                                        context.resources.getString(R.string.player_swiping_down_is_disabled),
+                                        context = context
+                                    )
                             }
                         }
                     )
@@ -355,7 +358,7 @@ fun MiniPlayer(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier
-                        .basicMarquee(iterations = Int.MAX_VALUE)
+                        .conditional(!disableScrollingText) { basicMarquee(iterations = Int.MAX_VALUE) }
                 )
             }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
@@ -217,6 +217,7 @@ import it.fast4x.rimusic.cleanPrefix
 import it.fast4x.rimusic.utils.textoutlineKey
 import kotlin.Float.Companion.POSITIVE_INFINITY
 import it.fast4x.rimusic.utils.clickOnLyricsTextKey
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.controlsExpandedKey
 import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.discoverKey

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
@@ -1419,7 +1419,8 @@ fun Player(
                                             binder = binder,
                                             onClosePlayer = {
                                                 onDismiss()
-                                            }
+                                            },
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
                                 },
@@ -1584,8 +1585,8 @@ fun Player(
                                             binder = binder,
                                             onClosePlayer = {
                                                 onDismiss()
-                                            }
-
+                                            },
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
                                 },
@@ -1608,7 +1609,8 @@ fun Player(
                                             binder = binder,
                                             onClosePlayer = {
                                                 onDismiss()
-                                            }
+                                            },
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
                                 },
@@ -2273,7 +2275,8 @@ fun Player(
                                                 binder = binder,
                                                 onClosePlayer = {
                                                     onDismiss()
-                                                }
+                                                },
+                                                disableScrollingText = disableScrollingText
                                             )
                                         }
                                     }
@@ -2685,7 +2688,8 @@ fun Player(
             SearchYoutubeEntity(
                 navController = navController,
                 onDismiss = { showSearchEntity = false },
-                query = "${mediaItem.mediaMetadata.artist.toString()} - ${mediaItem.mediaMetadata.title.toString()}"
+                query = "${mediaItem.mediaMetadata.artist.toString()} - ${mediaItem.mediaMetadata.title.toString()}",
+                disableScrollingText = disableScrollingText
             )
         }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/QueueModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/QueueModern.kt
@@ -687,8 +687,8 @@ fun QueueModern(
                                                                 mediaItem = window.mediaItem,
                                                                 downloadState = isDownloaded
                                                             )
-                                                        }
-
+                                                        },
+                                                        disableScrollingText = disableScrollingText
                                                     )
                                                 }
                                                 hapticFeedback.performHapticFeedback(
@@ -718,8 +718,8 @@ fun QueueModern(
 
                                          */
                                         .animateItemPlacement(reorderingState)
-                                        .background(color = if (queueType == QueueType.Modern) Color.Transparent else colorPalette().background0)
-
+                                        .background(color = if (queueType == QueueType.Modern) Color.Transparent else colorPalette().background0),
+                                    disableScrollingText = disableScrollingText
                                 )
                             }
                         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/QueueModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/QueueModern.kt
@@ -116,6 +116,7 @@ import it.fast4x.rimusic.ui.styling.onOverlay
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.DisposableListener
 import it.fast4x.rimusic.utils.addNext
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.discoverKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.getDownloadState
@@ -168,6 +169,8 @@ fun QueueModern(
     val context = LocalContext.current
     val showButtonPlayerArrow by rememberPreference(showButtonPlayerArrowKey, false)
     var queueType by rememberPreference(queueTypeKey, QueueType.Essential)
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     Box(
         modifier = Modifier
@@ -1033,7 +1036,8 @@ fun QueueModern(
                                     },
                                     onGoToPlaylist = {
                                         navController.navigate("${NavRoutes.localPlaylist.name}/$it")
-                                    }
+                                    },
+                                    disableScrollingText = disableScrollingText
                                 )
                             }
                         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongList.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongList.kt
@@ -93,6 +93,7 @@ import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.completed
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.durationTextToMillis
 import it.fast4x.rimusic.utils.enqueue
@@ -197,6 +198,8 @@ fun PlaylistSongList(
         thumbnailRoundnessKey,
         ThumbnailRoundness.Heavy
     )
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 /*
     var showAddPlaylistSelectDialog by remember {
         mutableStateOf(false)
@@ -450,9 +453,8 @@ fun PlaylistSongList(
                                         },
                                         onGoToPlaylist = {
                                             navController.navigate("${NavRoutes.localPlaylist.name}/$it")
-                                        }
-
-
+                                        },
+                                        disableScrollingText = disableScrollingText
                                     )
                                 }
                             },

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongList.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongList.kt
@@ -729,6 +729,7 @@ fun PlaylistSongList(
                                             navController = navController,
                                             onDismiss = menuState::hide,
                                             mediaItem = song.asMediaItem,
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
                                 },
@@ -740,7 +741,8 @@ fun PlaylistSongList(
                                         binder?.player?.forcePlayAtIndex(mediaItems, index)
                                     }
                                 }
-                            )
+                            ),
+                        disableScrollingText = disableScrollingText
                     )
                 }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongListModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongListModern.kt
@@ -110,6 +110,7 @@ import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.asSong
 import it.fast4x.rimusic.utils.completed
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.durationTextToMillis
 import it.fast4x.rimusic.utils.enqueue
@@ -160,6 +161,7 @@ fun PlaylistSongListModern(
     var filter: String? by rememberSaveable { mutableStateOf(null) }
     val hapticFeedback = LocalHapticFeedback.current
     val parentalControlEnabled by rememberPreference(parentalControlEnabledKey, false)
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     LaunchedEffect(Unit, filter) {
         if (playlistPage != null && playlistPage?.songsPage?.continuation == null) return@LaunchedEffect
@@ -625,9 +627,8 @@ fun PlaylistSongListModern(
 
                                                     onGoToPlaylist = {
                                                         navController.navigate("${NavRoutes.localPlaylist.name}/$it")
-                                                    }
-
-
+                                                    },
+                                                    disableScrollingText = disableScrollingText
                                                 )
                                             }
                                         },

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongListModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/playlist/PlaylistSongListModern.kt
@@ -799,6 +799,7 @@ fun PlaylistSongListModern(
                                                 navController = navController,
                                                 onDismiss = menuState::hide,
                                                 mediaItem = song.asMediaItem,
+                                                disableScrollingText = disableScrollingText
                                             )
                                         };
                                         hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -812,7 +813,8 @@ fun PlaylistSongListModern(
                                                 binder?.player?.forcePlayAtIndex(mediaItems, index)
                                             }
                                     }
-                                )
+                                ),
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/podcast/Podcast.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/podcast/Podcast.kt
@@ -757,6 +757,7 @@ fun Podcast(
                                                 navController = navController,
                                                 onDismiss = menuState::hide,
                                                 mediaItem = song.asMediaItem,
+                                                disableScrollingText = disableScrollingText
                                             )
                                         };
                                         hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -770,7 +771,8 @@ fun Podcast(
                                                 binder?.player?.forcePlayAtIndex(mediaItems, index)
                                             }
                                     }
-                                )
+                                ),
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/podcast/Podcast.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/podcast/Podcast.kt
@@ -105,6 +105,7 @@ import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.asMediaItem
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.durationTextToMillis
 import it.fast4x.rimusic.utils.enqueue
@@ -198,6 +199,8 @@ fun Podcast(
         thumbnailRoundnessKey,
         ThumbnailRoundness.Heavy
     )
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     var totalPlayTimes = 0L
     podcastPage?.listEpisode?.forEach {
@@ -569,9 +572,8 @@ fun Podcast(
                                                     },
                                                     onGoToPlaylist = {
                                                         navController.navigate("${NavRoutes.localPlaylist.name}/$it")
-                                                    }
-
-
+                                                    },
+                                                    disableScrollingText = disableScrollingText
                                                 )
                                             }
                                         },

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/LocalSongSearch.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/LocalSongSearch.kt
@@ -55,6 +55,7 @@ import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.align
 import it.fast4x.rimusic.utils.asMediaItem
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.forcePlay
 import it.fast4x.rimusic.utils.getDownloadState
@@ -107,6 +108,8 @@ fun LocalSongSearch(
         thumbnailRoundnessKey,
         ThumbnailRoundness.Heavy
     )
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     val focusRequester = remember {
         FocusRequester()
@@ -286,7 +289,8 @@ fun LocalSongSearch(
                                     InHistoryMediaItemMenu(
                                         navController = navController,
                                         song = song,
-                                        onDismiss = menuState::hide
+                                        onDismiss = menuState::hide,
+                                        disableScrollingText = disableScrollingText
                                     )
                                 }
                             },
@@ -299,7 +303,8 @@ fun LocalSongSearch(
                                 )
                             }
                         )
-                        .animateItemPlacement()
+                        .animateItemPlacement(),
+                    disableScrollingText = disableScrollingText
                 )
             }
         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/OnlineSearch.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/OnlineSearch.kt
@@ -80,6 +80,7 @@ import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.align
 import it.fast4x.rimusic.utils.asMediaItem
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.forcePlay
 import it.fast4x.rimusic.utils.medium
 import it.fast4x.rimusic.utils.pauseSearchHistoryKey
@@ -175,6 +176,8 @@ fun OnlineSearch(
     val menuState = LocalMenuState.current
     val hapticFeedback = LocalHapticFeedback.current
     val binder = LocalPlayerServiceBinder.current
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     Box(
         modifier = Modifier
@@ -382,8 +385,8 @@ fun OnlineSearch(
                                 modifier = Modifier
                                     .clickable {
                                         navController.navigate(route = "${NavRoutes.album.name}/${album.key}")
-                                    }
-
+                                    },
+                                disableScrollingText = disableScrollingText
                             )
                         }
                     }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/OnlineSearch.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/OnlineSearch.kt
@@ -362,6 +362,7 @@ fun OnlineSearch(
                                                     navController = navController,
                                                     onDismiss = menuState::hide,
                                                     mediaItem = mediaItem,
+                                                    disableScrollingText = disableScrollingText
                                                 )
                                             };
                                             hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -369,7 +370,8 @@ fun OnlineSearch(
                                         onClick = {
                                             binder?.player?.forcePlay(mediaItem)
                                         }
-                                    )
+                                    ),
+                                disableScrollingText = disableScrollingText
                             )
                         }
                     }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/OnlineSearch.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/search/OnlineSearch.kt
@@ -401,8 +401,8 @@ fun OnlineSearch(
                                 modifier = Modifier
                                     .clickable {
                                         navController.navigate(route = "${NavRoutes.artist.name}/${artist.key}")
-                                    }
-
+                                    },
+                                disableScrollingText = disableScrollingText
                             )
                         }
                     }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
@@ -252,6 +252,7 @@ fun SearchResultScreen(
                                                                 navController = navController,
                                                                 onDismiss = menuState::hide,
                                                                 mediaItem = song.asMediaItem,
+                                                                disableScrollingText = disableScrollingText
                                                             )
                                                         };
                                                         hapticFeedback.performHapticFeedback(
@@ -263,7 +264,8 @@ fun SearchResultScreen(
                                                         localBinder?.player?.forcePlay(song.asMediaItem)
                                                         localBinder?.setupRadio(song.info?.endpoint)
                                                     }
-                                                )
+                                                ),
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
                                 },
@@ -526,7 +528,8 @@ fun SearchResultScreen(
                                                             NonQueuedMediaItemMenu(
                                                                 navController = navController,
                                                                 mediaItem = video.asMediaItem,
-                                                                onDismiss = menuState::hide
+                                                                onDismiss = menuState::hide,
+                                                                disableScrollingText = disableScrollingText
                                                             )
                                                         };
                                                         hapticFeedback.performHapticFeedback(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
@@ -472,7 +472,8 @@ fun SearchResultScreen(
                                             .clickable(onClick = {
                                                 //artistRoute(artist.key)
                                                 navController.navigate("${NavRoutes.artist.name}/${artist.key}")
-                                            })
+                                            }),
+                                        disableScrollingText = disableScrollingText
                                     )
                                 },
                                 itemPlaceholderContent = {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
@@ -66,6 +66,7 @@ import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.asSong
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.enqueue
 import it.fast4x.rimusic.utils.forcePlay
@@ -110,6 +111,8 @@ fun SearchResultScreen(
 
     val isVideoEnabled = LocalContext.current.preferences.getBoolean(showButtonPlayerVideoKey, false)
     val parentalControlEnabled by rememberPreference(parentalControlEnabledKey, false)
+
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     PersistMapCleanup(tagPrefix = "searchResults/$query/")
 
@@ -425,7 +428,8 @@ fun SearchResultScreen(
                                                     },
                                                     onLongClick = {}
 
-                                                )
+                                                ),
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
                                 },

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
@@ -544,7 +544,8 @@ fun SearchResultScreen(
                                                             localBinder?.player?.forcePlay(video.asMediaItem)
                                                         //binder?.setupRadio(video.info?.endpoint)
                                                     }
-                                                )
+                                                ),
+                                            disableScrollingText = disableScrollingText
                                         )
                                     }
                                 },

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
@@ -597,7 +597,8 @@ fun SearchResultScreen(
                                             .clickable(onClick = {
                                                 //playlistRoute(playlist.key)
                                                 navController.navigate("${NavRoutes.playlist.name}/${playlist.key}")
-                                            })
+                                            }),
+                                        disableScrollingText = disableScrollingText
                                     )
                                 },
                                 itemPlaceholderContent = {
@@ -642,7 +643,8 @@ fun SearchResultScreen(
                                                 //playlistRoute(playlist.key)
                                                 println("mediaItem searchResultScreen playlist key ${playlist.key}")
                                                 navController.navigate("${NavRoutes.podcast.name}/${playlist.key}")
-                                            })
+                                            }),
+                                        disableScrollingText = disableScrollingText
                                     )
                                 },
                                 itemPlaceholderContent = {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPage.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPage.kt
@@ -72,6 +72,7 @@ import it.fast4x.rimusic.ui.styling.shimmer
 import it.fast4x.rimusic.utils.UpdateYoutubeAlbum
 import it.fast4x.rimusic.utils.UpdateYoutubeArtist
 import it.fast4x.rimusic.utils.asMediaItem
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.durationTextToMillis
 import it.fast4x.rimusic.utils.forcePlayAtIndex
@@ -129,6 +130,7 @@ fun StatisticsPage(
     )
 
     val showStatsListeningTime by rememberPreference(showStatsListeningTimeKey,   true)
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     val context = LocalContext.current
 
@@ -415,7 +417,8 @@ fun StatisticsPage(
                                 if (albums[it].id != "" )
                                 //onGoToAlbum(albums[it].id)
                                     navController.navigate("${NavRoutes.album.name}/${albums[it].id}")
-                            })
+                            }),
+                        disableScrollingText = disableScrollingText
                     )
                 }
             }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPage.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPage.kt
@@ -453,7 +453,8 @@ fun StatisticsPage(
                                  //       null
                                  //   )
 
-                            })
+                            }),
+                        disableScrollingText = disableScrollingText
                     )
                 }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPage.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPage.kt
@@ -386,7 +386,8 @@ fun StatisticsPage(
                                     //onGoToArtist(artists[it].id)
                                     navController.navigate("${NavRoutes.artist.name}/${artists[it].id}")
                                 }
-                            })
+                            }),
+                        disableScrollingText = disableScrollingText
                     )
                 }
             }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPage.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPage.kt
@@ -332,7 +332,8 @@ fun StatisticsPage(
                                             NonQueuedMediaItemMenu(
                                                 navController = navController,
                                                 mediaItem = songs.get(it).asMediaItem,
-                                                onDismiss = menuState::hide
+                                                onDismiss = menuState::hide,
+                                                disableScrollingText = disableScrollingText
                                             )
                                             /*
                                                 BuiltInPlaylist.Offline -> InHistoryMediaItemMenu(
@@ -353,7 +354,8 @@ fun StatisticsPage(
                                     }
                                 )
                                 .animateItemPlacement()
-                                .width(itemInHorizontalGridWidth)
+                                .width(itemInHorizontalGridWidth),
+                            disableScrollingText = disableScrollingText
                         )
 
                     }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPageModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPageModern.kt
@@ -81,6 +81,7 @@ import it.fast4x.rimusic.utils.UpdateYoutubeArtist
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.center
 import it.fast4x.rimusic.utils.color
+import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.durationTextToMillis
 import it.fast4x.rimusic.utils.forcePlayAtIndex
@@ -144,6 +145,7 @@ fun StatisticsPageModern(
     )
 
     val showStatsListeningTime by rememberPreference(showStatsListeningTimeKey, true)
+    val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
 
     val context = LocalContext.current
 
@@ -432,7 +434,8 @@ fun StatisticsPageModern(
                                 .clickable(onClick = {
                                     if (albums[it].id != "")
                                         navController.navigate("${NavRoutes.album.name}/${albums[it].id}")
-                                })
+                                }),
+                            disableScrollingText = disableScrollingText
                         )
                     }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPageModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPageModern.kt
@@ -372,7 +372,8 @@ fun StatisticsPageModern(
                                             NonQueuedMediaItemMenu(
                                                 navController = navController,
                                                 mediaItem = songs.get(it).asMediaItem,
-                                                onDismiss = menuState::hide
+                                                onDismiss = menuState::hide,
+                                                disableScrollingText = disableScrollingText
                                             )
                                         }
                                     },
@@ -384,7 +385,8 @@ fun StatisticsPageModern(
                                         )
                                     }
                                 )
-                                .fillMaxWidth()
+                                .fillMaxWidth(),
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPageModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPageModern.kt
@@ -410,7 +410,8 @@ fun StatisticsPageModern(
                                     if (artists[it].id != "") {
                                         navController.navigate("${NavRoutes.artist.name}/${artists[it].id}")
                                     }
-                                })
+                                }),
+                            disableScrollingText = disableScrollingText
                         )
                     }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPageModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPageModern.kt
@@ -515,7 +515,8 @@ fun StatisticsPageModern(
                                             "${NavRoutes.localPlaylist.name}/$playlistId"
 
                                     navController.navigate(route = route)
-                                })
+                                }),
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/SearchYoutubeEntity.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/SearchYoutubeEntity.kt
@@ -44,7 +44,8 @@ fun SearchYoutubeEntity (
     navController: NavController,
     onDismiss: () -> Unit,
     query: String,
-    filter: Innertube.SearchFilter = Innertube.SearchFilter.Video
+    filter: Innertube.SearchFilter = Innertube.SearchFilter.Video,
+    disableScrollingText: Boolean
 ) {
     val binder = LocalPlayerServiceBinder.current
     val menuState = LocalMenuState.current
@@ -109,7 +110,8 @@ fun SearchYoutubeEntity (
                                             NonQueuedMediaItemMenu(
                                                 navController = rememberNavController(),
                                                 mediaItem = video.asMediaItem,
-                                                onDismiss = menuState::hide
+                                                onDismiss = menuState::hide,
+                                                disableScrollingText = disableScrollingText
                                             )
                                         };
                                         hapticFeedback.performHapticFeedback(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/SearchYoutubeEntity.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/SearchYoutubeEntity.kt
@@ -127,7 +127,8 @@ fun SearchYoutubeEntity (
                                         //binder?.setupRadio(video.info?.endpoint)
                                         onDismiss()
                                     }
-                                )
+                                ),
+                            disableScrollingText = disableScrollingText
                         )
                     }
                 },

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Utils.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Utils.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
@@ -612,3 +613,11 @@ inline val isAtLeastAndroid13
 
 inline val isAtLeastAndroid14
     get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+
+fun Modifier.conditional(condition : Boolean, modifier : Modifier.() -> Modifier) : Modifier {
+    return if (condition) {
+        then(modifier(Modifier))
+    } else {
+        this
+    }
+}


### PR DESCRIPTION
Disabling of scrolling of long text only worked in Player screen before.

Now also works for
- `ArtistItem`
- `AlbumItem`
- `FolderItem`
- `PlayListItem`
- `SongItem`
- `MiniPlayer`
- `VideoItem`

Additionally the text now scrolls in
- `ArtistsOverviewModern`
- `Header`
- album titles

Examples
<details><summary>Album</summary>
<p>

![rimusic_albums_list_no_text_scrolling](https://github.com/user-attachments/assets/6e562246-b4d2-4a0e-b949-f78a1b022941)

</p>
</details>

<details><summary>Artists list</summary>
<p>

![rimusic_artists_list_no_text_scrolling](https://github.com/user-attachments/assets/24363f07-3745-48fd-b1cc-68bf44550e0a)

</p>
</details> 

<details><summary>Playlist list</summary>
<p>

![rimusic_playlist_list_no_text_scrolling](https://github.com/user-attachments/assets/15fa8d0f-b5d7-4e1d-97e2-093a9df3c3ec)

</p>
</details> 

<details><summary>Song list</summary>
<p>

![rimusic_song_list_no_text_scrolling](https://github.com/user-attachments/assets/33df41fd-dafc-4b5f-9d57-388c2c839f2d)

</p>
</details> 

<details><summary>Quick Picks</summary>
<p>

![rimusic_quickpicks_no_text_scrolling](https://github.com/user-attachments/assets/7e971cd1-cbfd-46e7-9121-567e98e0bb5e)

</p>
</details>

<details><summary>Artist overview with Scrolling</summary>
<p>

![rimusic_artistoverview_text_scrolling](https://github.com/user-attachments/assets/207379e9-e84f-48b7-8942-174db511c59f)

</p>
</details> 

Closes #4093