### PR TITLE
Bug fix for app crash when persistant queue is enabled

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/PlayerServiceModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/PlayerServiceModern.kt
@@ -1334,16 +1334,6 @@ class PlayerServiceModern : MediaLibraryService(),
                     queuedSong[index].position ?: C.TIME_UNSET
                 )
                 player.prepare()
-
-                runCatching {
-                    ContextCompat.startForegroundService(
-                        this@PlayerServiceModern,
-                        intent<PlayerServiceModern>()
-                    )
-                }.onFailure {
-                    Timber.e("maybeRestorePlayerQueue startForegroundService ${it.stackTraceToString()}")
-                }
-
             }
         }
 


### PR DESCRIPTION
Refer this issue #4492 for full details on the bug and the fix.

this is a resource I found online: https://stackoverflow.com/questions/44425584/context-startforegroundservice-did-not-then-call-service-startforeground

From what I understood, the `startForegroundService` is only required when the app wants to push a notification, and the catch is the app has to start notification within 5 seconds of calling `startForegroundService`.

In this piece of code: 

```
runCatching {
                    ContextCompat.startForegroundService(
                        this@PlayerServiceModern,
                        intent<PlayerServiceModern>()
                    )
                }.onFailure {
                    Timber.e("maybeRestorePlayerQueue startForegroundService ${it.stackTraceToString()}")
                }
```

The app is unnecessarily calling `startForegroundService` because it is never creating a notification from here. the notification logic seems to somewhere else and independent of this. Since notification is not being started within 5 seconds, the OS things its an ANR and closes the app.

On removing this code snippet, the bug got fixed for me. so I think this is the issue.

This code might have ended up here while refactoring the notification logic, because originally in `PlayerService.kt`, notification logic was immediately after this code snippet.

please correct me if am wrong