### PR TITLE
Fixed (modern) vinyl thumbnail

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/VinylThumbnailCover.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/VinylThumbnailCover.kt
@@ -160,7 +160,7 @@ fun VinylThumbnailCoverAnimationModern(
         Animatable(currentRotation)
     }
 
-    LaunchedEffect(isSongPlaying) {
+    LaunchedEffect(isSongPlaying, state.settledPage) {
         if (isSongPlaying && it == state.settledPage) {
             rotation.animateTo(
                 targetValue = currentRotation + 360f,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/VinylThumbnailCover.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/VinylThumbnailCover.kt
@@ -172,7 +172,7 @@ fun VinylThumbnailCoverAnimationModern(
                 currentRotation = value
             }
         } else {
-            if (currentRotation > 0f) {
+            if (currentRotation > 0f && it == state.settledPage) {
                 rotation.animateTo(
                     targetValue = currentRotation + 50,
                     animationSpec = tween(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/VinylThumbnailCover.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/themed/VinylThumbnailCover.kt
@@ -36,7 +36,7 @@ import it.fast4x.rimusic.utils.VinylSizeKey
 import it.fast4x.rimusic.utils.rememberPreference
 
 @Composable
-fun VinylThumnbailCover(
+fun VinylThumbnailCover(
     modifier: Modifier = Modifier,
     rotationDegrees: Float = 0f,
     painter: Painter
@@ -136,7 +136,7 @@ fun VinylThumbnailCoverAnimation(
         }
     }
 
-    VinylThumnbailCover(
+    VinylThumbnailCover(
         painter = painter,
         rotationDegrees = rotation.value,
         modifier = modifier
@@ -186,7 +186,7 @@ fun VinylThumbnailCoverAnimationModern(
         }
     }
 
-    VinylThumnbailCover(
+    VinylThumbnailCover(
         painter = painter,
         rotationDegrees = rotation.value,
         modifier = modifier


### PR DESCRIPTION
- [fix problem non-main covers rotating a bit](https://github.com/fast4x/RiMusic/commit/2cee74af8ce128b8282fd690eee69c8ebd1aa627)
- [fixed rotation of wrong thumbnail in certain situations](https://github.com/fast4x/RiMusic/commit/983f7e64cad5209e937a013d1f3f1e16b9b09200)

I only observed the problems on modern player.

As it can be read from the commit messages, these solutions are not optimal, but good enough I think.

Demo:
<details><summary>Bug 1</summary>
<p>

https://github.com/user-attachments/assets/0a529f1e-239a-407d-b06d-71359a8cc410

</p>
</details> 

<details><summary>Bug 2</summary>
<p>

https://github.com/user-attachments/assets/7fd7a29d-9970-4822-a291-54bcc3fa1640

</p>
</details>

<details><summary>Fixed 1</summary>
<p>

https://github.com/user-attachments/assets/cc5608a6-df35-4298-8c97-63b4c8103dfc

</p>

</details>

<details><summary>Fixed 2</summary>
<p>


https://github.com/user-attachments/assets/3cf7edac-e72f-4228-975f-581f160728af

</p>
</details> 