### PR TITLE
Fixed a crash when using visualizer while offline #4643

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/extensions/nextvisualizer/NextVisualizer.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/extensions/nextvisualizer/NextVisualizer.kt
@@ -36,9 +36,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.media3.common.MediaItem
-import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
-import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
@@ -71,14 +69,10 @@ import it.fast4x.rimusic.utils.currentWindow
 import it.fast4x.rimusic.utils.getBitmapFromUrl
 import it.fast4x.rimusic.utils.hasPermission
 import it.fast4x.rimusic.utils.isCompositionLaunched
-import it.fast4x.rimusic.utils.mediaItems
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.resize
 import it.fast4x.rimusic.utils.semiBold
-import it.fast4x.rimusic.utils.shouldBePlaying
 import it.fast4x.rimusic.utils.visualizerEnabledKey
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.knighthat.colorPalette
 import me.knighthat.typography
@@ -263,16 +257,16 @@ fun getVisualizers(): List<Painter> {
     binder?.player?.DisposableListener {
         object : Player.Listener {
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-                try {
-                    coroutineScope.launch {
+                coroutineScope.launch {
+                    try {
                         bitmapCover = getBitmapFromUrl(
                             context,
                             binder.player.currentWindow?.mediaItem?.mediaMetadata?.artworkUri.toString()
                                 .resize(1200, 1200)
                         )
+                    } catch (e: Exception) {
+                        Timber.e("Failed to get bitmap in NextVisualizer ${e.stackTraceToString()}")
                     }
-                } catch (e: Exception) {
-                    Timber.e("Failed get bitmap in NextVisualizer ${e.stackTraceToString()}")
                 }
             }
         }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/BitmapUtils.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/BitmapUtils.kt
@@ -4,13 +4,18 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import coil.ImageLoader
+import coil.request.ErrorResult
 import coil.request.ImageRequest
 import coil.request.SuccessResult
 
 suspend fun getBitmapFromUrl(context: Context, url: String): Bitmap {
     val loading = ImageLoader(context)
     val request = ImageRequest.Builder(context).data(url).allowHardware(false).build()
-    val result = (loading.execute(request) as SuccessResult).drawable
-    return (result as BitmapDrawable).bitmap
+    val result = loading.execute(request)
+    if(result is ErrorResult) {
+        throw result.throwable
+    }
+    val drawable = (result as SuccessResult).drawable
+    return (drawable as BitmapDrawable).bitmap
 }
 


### PR DESCRIPTION
The app crashes if the visualizer is enabled, the device has no network connection (is offline) and the song is switched to a different song.

- correct throwing of the error
- correct catching of the error

The old usage of `try/catch` was not correct has an exception (except `CancellationException`) stops the parent process/thread.

Fixes #4643.