### PR TITLE
fixed lyrics outline alignment, improved vinyl in modern player

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/VinylThumbnailCover.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/VinylThumbnailCover.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -109,6 +110,55 @@ fun VinylThumbnailCoverAnimation(
 
     LaunchedEffect(isSongPlaying) {
         if (isSongPlaying) {
+            rotation.animateTo(
+                targetValue = currentRotation + 360f,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(8000, easing = LinearEasing),
+                    repeatMode = RepeatMode.Restart
+                )
+            ) {
+                currentRotation = value
+            }
+        } else {
+            if (currentRotation > 0f) {
+                rotation.animateTo(
+                    targetValue = currentRotation + 50,
+                    animationSpec = tween(
+                        1250,
+                        easing = LinearOutSlowInEasing
+                    )
+                ) {
+                    currentRotation = value
+                }
+            }
+        }
+    }
+
+    VinylThumnbailCover(
+        painter = painter,
+        rotationDegrees = rotation.value,
+        modifier = modifier
+    )
+}
+
+@Composable
+fun VinylThumbnailCoverAnimationModern(
+    modifier: Modifier = Modifier,
+    isSongPlaying: Boolean = true,
+    painter: Painter,
+    state : PagerState,
+    it : Int
+) {
+    var currentRotation by remember {
+        mutableFloatStateOf(0f)
+    }
+
+    val rotation = remember {
+        Animatable(currentRotation)
+    }
+
+    LaunchedEffect(isSongPlaying) {
+        if (isSongPlaying && it == state.settledPage) {
             rotation.animateTo(
                 targetValue = currentRotation + 360f,
                 animationSpec = infiniteRepeatable(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Lyrics.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Lyrics.kt
@@ -47,6 +47,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -150,9 +151,11 @@ import timber.log.Timber
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import it.fast4x.rimusic.enums.LyricsBackground
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.lyricsAlignmentKey
 import it.fast4x.rimusic.utils.romanizationEnabeledKey
 import it.fast4x.rimusic.utils.showSecondLineKey
+import it.fast4x.rimusic.utils.showVinylThumbnailAnimationKey
 import me.bush.translator.Translation
 
 
@@ -330,6 +333,7 @@ fun Lyrics(
         }
         var lyricsHighlight by rememberPreference(lyricsHighlightKey, LyricsHighlight.None)
         var lyricsAlignment by rememberPreference(lyricsAlignmentKey, LyricsAlignment.Center)
+        var showVinylThumbnailAnimation by rememberPreference(showVinylThumbnailAnimationKey, false)
 
         fun translateLyricsWithRomanization(output: MutableState<String>, textToTranslate: String, isSync: Boolean, destinationLanguage: Language = Language.AUTO) = @Composable{
             LaunchedEffect(showSecondLine, romanizationEnabeled, textToTranslate, destinationLanguage){
@@ -338,7 +342,6 @@ fun Lyrics(
                     try {
                         var translation: Translation?
                         var translation2: Translation?
-                        val regex = "\\s+".toRegex()
                         if(destinationLanguage == Language.AUTO){
                             translation = translator.translate(
                                 textToTranslate,
@@ -358,9 +361,9 @@ fun Lyrics(
                             translation.sourceLanguage
                         )
                         val outputText = if(romanizationEnabeled){
-                            if (showSecondLine && isSync && textToTranslate != "" && !regex.matches(textToTranslate) && translation.sourceLanguage != translation.targetLanguage) {(translation2.pronunciation ?: translation2.sourceText) + "\\n[${translation.translatedText}]"} else translation.pronunciation ?: translation.translatedText
+                            if (showSecondLine && isSync && textToTranslate != "" && translation.sourceLanguage != translation.targetLanguage) {(translation2.pronunciation ?: translation2.sourceText) + "\\n[${translation.translatedText}]"} else translation.pronunciation ?: translation.translatedText
                         }else{
-                            if (showSecondLine && isSync && textToTranslate != "" && !regex.matches(textToTranslate) && translation.sourceLanguage != translation.targetLanguage) {textToTranslate + "\\n[${translation.translatedText}]"} else translation.translatedText
+                            if (showSecondLine && isSync && textToTranslate != "" && translation.sourceLanguage != translation.targetLanguage) {textToTranslate + "\\n[${translation.translatedText}]"} else translation.translatedText
                         }
                         outputText.replace("\\r","\r").replace("\\n","\n")
                     } catch (e: Exception) {
@@ -744,17 +747,18 @@ fun Lyrics(
                             items = synchronizedLyrics.sentences
                         ) { index, sentence ->
                             var translatedText by remember { mutableStateOf("") }
+                            val trimmedSentence = sentence.second.trim()
                             if (translateEnabled) {
                                 val mutState = remember { mutableStateOf("") }
-                                translateLyricsWithRomanization(mutState, sentence.second, true, languageDestination)()
+                                translateLyricsWithRomanization(mutState, trimmedSentence, true, languageDestination)()
                                 translatedText = mutState.value
                             } else {
                                 if (romanizationEnabeled) {
                                     val mutState = remember { mutableStateOf("") }
-                                    translateLyricsWithRomanization(mutState, sentence.second, true)()
+                                    translateLyricsWithRomanization(mutState, trimmedSentence, true)()
                                     translatedText = mutState.value
                                 } else {
-                                    translatedText = sentence.second
+                                    translatedText = trimmedSentence
                                 }
                             }
 
@@ -903,6 +907,7 @@ fun Lyrics(
                                         }),
                                         modifier = Modifier
                                             .padding(vertical = 4.dp, horizontal = 32.dp)
+                                            .align(if (lyricsAlignment == LyricsAlignment.Left) Alignment.CenterStart else if (lyricsAlignment == LyricsAlignment.Right) Alignment.CenterEnd else Alignment.Center)
                                             .clickable {
                                                 if (clickLyricsText)
                                                     binder?.player?.seekTo(sentence.first)
@@ -993,6 +998,7 @@ fun Lyrics(
                                         }),
                                         modifier = Modifier
                                             .padding(vertical = 4.dp, horizontal = 32.dp)
+                                            .align(if (lyricsAlignment == LyricsAlignment.Left) Alignment.CenterStart else if (lyricsAlignment == LyricsAlignment.Right) Alignment.CenterEnd else Alignment.Center)
                                             .clickable {
                                                 if (clickLyricsText)
                                                     binder?.player?.seekTo(sentence.first)
@@ -1042,6 +1048,7 @@ fun Lyrics(
                                         ),
                                         modifier = Modifier
                                             .padding(vertical = 4.dp, horizontal = 32.dp)
+                                            .align(if (lyricsAlignment == LyricsAlignment.Left) Alignment.CenterStart else if (lyricsAlignment == LyricsAlignment.Right) Alignment.CenterEnd else Alignment.Center)
                                             .clickable {
                                                 if (clickLyricsText)
                                                     binder?.player?.seekTo(sentence.first)
@@ -1219,6 +1226,7 @@ fun Lyrics(
                                             ),
                                             modifier = Modifier
                                                 .padding(vertical = 4.dp, horizontal = 32.dp)
+                                                .align(if (lyricsAlignment == LyricsAlignment.Left) Alignment.CenterStart else if (lyricsAlignment == LyricsAlignment.Right) Alignment.CenterEnd else Alignment.Center)
                                                 .clickable {
                                                     if (clickLyricsText)
                                                         binder?.player?.seekTo(sentence.first)
@@ -1266,6 +1274,7 @@ fun Lyrics(
                                             ),
                                             modifier = Modifier
                                                 .padding(vertical = 4.dp, horizontal = 32.dp)
+                                                .align(if (lyricsAlignment == LyricsAlignment.Left) Alignment.CenterStart else if (lyricsAlignment == LyricsAlignment.Right) Alignment.CenterEnd else Alignment.Center)
                                                 .clickable {
                                                     if (clickLyricsText)
                                                         binder?.player?.seekTo(sentence.first)
@@ -1335,6 +1344,7 @@ fun Lyrics(
                                             ),
                                             modifier = Modifier
                                                 .padding(vertical = 4.dp, horizontal = 32.dp)
+                                                .align(if (lyricsAlignment == LyricsAlignment.Left) Alignment.CenterStart else if (lyricsAlignment == LyricsAlignment.Right) Alignment.CenterEnd else Alignment.Center)
                                                 .clickable {
                                                     if (clickLyricsText)
                                                         binder?.player?.seekTo(sentence.first)
@@ -1470,7 +1480,9 @@ fun Lyrics(
                                             typography().xlxl.medium.color(
                                                 PureBlackColorPalette.text
                                             )
-                                    })
+                                    }),
+                                    modifier = Modifier
+                                            .align(if (lyricsAlignment == LyricsAlignment.Left) Alignment.CenterStart else if (lyricsAlignment == LyricsAlignment.Right) Alignment.CenterEnd else Alignment.Center)
                                 )
                             else if ((lyricsColor == LyricsColor.Thememode) || (lyricsColor == LyricsColor.White) || (lyricsColor == LyricsColor.Black) || (lyricsColor == LyricsColor.Accent))
                                 BasicText(
@@ -1514,7 +1526,9 @@ fun Lyrics(
                                                 else if (lyricsColor == LyricsColor.Accent) colorPalette().accent
                                                 else Color.Transparent
                                             )
-                                    })
+                                    }),
+                                    modifier = Modifier
+                                        .align(if (lyricsAlignment == LyricsAlignment.Left) Alignment.CenterStart else if (lyricsAlignment == LyricsAlignment.Right) Alignment.CenterEnd else Alignment.Center)
                                 )
                             else
                                 BasicText(
@@ -1544,7 +1558,9 @@ fun Lyrics(
                                                     PureBlackColorPalette.text
                                                 )
                                         }
-                                    )
+                                    ),
+                                    modifier = Modifier
+                                        .align(if (lyricsAlignment == LyricsAlignment.Left) Alignment.CenterStart else if (lyricsAlignment == LyricsAlignment.Right) Alignment.CenterEnd else Alignment.Center)
                                 )
                             //Lyrics Outline Non Synced
                             if (!showlyricsthumbnail)
@@ -1622,7 +1638,9 @@ fun Lyrics(
                                                         else Color.Black.copy(0.6f)
                                                     )
                                             }
-                                        )
+                                        ),
+                                        modifier = Modifier
+                                                .align(if (lyricsAlignment == LyricsAlignment.Left) Alignment.CenterStart else if (lyricsAlignment == LyricsAlignment.Right) Alignment.CenterEnd else Alignment.Center)
                                     )
                                 else
                                     BasicText(
@@ -1671,7 +1689,9 @@ fun Lyrics(
                                                         else Color.Black.copy(0.6f)
                                                     )
                                             }
-                                        )
+                                        ),
+                                        modifier = Modifier
+                                           .align(if (lyricsAlignment == LyricsAlignment.Left) Alignment.CenterStart else if (lyricsAlignment == LyricsAlignment.Right) Alignment.CenterEnd else Alignment.Center)
                                     )
 
                         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Lyrics.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Lyrics.kt
