### PR TITLE
only take audio formats

### DIFF
--- a/extensions/innertube/src/main/kotlin/it/fast4x/innertube/models/PlayerResponse.kt
+++ b/extensions/innertube/src/main/kotlin/it/fast4x/innertube/models/PlayerResponse.kt
@@ -41,7 +41,13 @@ data class PlayerResponse(
     ): MediaFormatContainer<StreamingData.AdaptiveFormat> {
 
         override val formats: SortedSet<AdaptiveFormat> =
-            sortedSetOf<AdaptiveFormat>().apply { addAll( adaptiveFormats ) }
+            sortedSetOf<AdaptiveFormat>().apply {
+                val audioOnly = adaptiveFormats.filter {
+                    it.mimeType.startsWith("audio")
+                }
+
+                addAll( audioOnly )
+            }
 
         @Serializable
         data class AdaptiveFormat(

--- a/extensions/innertube/src/main/kotlin/me/knighthat/invidious/response/PlayerResponse.kt
+++ b/extensions/innertube/src/main/kotlin/me/knighthat/invidious/response/PlayerResponse.kt
@@ -11,7 +11,13 @@ data class PlayerResponse(
 ): MediaFormatContainer<PlayerResponse.AdaptiveFormat> {
 
     override val formats: SortedSet<out AdaptiveFormat> =
-        sortedSetOf<AdaptiveFormat>().apply { addAll( adaptiveFormats ) }
+        sortedSetOf<AdaptiveFormat>().apply {
+            val audioOnly = adaptiveFormats.filter {
+                it.mimeType.startsWith("audio")
+            }
+
+            addAll( audioOnly )
+        }
 
     @Serializable
     data class AdaptiveFormat(


### PR DESCRIPTION
As discussed in [this post](https://github.com/fast4x/RiMusic/pull/4166#issuecomment-2443556816). I've gone ahead and add a filter to make sure all formats are audio only.