### PR TITLE
fix #4619 and maybe # #4614

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/SongItem.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/SongItem.kt
@@ -4,15 +4,19 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -38,17 +42,17 @@ import it.fast4x.innertube.Innertube
 import it.fast4x.rimusic.Database
 import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.R
+import it.fast4x.rimusic.cleanPrefix
+import it.fast4x.rimusic.enums.DownloadedStateMedia
 import it.fast4x.rimusic.models.Song
 import it.fast4x.rimusic.service.MyDownloadService
+import it.fast4x.rimusic.service.isLocal
 import it.fast4x.rimusic.ui.components.themed.HeaderIconButton
 import it.fast4x.rimusic.ui.components.themed.IconButton
 import it.fast4x.rimusic.ui.components.themed.SmartMessage
 import it.fast4x.rimusic.ui.components.themed.TextPlaceholder
 import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.ui.styling.shimmer
-import it.fast4x.rimusic.cleanPrefix
-import it.fast4x.rimusic.enums.DownloadedStateMedia
-import it.fast4x.rimusic.service.isLocal
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.asSong
 import it.fast4x.rimusic.utils.conditional
@@ -65,9 +69,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import me.knighthat.colorPalette
+import me.knighthat.extra.shimmerEffect
 import me.knighthat.thumbnailShape
 import me.knighthat.typography
-
 
 
 @UnstableApi
