### PR TITLE
Fix binder null on use

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
@@ -148,7 +148,7 @@ fun HomeAlbumsModern(
             override fun onClick(item: Album) = onAlbumClick(item)
         }
     }
-    val shuffle = remember {
+    val shuffle = remember(binder) {
         object: SongsShuffle{
             override val binder = binder
             override val context = context

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
@@ -148,13 +148,14 @@ fun HomeAlbumsModern(
             override fun onClick(item: Album) = onAlbumClick(item)
         }
     }
-    val shuffle = object: SongsShuffle{
-        override val binder = binder
-        override val context = context
+    val shuffle = remember {
+        object: SongsShuffle{
+            override val binder = binder
+            override val context = context
 
-        override fun query(): Flow<List<Song>?> = Database.songsInAllBookmarkedAlbums()
+            override fun query(): Flow<List<Song>?> = Database.songsInAllBookmarkedAlbums()
+        }
     }
-
 
     // Search mutable
     var isSearchBarVisible by search.visibleState

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeAlbumsModern.kt
@@ -148,14 +148,13 @@ fun HomeAlbumsModern(
             override fun onClick(item: Album) = onAlbumClick(item)
         }
     }
-    val shuffle = remember {
-        object: SongsShuffle{
-            override val binder = binder
-            override val context = context
+    val shuffle = object: SongsShuffle{
+        override val binder = binder
+        override val context = context
 
-            override fun query(): Flow<List<Song>?> = Database.songsInAllBookmarkedAlbums()
-        }
+        override fun query(): Flow<List<Song>?> = Database.songsInAllBookmarkedAlbums()
     }
+
 
     // Search mutable
     var isSearchBarVisible by search.visibleState

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
@@ -141,7 +141,7 @@ fun HomeArtistsModern(
             override fun onClick(item: Artist) = onArtistClick(item)
         }
     }
-    val shuffle = remember {
+    val shuffle = remember(binder) {
         object: SongsShuffle{
             override val binder = binder
             override val context = context

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
@@ -141,14 +141,13 @@ fun HomeArtistsModern(
             override fun onClick(item: Artist) = onArtistClick(item)
         }
     }
-    val shuffle = remember {
-        object: SongsShuffle{
-            override val binder = binder
-            override val context = context
+    val shuffle = object: SongsShuffle{
+        override val binder = binder
+        override val context = context
 
-            override fun query(): Flow<List<Song>?> = Database.songsInAllFollowedArtists()
-        }
+        override fun query(): Flow<List<Song>?> = Database.songsInAllFollowedArtists()
     }
+
 
     // Search mutable
     var isSearchBarVisible by search.visibleState

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeArtistsModern.kt
@@ -141,13 +141,14 @@ fun HomeArtistsModern(
             override fun onClick(item: Artist) = onArtistClick(item)
         }
     }
-    val shuffle = object: SongsShuffle{
-        override val binder = binder
-        override val context = context
+    val shuffle = remember {
+        object: SongsShuffle{
+            override val binder = binder
+            override val context = context
 
-        override fun query(): Flow<List<Song>?> = Database.songsInAllFollowedArtists()
+            override fun query(): Flow<List<Song>?> = Database.songsInAllFollowedArtists()
+        }
     }
-
 
     // Search mutable
     var isSearchBarVisible by search.visibleState

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -157,7 +157,7 @@ fun HomeLibraryModern(
             override val sizeState = sizeState
         }
     }
-    val shuffle = remember {
+    val shuffle = remember(binder) {
         object: SongsShuffle {
             override val binder = binder
             override val context = context

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -157,19 +157,17 @@ fun HomeLibraryModern(
             override val sizeState = sizeState
         }
     }
-    val shuffle = remember {
-        object: SongsShuffle {
-            override val binder = binder
-            override val context = context
+    val shuffle = object: SongsShuffle {
+        override val binder = binder
+        override val context = context
 
-            override fun query(): Flow<List<Song>?> =
-                when( playlistType ) {
-                    PlaylistsType.Playlist -> Database.songsInAllPlaylists()
-                    PlaylistsType.PinnedPlaylist -> Database.songsInAllPinnedPlaylists()
-                    PlaylistsType.MonthlyPlaylist -> Database.songsInAllMonthlyPlaylists()
-                    PlaylistsType.PipedPlaylist -> Database.songsInAllPipedPlaylists()
-                }
-        }
+        override fun query(): Flow<List<Song>?> =
+            when( playlistType ) {
+                PlaylistsType.Playlist -> Database.songsInAllPlaylists()
+                PlaylistsType.PinnedPlaylist -> Database.songsInAllPinnedPlaylists()
+                PlaylistsType.MonthlyPlaylist -> Database.songsInAllMonthlyPlaylists()
+                PlaylistsType.PipedPlaylist -> Database.songsInAllPipedPlaylists()
+            }
     }
     val newPlaylistDialog = remember {
         object: InputDialog {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeLibraryModern.kt
@@ -157,17 +157,19 @@ fun HomeLibraryModern(
             override val sizeState = sizeState
         }
     }
-    val shuffle = object: SongsShuffle {
-        override val binder = binder
-        override val context = context
+    val shuffle = remember {
+        object: SongsShuffle {
+            override val binder = binder
+            override val context = context
 
-        override fun query(): Flow<List<Song>?> =
-            when( playlistType ) {
-                PlaylistsType.Playlist -> Database.songsInAllPlaylists()
-                PlaylistsType.PinnedPlaylist -> Database.songsInAllPinnedPlaylists()
-                PlaylistsType.MonthlyPlaylist -> Database.songsInAllMonthlyPlaylists()
-                PlaylistsType.PipedPlaylist -> Database.songsInAllPipedPlaylists()
-            }
+            override fun query(): Flow<List<Song>?> =
+                when( playlistType ) {
+                    PlaylistsType.Playlist -> Database.songsInAllPlaylists()
+                    PlaylistsType.PinnedPlaylist -> Database.songsInAllPinnedPlaylists()
+                    PlaylistsType.MonthlyPlaylist -> Database.songsInAllMonthlyPlaylists()
+                    PlaylistsType.PipedPlaylist -> Database.songsInAllPipedPlaylists()
+                }
+        }
     }
     val newPlaylistDialog = remember {
         object: InputDialog {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -315,16 +315,18 @@ fun HomeSongsModern(
             override val sortByState = deviceFolderSortState
         }
     }
-    val shuffle = object: SongsShuffle {
-        override val binder = binder
-        override val context = context
-        override val dispatcher = Dispatchers.Main
+    val shuffle = remember {
+        object: SongsShuffle {
+            override val binder = binder
+            override val context = context
+            override val dispatcher = Dispatchers.Main
 
-        override fun query(): Flow<List<Song>?> {
-            if ( builtInPlaylist == BuiltInPlaylist.OnDevice )
-                items = filteredSongs
+            override fun query(): Flow<List<Song>?> {
+                if ( builtInPlaylist == BuiltInPlaylist.OnDevice )
+                    items = filteredSongs
 
-            return  flowOf(items.map(SongEntity::song))
+                return  flowOf(items.map(SongEntity::song))
+            }
         }
     }
     // START - Import songs
@@ -372,33 +374,37 @@ fun HomeSongsModern(
             }
         }
     }
-    val downloadAllDialog = object: DownloadAllDialog {
-        override val context = context
-        override val binder = binder
-        override val toggleState = downloadAllToggleState
-        override val downloadState = downloadState
+    val downloadAllDialog = remember {
+        object: DownloadAllDialog {
+            override val context = context
+            override val binder = binder
+            override val toggleState = downloadAllToggleState
+            override val downloadState = downloadState
 
-        override fun listToProcess(): List<MediaItem> =
-            if( listMediaItems.isNotEmpty() )
-                listMediaItems
-            else if( items.isNotEmpty() )
-                items.map( SongEntity::asMediaItem )
-            else
-                listOf()
+            override fun listToProcess(): List<MediaItem> =
+                if( listMediaItems.isNotEmpty() )
+                    listMediaItems
+                else if( items.isNotEmpty() )
+                    items.map( SongEntity::asMediaItem )
+                else
+                    listOf()
+        }
     }
-    val deleteDownloadsDialog = object: DeleteDownloadsDialog {
-        override val context = context
-        override val binder = binder
-        override val toggleState = deleteDownloadsToggleState
-        override val downloadState = downloadState
+    val deleteDownloadsDialog = remember {
+        object: DeleteDownloadsDialog {
+            override val context = context
+            override val binder = binder
+            override val toggleState = deleteDownloadsToggleState
+            override val downloadState = downloadState
 
-        override fun listToProcess(): List<MediaItem> =
-            if( listMediaItems.isNotEmpty() )
-                listMediaItems
-            else if( items.isNotEmpty() )
-                items.map( SongEntity::asMediaItem )
-            else
-                emptyList()
+            override fun listToProcess(): List<MediaItem> =
+                if( listMediaItems.isNotEmpty() )
+                    listMediaItems
+                else if( items.isNotEmpty() )
+                    items.map( SongEntity::asMediaItem )
+                else
+                    emptyList()
+        }
     }
     val deleteSongDialog = remember {
         object: ConfirmationDialog {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -525,7 +525,7 @@ fun HomeSongsModern(
         }
         BuiltInPlaylist.Downloaded, BuiltInPlaylist.Favorites, BuiltInPlaylist.Offline, BuiltInPlaylist.Top -> {
 
-            LaunchedEffect(Unit, builtInPlaylist, sortBy, sortOrder, searchInput, topPlaylistPeriod) {
+            LaunchedEffect(Unit, builtInPlaylist, sortBy, sortOrder, searchInput, topPlaylistPeriod, binder) {
 
                 var songFlow: Flow<List<SongEntity>> = flowOf()
                 var dispatcher = Dispatchers.Default

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -315,7 +315,7 @@ fun HomeSongsModern(
             override val sortByState = deviceFolderSortState
         }
     }
-    val shuffle = remember {
+    val shuffle = remember(binder) {
         object: SongsShuffle {
             override val binder = binder
             override val context = context
@@ -374,7 +374,7 @@ fun HomeSongsModern(
             }
         }
     }
-    val downloadAllDialog = remember {
+    val downloadAllDialog = remember(binder) {
         object: DownloadAllDialog {
             override val context = context
             override val binder = binder
@@ -390,7 +390,7 @@ fun HomeSongsModern(
                     listOf()
         }
     }
-    val deleteDownloadsDialog = remember {
+    val deleteDownloadsDialog = remember(binder) {
         object: DeleteDownloadsDialog {
             override val context = context
             override val binder = binder

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongsModern.kt
@@ -315,18 +315,16 @@ fun HomeSongsModern(
             override val sortByState = deviceFolderSortState
         }
     }
-    val shuffle = remember {
-        object: SongsShuffle {
-            override val binder = binder
-            override val context = context
-            override val dispatcher = Dispatchers.Main
+    val shuffle = object: SongsShuffle {
+        override val binder = binder
+        override val context = context
+        override val dispatcher = Dispatchers.Main
 
-            override fun query(): Flow<List<Song>?> {
-                if ( builtInPlaylist == BuiltInPlaylist.OnDevice )
-                    items = filteredSongs
+        override fun query(): Flow<List<Song>?> {
+            if ( builtInPlaylist == BuiltInPlaylist.OnDevice )
+                items = filteredSongs
 
-                return  flowOf(items.map(SongEntity::song))
-            }
+            return  flowOf(items.map(SongEntity::song))
         }
     }
     // START - Import songs
@@ -374,37 +372,33 @@ fun HomeSongsModern(
             }
         }
     }
-    val downloadAllDialog = remember {
-        object: DownloadAllDialog {
-            override val context = context
-            override val binder = binder
-            override val toggleState = downloadAllToggleState
-            override val downloadState = downloadState
+    val downloadAllDialog = object: DownloadAllDialog {
+        override val context = context
+        override val binder = binder
+        override val toggleState = downloadAllToggleState
+        override val downloadState = downloadState
 
-            override fun listToProcess(): List<MediaItem> =
-                if( listMediaItems.isNotEmpty() )
-                    listMediaItems
-                else if( items.isNotEmpty() )
-                    items.map( SongEntity::asMediaItem )
-                else
-                    listOf()
-        }
+        override fun listToProcess(): List<MediaItem> =
+            if( listMediaItems.isNotEmpty() )
+                listMediaItems
+            else if( items.isNotEmpty() )
+                items.map( SongEntity::asMediaItem )
+            else
+                listOf()
     }
-    val deleteDownloadsDialog = remember {
-        object: DeleteDownloadsDialog {
-            override val context = context
-            override val binder = binder
-            override val toggleState = deleteDownloadsToggleState
-            override val downloadState = downloadState
+    val deleteDownloadsDialog = object: DeleteDownloadsDialog {
+        override val context = context
+        override val binder = binder
+        override val toggleState = deleteDownloadsToggleState
+        override val downloadState = downloadState
 
-            override fun listToProcess(): List<MediaItem> =
-                if( listMediaItems.isNotEmpty() )
-                    listMediaItems
-                else if( items.isNotEmpty() )
-                    items.map( SongEntity::asMediaItem )
-                else
-                    emptyList()
-        }
+        override fun listToProcess(): List<MediaItem> =
+            if( listMediaItems.isNotEmpty() )
+                listMediaItems
+            else if( items.isNotEmpty() )
+                items.map( SongEntity::asMediaItem )
+            else
+                emptyList()
     }
     val deleteSongDialog = remember {
         object: ConfirmationDialog {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
@@ -373,47 +373,50 @@ fun LocalPlaylistSongs(
             }
         }
     }
-    val downloadAllDialog = object: DownloadAllDialog {
-        override val context = context
-        override val binder = binder
-        override val toggleState = downloadAllToggleState
-        override val downloadState = downloadState
+    val downloadAllDialog = remember {
+        object: DownloadAllDialog {
+            override val context = context
+            override val binder = binder
+            override val toggleState = downloadAllToggleState
+            override val downloadState = downloadState
 
-        override fun listToProcess(): List<MediaItem> =
-            if( listMediaItems.isNotEmpty() )
-                listMediaItems
-            else if( playlistSongs.isNotEmpty() ) {
-                playlistSongs.map {
-                    query {
-                        Database.insert(
-                            Song(
-                                id = it.asMediaItem.mediaId,
-                                title = it.asMediaItem.mediaMetadata.title.toString(),
-                                artistsText = it.asMediaItem.mediaMetadata.artist.toString(),
-                                thumbnailUrl = it.song.thumbnailUrl,
-                                durationText = null
+            override fun listToProcess(): List<MediaItem> =
+                if( listMediaItems.isNotEmpty() )
+                    listMediaItems
+                else if( playlistSongs.isNotEmpty() ) {
+                    playlistSongs.map {
+                        query {
+                            Database.insert(
+                                Song(
+                                    id = it.asMediaItem.mediaId,
+                                    title = it.asMediaItem.mediaMetadata.title.toString(),
+                                    artistsText = it.asMediaItem.mediaMetadata.artist.toString(),
+                                    thumbnailUrl = it.song.thumbnailUrl,
+                                    durationText = null
+                                )
                             )
-                        )
+                        }
+
+                        it.asMediaItem
                     }
-
-                    it.asMediaItem
-                }
-            } else listOf()
+                } else listOf()
+        }
     }
+    val deleteDownloadsDialog = remember {
+        object: DeleteDownloadsDialog {
+            override val context = context
+            override val binder = binder
+            override val toggleState = deleteDownloadsToggleState
+            override val downloadState = downloadState
 
-    val deleteDownloadsDialog = object: DeleteDownloadsDialog {
-        override val context = context
-        override val binder = binder
-        override val toggleState = deleteDownloadsToggleState
-        override val downloadState = downloadState
-
-        override fun listToProcess(): List<MediaItem> =
-            if( listMediaItems.isNotEmpty() )
-                listMediaItems
-            else if( playlistSongs.isNotEmpty() )
-                playlistSongs.map( SongEntity::asMediaItem )
-            else
-                emptyList()
+            override fun listToProcess(): List<MediaItem> =
+                if( listMediaItems.isNotEmpty() )
+                    listMediaItems
+                else if( playlistSongs.isNotEmpty() )
+                    playlistSongs.map( SongEntity::asMediaItem )
+                else
+                    emptyList()
+        }
     }
 
     // Search mutable

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
@@ -373,50 +373,47 @@ fun LocalPlaylistSongs(
             }
         }
     }
-    val downloadAllDialog = remember {
-        object: DownloadAllDialog {
-            override val context = context
-            override val binder = binder
-            override val toggleState = downloadAllToggleState
-            override val downloadState = downloadState
+    val downloadAllDialog = object: DownloadAllDialog {
+        override val context = context
+        override val binder = binder
+        override val toggleState = downloadAllToggleState
+        override val downloadState = downloadState
 
-            override fun listToProcess(): List<MediaItem> =
-                if( listMediaItems.isNotEmpty() )
-                    listMediaItems
-                else if( playlistSongs.isNotEmpty() ) {
-                    playlistSongs.map {
-                        query {
-                            Database.insert(
-                                Song(
-                                    id = it.asMediaItem.mediaId,
-                                    title = it.asMediaItem.mediaMetadata.title.toString(),
-                                    artistsText = it.asMediaItem.mediaMetadata.artist.toString(),
-                                    thumbnailUrl = it.song.thumbnailUrl,
-                                    durationText = null
-                                )
+        override fun listToProcess(): List<MediaItem> =
+            if( listMediaItems.isNotEmpty() )
+                listMediaItems
+            else if( playlistSongs.isNotEmpty() ) {
+                playlistSongs.map {
+                    query {
+                        Database.insert(
+                            Song(
+                                id = it.asMediaItem.mediaId,
+                                title = it.asMediaItem.mediaMetadata.title.toString(),
+                                artistsText = it.asMediaItem.mediaMetadata.artist.toString(),
+                                thumbnailUrl = it.song.thumbnailUrl,
+                                durationText = null
                             )
-                        }
-
-                        it.asMediaItem
+                        )
                     }
-                } else listOf()
-        }
-    }
-    val deleteDownloadsDialog = remember {
-        object: DeleteDownloadsDialog {
-            override val context = context
-            override val binder = binder
-            override val toggleState = deleteDownloadsToggleState
-            override val downloadState = downloadState
 
-            override fun listToProcess(): List<MediaItem> =
-                if( listMediaItems.isNotEmpty() )
-                    listMediaItems
-                else if( playlistSongs.isNotEmpty() )
-                    playlistSongs.map( SongEntity::asMediaItem )
-                else
-                    emptyList()
-        }
+                    it.asMediaItem
+                }
+            } else listOf()
+    }
+
+    val deleteDownloadsDialog = object: DeleteDownloadsDialog {
+        override val context = context
+        override val binder = binder
+        override val toggleState = deleteDownloadsToggleState
+        override val downloadState = downloadState
+
+        override fun listToProcess(): List<MediaItem> =
+            if( listMediaItems.isNotEmpty() )
+                listMediaItems
+            else if( playlistSongs.isNotEmpty() )
+                playlistSongs.map( SongEntity::asMediaItem )
+            else
+                emptyList()
     }
 
     // Search mutable

--- a/composeApp/src/androidMain/kotlin/me/knighthat/component/tab/toolbar/DeleteDownloadsDialog.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/component/tab/toolbar/DeleteDownloadsDialog.kt
@@ -32,6 +32,9 @@ interface DeleteDownloadsDialog: ConfirmationDialog {
 
     override fun onConfirm() {
         listToProcess().forEach {
+            if(binder == null){ // binder has to be non-null for remove from cache to work
+                return
+            }
             binder?.cache?.removeResource(it.mediaId)
             query {
                 Database.resetFormatContentLength(it.mediaId)

--- a/composeApp/src/androidMain/kotlin/me/knighthat/component/tab/toolbar/DownloadAllDialog.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/component/tab/toolbar/DownloadAllDialog.kt
@@ -36,6 +36,9 @@ interface DownloadAllDialog: ConfirmationDialog {
         downloadState.intValue = Download.STATE_DOWNLOADING
 
         listToProcess().forEach {
+            if(binder == null){ // binder has to be non-null for remove from cache to work
+                return
+            }
             binder?.cache?.removeResource(it.mediaId)
             query {
                 Database.resetFormatContentLength(it.mediaId)


### PR DESCRIPTION
Serval components do not work correctly if the app is started into the section where the component is located. As `binder` is `null` when the first composition happens, the components are not created correctly.

The solution is to condition the `remember`-/`LaunchedEffect`-blocks (that where the problem) on `binder` so that they get re-evaluated on the next recomposition.

Affected Features:

- shuffle button: start the player with a queue of shuffled songs (shuffle did not work)
- download all button: download all songs of the playlist (cached items where not removed)
- delete all button: delete all downloaded songs of the playlist (cached items where not removed)

closes #4297