### PR TITLE
A Solution for the "at most 100 Artist's Songs" Problem

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
@@ -466,13 +466,13 @@ fun ArtistScreen(
                                             ?.songsEndpoint
                                             ?.takeIf { it.browseId != null }
                                             ?.let { endpoint ->
-                                                    Innertube.itemsPage(
-                                                        body = BrowseBody(
-                                                            browseId = endpoint.browseId!!,
-                                                            params = endpoint.params
-                                                        ),
-                                                        fromMusicResponsiveListItemRenderer = Innertube.SongItem::from,
-                                                    )?.completed()
+                                                Innertube.itemsPage(
+                                                    body = BrowseBody(
+                                                        browseId = endpoint.browseId!!,
+                                                        params = endpoint.params
+                                                    ),
+                                                    fromMusicResponsiveListItemRenderer = Innertube.SongItem::from,
+                                                )?.completed()
                                             }
                                         ?: Result.success( // is this section ever reached now?
                                             Innertube.ItemsPage(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
@@ -72,7 +72,6 @@ import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.asMediaItem
-import it.fast4x.rimusic.utils.asSong
 import it.fast4x.rimusic.utils.completed
 import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.downloadedStateMedia

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
@@ -466,16 +466,13 @@ fun ArtistScreen(
                                             ?.songsEndpoint
                                             ?.takeIf { it.browseId != null }
                                             ?.let { endpoint ->
-                                                runCatching {
-                                                    val resultPlayListOrAlbumPage = Innertube.playlistPage(
-                                                        BrowseBody(
+                                                    Innertube.itemsPage(
+                                                        body = BrowseBody(
                                                             browseId = endpoint.browseId!!,
                                                             params = endpoint.params
-                                                        )
-                                                    ) ?.completed()
-                                                    val playListOrAlbumPage = resultPlayListOrAlbumPage?.getOrThrow()
-                                                    playListOrAlbumPage!!.songsPage // still a nullable value
-                                                }
+                                                        ),
+                                                        fromMusicResponsiveListItemRenderer = Innertube.SongItem::from,
+                                                    )?.completed()
                                             }
                                         ?: Result.success( // is this section ever reached now?
                                             Innertube.ItemsPage(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/artist/ArtistScreen.kt
@@ -470,7 +470,8 @@ fun ArtistScreen(
                                                 runCatching {
                                                     val resultPlayListOrAlbumPage = Innertube.playlistPage(
                                                         BrowseBody(
-                                                            browseId = endpoint.browseId!!
+                                                            browseId = endpoint.browseId!!,
+                                                            params = endpoint.params
                                                         )
                                                     ) ?.completed()
                                                     val playListOrAlbumPage = resultPlayListOrAlbumPage?.getOrThrow()


### PR DESCRIPTION
- solution based on code for playlist sync
- loads all songs at once instead of relying on continuation as before
- converts the `PlayListOrAlbumPage` to an `Innertube.ItemsPage`
- on purpose may throw error that then get converted to a result.
- output is nullable (it could still be null, maybe should prevent it)
- the following branch of the elvis-operator is maybe never called. Or is this branch the solution for the previous problem?

fixes #1604
fixes #2271
fixes #2596