@@ -652,6 +656,79 @@ fun SongItemPlaceholder(
         ItemInfoContainer {
             TextPlaceholder()
             TextPlaceholder()
+        }
+    }
+}
+
+/**
+ * New component is more resemble to the final
+ * SongItem that's currently being used.
+ */
+@Composable
+fun SongItemPlaceholder( thumbnailSizeDp: Dp ) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy( 12.dp ),
+        modifier = Modifier.fillMaxWidth()
+                           .padding(
+                               vertical = 8.dp,
+                               horizontal = 16.dp
+                           )
+    ) {
+        Box(
+            Modifier.size( thumbnailSizeDp )
+                    .clip( RoundedCornerShape(12.dp) )
+                    .shimmerEffect()
+        )
+
+        Column(
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth( .7f )
+            ) {
+                BasicText(
+                    text = "",
+                    style = typography().xs.semiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight( 1f ).shimmerEffect()
+                )
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box( Modifier.weight( 1f ).fillMaxWidth() ) {
+                    BasicText(
+                        text = "",
+                        style = typography().xs.semiBold.secondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Clip,
+                        modifier = Modifier.fillMaxWidth( .3f ).shimmerEffect()
+                    )
+                }
+
+                BasicText(
+                    text = "0:00",
+                    style = typography().xxs.secondary.medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding( top = 4.dp )
+                )
+
+                Spacer(modifier = Modifier.padding( horizontal = 4.dp ))
+
+                IconButton(
+                    onClick = {},
+                    icon = DownloadedStateMedia.NOT_CACHED_OR_DOWNLOADED.icon,
+                    color = colorPalette().textDisabled,
+                    modifier = Modifier.size( 20.dp ),
+                    enabled = false
+                )
+            }
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
@@ -88,6 +88,7 @@ import it.fast4x.rimusic.ui.components.themed.NowPlayingShow
 import it.fast4x.rimusic.ui.components.themed.SecondaryTextButton
 import it.fast4x.rimusic.ui.items.FolderItem
 import it.fast4x.rimusic.ui.items.SongItem
+import it.fast4x.rimusic.ui.items.SongItemPlaceholder
 import it.fast4x.rimusic.ui.screens.ondevice.musicFilesAsFlow
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.onOverlay
@@ -132,6 +133,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import me.knighthat.appContext
 import me.knighthat.colorPalette
 import me.knighthat.component.Enqueue
@@ -190,6 +192,8 @@ fun HomeSongs(
     val selectedItems = remember { mutableListOf<SongEntity>() }
 
     fun getMediaItems() = selectedItems.ifEmpty { itemsOnDisplay }.map( SongEntity::asMediaItem )
+
+    var isLoading by remember { mutableStateOf( false ) }
 
     val parentalControlEnabled by rememberPreference(parentalControlEnabledKey, false)
     val disableScrollingText by rememberPreference(disableScrollingTextKey, false)
@@ -359,6 +363,9 @@ fun HomeSongs(
     LaunchedEffect( builtInPlaylist, songSort.sortBy, songSort.sortOrder, hiddenSongs.isShown() ) {
         if( builtInPlaylist == BuiltInPlaylist.OnDevice ) return@LaunchedEffect
 
+        // This variable will be set to false after filtration stage is completed
+        isLoading = true
+
         when( builtInPlaylist ) {
             BuiltInPlaylist.All -> Database.songs( songSort.sortBy, songSort.sortOrder, hiddenSongs.isShown() )
             BuiltInPlaylist.Favorites -> Database.songsFavorites( songSort.sortBy, songSort.sortOrder )
@@ -399,6 +406,9 @@ fun HomeSongs(
     LaunchedEffect( builtInPlaylist, onDeviceSort.sortBy, onDeviceSort.sortOrder, hasPermission ) {
         if( builtInPlaylist != BuiltInPlaylist.OnDevice ) return@LaunchedEffect
 
+        // This variable will be set to false after filtration stage is completed
+        isLoading = true
+
         // [context] remains unchanged (because of **val**) during the lifecycle of this Composable
         context.musicFilesAsFlow( onDeviceSort.sortBy, onDeviceSort.sortOrder, context )
                .collect {
@@ -426,44 +436,50 @@ fun HomeSongs(
             items = songsDevice.map( OnDeviceSong::toSongEntity )
     // This phrase will filter out songs depends on search inputs, and natural filter
     // parameters, such as get downloaded songs when [BuiltInPlaylist.Offline] is set.
-    LaunchedEffect( builtInPlaylist, items, search.input ) {
-        val naturalFilter: (SongEntity) -> Boolean =
-            when( builtInPlaylist ) {
-                BuiltInPlaylist.All -> { song ->
-                    !includeLocalSongs || !song.song.id.startsWith(LOCAL_KEY_PREFIX)
-                }
-
-                BuiltInPlaylist.Offline -> { song ->
-                    song.contentLength?.let {
-                        binder?.cache?.isCached(song.song.id, 0, song.contentLength)
-                    } ?: false
-                }
-
-                BuiltInPlaylist.Downloaded -> { song ->
-                    val downloads = MyDownloadHelper.downloads.value
-                    downloads[song.song.id]?.state == Download.STATE_COMPLETED
-                }
-
-                BuiltInPlaylist.Top -> { songs ->
-                    if (excludeSongWithDurationLimit == DurationInMinutes.Disabled)
-                        true
-                    else
-                        songs.song.durationText?.let {
-                            durationTextToMillis(it)
-                        }!! < excludeSongWithDurationLimit.minutesInMilliSeconds
-                }
-
-                else -> { _ -> true }
+    val naturalFilter: (SongEntity) -> Boolean =
+        when( builtInPlaylist ) {
+            BuiltInPlaylist.All -> { song ->
+                !includeLocalSongs || !song.song.id.startsWith(LOCAL_KEY_PREFIX)
             }
 
-        itemsOnDisplay = items.filter( naturalFilter ).filter {
-            val containsTitle = it.song.title.contains( search.input, true )
-            val containsArtist = it.song.artistsText?.contains( search.input, true ) ?: false
-            val containsAlbum = it.albumTitle?.contains( search.input, true ) ?: false
-            val isExplicit = parentalControlEnabled && it.song.title.startsWith(EXPLICIT_PREFIX)
+            BuiltInPlaylist.Offline -> { song ->
+                song.contentLength?.let {
+                    binder?.cache?.isCached(song.song.id, 0, song.contentLength)
+                } ?: false
+            }
 
-            containsTitle || containsArtist || containsAlbum || isExplicit
+            BuiltInPlaylist.Downloaded -> { song ->
+                val downloads = MyDownloadHelper.downloads.value
+                downloads[song.song.id]?.state == Download.STATE_COMPLETED
+            }
+
+            BuiltInPlaylist.Top -> { songs ->
+                if (excludeSongWithDurationLimit == DurationInMinutes.Disabled)
+                    true
+                else
+                    songs.song.durationText?.let {
+                        durationTextToMillis(it)
+                    }!! < excludeSongWithDurationLimit.minutesInMilliSeconds
+            }
+
+            else -> { _ -> true }
         }
+    LaunchedEffect( items, search.input ) {
+        // Don't set [isLoading] to true here, it'll make searching look weird
+
+        itemsOnDisplay = withContext( Dispatchers.Default ) {
+            items.filter( naturalFilter )
+                 .filter {
+                     val containsTitle = it.song.title.contains(search.input, true)
+                     val containsArtist = it.song.artistsText?.contains(search.input, true) ?: false
+                     val containsAlbum = it.albumTitle?.contains(search.input, true) ?: false
+                     val isExplicit = parentalControlEnabled && it.song.title.startsWith(EXPLICIT_PREFIX)
+
+                     containsTitle || containsArtist || containsAlbum || isExplicit
+                 }
+        }
+
+        isLoading = false
     }
     // Filter folder on the side
     LaunchedEffect( builtInPlaylist, folders, search.input ) {
@@ -557,8 +573,24 @@ fun HomeSongs(
 
             LazyColumn(
                 state = lazyListState,
-                contentPadding = PaddingValues( start = 8.dp, bottom = Dimensions.bottomSpacer )
+                contentPadding = PaddingValues( start = 8.dp, bottom = Dimensions.bottomSpacer ),
+                userScrollEnabled = !isLoading // Effectively disable scroll (drag gesture) while loading
             ) {
+
+                /*
+                    On slower phones, having to load a large database will create a
+                    subtle feeling of the app is not responding. This component
+                    creates fake song card that notifies user that songs are loading.
+                 */
+                if( isLoading ) {
+                    items(
+                        count = 20,
+                        key = { it }
+                    ) { SongItemPlaceholder( thumbnailSizeDp ) }
+
+                    return@LazyColumn
+                }
+
                 if( builtInPlaylist == BuiltInPlaylist.OnDevice && !hasPermission ) {
                     item( "OnDeviceSongsPermission" ) {
                         LaunchedEffect(Unit, relaunchPermission) { launcher.launch(permission) }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
@@ -496,7 +496,7 @@ fun HomeSongs(
         Column( Modifier.fillMaxSize() ) {
             // Sticky tab's title
             TabHeader( R.string.songs ) {
-                HeaderInfo( items.size.toString(), R.drawable.musical_notes )
+                HeaderInfo( itemsOnDisplay.size.toString(), R.drawable.musical_notes )
             }
 
             // Sticky tab's tool bar

--- a/composeApp/src/androidMain/kotlin/me/knighthat/extra/Modifier.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/extra/Modifier.kt
@@ -1,0 +1,54 @@
+package me.knighthat.extra
+
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.IntSize
+import it.fast4x.rimusic.ui.styling.shimmer
+import me.knighthat.colorPalette
+
+/**
+ * A loading effect that goes from top left
+ * to bottom right in 2000 millis (2s).
+ */
+fun Modifier.shimmerEffect(): Modifier = composed {
+    var size by remember { mutableStateOf( IntSize.Zero ) }
+    val transition = rememberInfiniteTransition( "infiniteTransition" )
+    val startOffsetX by transition.animateFloat(
+        initialValue = -2 * size.width.toFloat(),
+        targetValue = 2 * size.width.toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = 2000,
+                easing = FastOutLinearInEasing
+            ),
+        ),
+        label = "offsetXAnimatedTransition"
+    )
+
+    background(
+        brush = Brush.linearGradient(
+            colors = listOf(
+                colorPalette().background1,
+                colorPalette().shimmer.copy( alpha = .3f ),
+                colorPalette().background1
+            ),
+            start = Offset(startOffsetX, 0f),
+            end = Offset(startOffsetX + size.width.toFloat(), size.height.toFloat())
+        )
+    ).onGloballyPositioned {
+        size = it.size
+    }
+}


### PR DESCRIPTION
Songs count indicator will now show how many songs is being displayed on the screen. It can be used to show how many results come back from the search.

![image](https://github.com/user-attachments/assets/5b2904c5-08cd-40ff-a677-651f3c15f9e6)

New loading screen in `Songs` tab (Experimental).

> I artificially added a timer to this video to simulate a slow phone.

https://github.com/user-attachments/assets/746f777a-3c2a-4247-b661-20d54e8f9661

