### PR TITLE
Fixed Scrubbing with "Fake Wave Form" - Audio bar

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/GetSeekBarType.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/GetSeekBarType.kt
@@ -238,6 +238,7 @@ fun GetSeekBar(
                 waveInteraction = {
                     scrubbingPosition = (it.value * duration.toFloat()).toLong()
                     binder.player.seekTo(scrubbingPosition!!)
+                    scrubbingPosition = null
                 },
                 modifier = Modifier
                     .height(40.dp)


### PR DESCRIPTION
- the play time did not get updated, if the audio bar was set to Fake Wave Form and the position is changed by "scrubbing"

Demo:

<details><summary>With the bug</summary>
<p>


https://github.com/user-attachments/assets/b0f5a91e-7a57-4c7f-b727-5b7bcfd58eb0



</p>
</details> 

<details><summary>Fixed</summary>
<p>


https://github.com/user-attachments/assets/2c7b768b-0d59-4c86-bb01-ac2c2c875fba


</p>
</details> 