### PR TITLE
Allow for custom button order (for TabToolBar-Buttons)

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/enums/HomeSongsButton.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/enums/HomeSongsButton.kt
@@ -1,0 +1,20 @@
+package it.fast4x.rimusic.enums
+
+enum class HomeSongsButton {
+    SortOrTop,
+    Search,
+    Locator,
+    DownloadAll,
+    DeleteDownloads,
+    DeleteSong,
+    HiddenSongs,
+    Shuffle,
+    RandomSorter,
+    ItemSelector,
+    PlayNext,
+    Enqueue,
+    AddToFavorite,
+    AddToPlaylist,
+    Export,
+    Import
+}

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
@@ -937,6 +937,8 @@ private fun HomeSongsTabToolBarButtons(
     )
 
     if(isCustomButtonOrder) {
+
+        // todo (correct) string add to keys
         val customButtonOrder by rememberPreference("home_songs_custom_button_order",
             HomeSongsButton.entries.toList()
         )

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
@@ -60,6 +60,7 @@ import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.BuiltInPlaylist
 import it.fast4x.rimusic.enums.DurationInMinutes
+import it.fast4x.rimusic.enums.HomeSongsButton
 import it.fast4x.rimusic.enums.MaxSongs
 import it.fast4x.rimusic.enums.MaxTopPlaylistItems
 import it.fast4x.rimusic.enums.NavigationBarPosition
@@ -154,6 +155,7 @@ import me.knighthat.component.tab.TabHeader
 import me.knighthat.component.tab.toolbar.Button
 import me.knighthat.component.tab.toolbar.DelAllDownloadedDialog
 import me.knighthat.component.tab.toolbar.DownloadAllDialog
+import me.knighthat.component.tab.toolbar.MenuIcon
 import me.knighthat.component.tab.toolbar.SongsShuffle
 import me.knighthat.thumbnailShape
 import me.knighthat.typography
@@ -512,39 +514,30 @@ fun HomeSongs(
             }
 
             // Sticky tab's tool bar
-            TabToolBar.Buttons(
-                mutableListOf<Button>().apply {
-                    this.add(
-                        when( builtInPlaylist ) {
-                            BuiltInPlaylist.Top -> topPlaylists
-                            BuiltInPlaylist.OnDevice -> {
-                                if( showFolders )
-                                    deviceFolderSort
-                                else
-                                    onDeviceSort
-                            }
-                            else -> songSort
-                        }
-                    )
-                    this.add( search )
-                    this.add( locator )
-                    this.add( downloadAllDialog )
-                    this.add( deleteDownloadsDialog )
-                    this.add( deleteSongDialog )
-                    if (builtInPlaylist == BuiltInPlaylist.All)
-                        this.add( hiddenSongs )
-                    this.add( shuffle )
-                    if (builtInPlaylist == BuiltInPlaylist.Favorites)
-                        this.add( randomSorter )
-                    this.add( itemSelector )
-                    this.add( playNext )
-                    this.add( enqueue )
-                    this.add( addToFavorite )
-                    this.add( addToPlaylist )
-                    this.add( exportDialog )
-                    this.add( import )
-                }
+            HomeSongsTabToolBarButtons(
+                builtInPlaylist,
+                topPlaylists,
+                showFolders,
+                deviceFolderSort,
+                onDeviceSort,
+                songSort,
+                search,
+                locator,
+                downloadAllDialog,
+                deleteDownloadsDialog,
+                deleteSongDialog,
+                hiddenSongs,
+                shuffle,
+                randomSorter,
+                itemSelector,
+                playNext,
+                enqueue,
+                addToFavorite,
+                addToPlaylist,
+                exportDialog,
+                import
             )
+
 
             Row(
                 horizontalArrangement = Arrangement.SpaceBetween,
@@ -896,4 +889,106 @@ fun HomeSongs(
                 onClickSearch = onSearchClick
             )
     }
+}
+
+@androidx.annotation.OptIn(UnstableApi::class)
+@Composable
+private fun HomeSongsTabToolBarButtons(
+    builtInPlaylist: BuiltInPlaylist,
+    topPlaylists: PeriodSelector,
+    showFolders: Boolean,
+    deviceFolderSort: Sort<OnDeviceFolderSortBy>,
+    onDeviceSort: Sort<OnDeviceSongSortBy>,
+    songSort: Sort<SongSortBy>,
+    search: Search,
+    locator: LocateComponent,
+    downloadAllDialog: DownloadAllDialog,
+    deleteDownloadsDialog: DelAllDownloadedDialog,
+    deleteSongDialog: DelSongDialog,
+    hiddenSongs: HiddenSongs,
+    shuffle: SongsShuffle,
+    randomSorter: Button,
+    itemSelector: ItemSelector,
+    playNext: MenuIcon,
+    enqueue: MenuIcon,
+    addToFavorite: MenuIcon,
+    addToPlaylist: PlaylistsMenu,
+    exportDialog: ExportSongsToCSVDialog,
+    import: ImportSongsFromCSV
+) {
+    val isCustomButtonOrder by rememberPreference("home_songs_is_custom_button_order", false)
+    val buttonOrder = mutableListOf<Button>()
+
+    val sortOrTopButton = when (builtInPlaylist) {
+        BuiltInPlaylist.Top -> topPlaylists
+        BuiltInPlaylist.OnDevice -> {
+            if (showFolders)
+                deviceFolderSort
+            else
+                onDeviceSort
+        }
+        else -> songSort
+    }
+
+    val basicButtonOrder = listOf<Button>(
+        sortOrTopButton, search, locator, downloadAllDialog,
+        deleteDownloadsDialog, deleteSongDialog, shuffle, itemSelector,
+        playNext, enqueue, addToFavorite, addToPlaylist, exportDialog, import
+    )
+
+    if(isCustomButtonOrder) {
+        val customButtonOrder by rememberPreference("home_songs_custom_button_order",
+            HomeSongsButton.entries.toList()
+        )
+
+        val homeSongsButtonEnumToButton = customButtonOrder?.map {
+            when (it) {
+                HomeSongsButton.SortOrTop -> sortOrTopButton
+                HomeSongsButton.Search -> search
+                HomeSongsButton.Locator -> locator
+                HomeSongsButton.DownloadAll -> downloadAllDialog
+                HomeSongsButton.DeleteDownloads -> deleteDownloadsDialog
+                HomeSongsButton.DeleteSong -> deleteSongDialog
+                HomeSongsButton.HiddenSongs -> hiddenSongs
+                HomeSongsButton.Shuffle -> shuffle
+                HomeSongsButton.RandomSorter -> randomSorter
+                HomeSongsButton.ItemSelector -> itemSelector
+                HomeSongsButton.PlayNext -> playNext
+                HomeSongsButton.Enqueue -> enqueue
+                HomeSongsButton.AddToFavorite -> addToFavorite
+                HomeSongsButton.AddToPlaylist -> addToPlaylist
+                HomeSongsButton.Export -> exportDialog
+                HomeSongsButton.Import -> import
+            }
+        }?.toMutableList()
+
+        when(builtInPlaylist){
+            BuiltInPlaylist.All ->  {
+                homeSongsButtonEnumToButton?.remove(randomSorter)
+
+            }
+            BuiltInPlaylist.Favorites -> {
+                homeSongsButtonEnumToButton?.remove(hiddenSongs)
+            }
+            else -> {
+                homeSongsButtonEnumToButton?.remove(randomSorter)
+                homeSongsButtonEnumToButton?.remove(hiddenSongs)
+            }
+        }
+        buttonOrder.addAll(homeSongsButtonEnumToButton ?: listOf())
+    } else {
+        val defaultButtonOrder = basicButtonOrder.toMutableList()
+
+        when(builtInPlaylist){
+            BuiltInPlaylist.All ->  {
+                defaultButtonOrder.add(defaultButtonOrder.indexOf(shuffle), hiddenSongs)
+            }
+            BuiltInPlaylist.Favorites -> {
+                defaultButtonOrder.add(defaultButtonOrder.indexOf(itemSelector), randomSorter)
+            }
+            else -> {}
+        }
+        buttonOrder.addAll(defaultButtonOrder)
+    }
+    TabToolBar.Buttons(buttonOrder)
 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Preferences.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Preferences.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.edit
 import com.google.gson.Gson
 import it.fast4x.innertube.Innertube
+import it.fast4x.rimusic.enums.HomeSongsButton
 import it.fast4x.rimusic.models.Song
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.encodeToString
@@ -379,6 +380,28 @@ inline fun <reified T : Json> rememberPreference(key: String, defaultValue: T, j
     }
 }
 */
+
+@Composable
+fun rememberPreference(key: String, defaultValue: List<HomeSongsButton>?): MutableState<List<HomeSongsButton>?>{
+    val context = LocalContext.current
+    val json = Json.encodeToString(defaultValue)
+    return remember {
+        mutableStatePreferenceOf(
+            try {
+                context.preferences.getString(key, json)
+                    ?.let { Json.decodeFromString<List<HomeSongsButton>>(it) }
+            } catch (e: Exception) {
+                Timber.e("RememberPreference HomeSongsPage Error: ${ e.stackTraceToString() }")
+                null
+            }
+        ) {
+            context.preferences.edit { putString(
+                key,
+                Json.encodeToString(it)
+            ) }
+        }
+    }
+}
 
 @Composable
 fun rememberPreference(key: String, defaultValue: Song?): MutableState<Song?> {


### PR DESCRIPTION
Currently this is a WIP in an early phase.

Idea is to allow for a custom order of the buttons.
Started implementation for HomeSongs.