### PR TITLE
fixed settings for expanded lyrics not showing

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/settings/AppearanceSettings.kt
@@ -63,6 +63,7 @@ import it.fast4x.rimusic.utils.disablePlayerHorizontalSwipeKey
 import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.effectRotationKey
 import it.fast4x.rimusic.utils.expandedlyricsKey
+import it.fast4x.rimusic.utils.expandedplayerKey
 import it.fast4x.rimusic.utils.expandedplayertoggleKey
 import it.fast4x.rimusic.utils.fadingedgeKey
 import it.fast4x.rimusic.utils.iconLikeTypeKey
@@ -337,6 +338,7 @@ fun AppearanceSettings(
     var transparentbar by rememberPreference(transparentbarKey, true)
     var blackgradient by rememberPreference(blackgradientKey, false)
     var showlyricsthumbnail by rememberPreference(showlyricsthumbnailKey, false)
+    var expandedplayer by rememberPreference(expandedplayerKey, false)
     var playerPlayButtonType by rememberPreference(
         playerPlayButtonTypeKey,
         PlayerPlayButtonType.Disabled
@@ -1495,7 +1497,7 @@ fun AppearanceSettings(
                 onCheckedChange = { showButtonPlayerMenu = it }
             )
 
-        if (!showlyricsthumbnail && (expandedplayertoggle || expandedlyrics)) {
+        if (!showlyricsthumbnail && (expandedplayertoggle || expandedplayer || expandedlyrics)) {
             SettingsGroupSpacer()
             SettingsEntryGroupText(title = stringResource(R.string.full_screen_lyrics_components))
 


### PR DESCRIPTION
- the settings now also show if `expandedplayer` is enabled (but the button is not)

Based on an idea by @aneesh1122.