@@ -47,7 +47,6 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -151,11 +150,9 @@ import timber.log.Timber
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import it.fast4x.rimusic.enums.LyricsBackground
-import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.lyricsAlignmentKey
 import it.fast4x.rimusic.utils.romanizationEnabeledKey
 import it.fast4x.rimusic.utils.showSecondLineKey
-import it.fast4x.rimusic.utils.showVinylThumbnailAnimationKey
 import me.bush.translator.Translation
 
 
@@ -333,7 +330,6 @@ fun Lyrics(
         }
         var lyricsHighlight by rememberPreference(lyricsHighlightKey, LyricsHighlight.None)
         var lyricsAlignment by rememberPreference(lyricsAlignmentKey, LyricsAlignment.Center)
-        var showVinylThumbnailAnimation by rememberPreference(showVinylThumbnailAnimationKey, false)
 
         fun translateLyricsWithRomanization(output: MutableState<String>, textToTranslate: String, isSync: Boolean, destinationLanguage: Language = Language.AUTO) = @Composable{
             LaunchedEffect(showSecondLine, romanizationEnabeled, textToTranslate, destinationLanguage){

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
@@ -214,7 +214,7 @@ import it.fast4x.rimusic.utils.carouselKey
 import it.fast4x.rimusic.utils.carouselSizeKey
 import it.fast4x.rimusic.cleanPrefix
 import it.fast4x.rimusic.enums.QueueLoopType
-import it.fast4x.rimusic.ui.components.themed.VinylThumbnailCoverAnimation
+import it.fast4x.rimusic.ui.components.themed.VinylThumbnailCoverAnimationModern
 import it.fast4x.rimusic.utils.VerticalfadingEdge2
 import it.fast4x.rimusic.utils.actionExpandedKey
 import it.fast4x.rimusic.utils.textoutlineKey
@@ -1787,11 +1787,12 @@ fun Player(
                          )
 
                      if (showVinylThumbnailAnimation)
-                         VinylThumbnailCoverAnimation(
+                         VinylThumbnailCoverAnimationModern(
                              painter = coverPainter,
                              isSongPlaying = player.isPlaying,
-                             modifier = coverModifier
-
+                             modifier = coverModifier,
+                             state = pagerState,
+                             it = it
                          )
                      else
                          Image(
@@ -2620,11 +2621,12 @@ fun Player(
                                          )
 
                                      if (showVinylThumbnailAnimation)
-                                         VinylThumbnailCoverAnimation(
+                                         VinylThumbnailCoverAnimationModern(
                                              painter = coverPainter,
                                              isSongPlaying = player.isPlaying,
-                                             modifier = coverModifier
-
+                                             modifier = coverModifier,
+                                             state = pagerState,
+                                             it = it
                                          )
                                      else
                                          Image(


### PR DESCRIPTION
1) fixed lyrics outline problem
2) trimmed spaces at the starting and end of the lyrics
3) Stopped those thumbnails from spinning which are not playing in carousel view