### PR TITLE
Fixed thumbnail fit for small images

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/Playlist.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/Playlist.kt
@@ -46,6 +46,8 @@ fun Playlist(
                 AsyncImage(
                     model = thumbnailUrl.thumbnail(thumbnailSizePx),
                     contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxSize(),
                     contentScale = ContentScale.Crop,
                 )
             } else if (thumbnails.toSet().size == 1) {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/PlaylistItem.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/PlaylistItem.kt
@@ -130,6 +130,8 @@ fun PlaylistItem(
                 AsyncImage(
                     model = playlistThumbnailUrl.value,
                     contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxSize(),
                     contentScale = ContentScale.Crop
                 )
             } else if (thumbnails.toSet().size == 1) {


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/98e79e42-e56b-4a90-8aa3-450693cd5f26)


With this PR, this issue has been fixed by filling the image to max size and cropping the extra