### PR TITLE
Fixes the selection issue for CSV-file import

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -231,7 +231,7 @@ fun HomeLibraryModern(
         object: ImportSongsFromCSV {
             override val context = context
 
-            override fun onShortClick() = importLauncher.launch( arrayOf( "text/csv" ) )
+            override fun onShortClick() = importLauncher.launch( arrayOf("text/csv", "text/comma-separated-values") )
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -347,7 +347,7 @@ fun HomeSongsModern(
         object: ImportSongsFromCSV {
             override val context = context
 
-            override fun onShortClick() = importLauncher.launch(arrayOf("text/csv"))
+            override fun onShortClick() = importLauncher.launch(arrayOf("text/csv", "text/comma-separated-values"))
         }
     }
     // START - Export songs


### PR DESCRIPTION
Added another mime-type for csv-file import: `"text/comma-separated-values"`
For some reason `"text/csv"` does not work for files exported by RiMusic.

fixes #4094