### PR TITLE
Clear search

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
@@ -482,6 +482,15 @@ fun HomeSongs(
                  }
         }
 
+        /*
+            [LazyListState] will try to keep the visible song at the top
+            after search input has changed. This creates a weird effect
+            that fools user to believe search results haven't change.
+
+            To prevent it, always scroll the list to the top
+         */
+        lazyListState.scrollToItem( 0 )
+
         isLoading = false
     }
     // Filter folder on the side

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
@@ -415,6 +415,15 @@ fun LocalPlaylistSongs(
 
             containsName || containsArtist || containsAlbum
         }.let { itemsOnDisplay = it }
+
+        /*
+            [LazyListState] will try to keep the visible song at the top
+            after search input has changed. This creates a weird effect
+            that fools user to believe search results haven't change.
+
+            To prevent it, always scroll the list to the top
+         */
+        lazyListState.scrollToItem( 0 )
     }
     LaunchedEffect(Unit) {
         Database.singlePlaylistPreview( playlistId )

--- a/composeApp/src/androidMain/kotlin/me/knighthat/component/Search.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/component/Search.kt
@@ -155,10 +155,6 @@ class Search private constructor(
 
     @Composable
     fun SearchBar( columnScope: ColumnScope ) {
-        var showSearchBar by visibleState
-        var isFocused by focusState
-        var input by inputState
-
         val thumbnailRoundness by rememberPreference(
             thumbnailRoundnessKey,
             ThumbnailRoundness.Heavy
@@ -167,15 +163,15 @@ class Search private constructor(
         val focusRequester = remember { FocusRequester() }
 
         AnimatedVisibility(
-            visible = showSearchBar,
+            visible = isVisible,
             modifier = Modifier.padding(all = 10.dp)
                 .fillMaxWidth()
         ) {
             // Auto focus on search bar when it's visible
             val focusManager = LocalFocusManager.current
             val keyboardController = LocalSoftwareKeyboardController.current
-            LaunchedEffect( showSearchBar, isFocused ) {
-                if( !showSearchBar ) return@LaunchedEffect
+            LaunchedEffect( isVisible, isFocused ) {
+                if( !isVisible ) return@LaunchedEffect
 
                 if( isFocused )
                     focusRequester.requestFocus()
@@ -207,7 +203,7 @@ class Search private constructor(
                 maxLines = 1,
                 keyboardOptions = KeyboardOptions( imeAction = ImeAction.Done ),
                 keyboardActions = KeyboardActions(onDone = {
-                    showSearchBar = input.isNotBlank()
+                    isVisible = input.isNotBlank()
                     isFocused = false
                     keyboardController?.hide()
                 }),

--- a/composeApp/src/androidMain/kotlin/me/knighthat/component/Search.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/component/Search.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -181,21 +180,15 @@ class Search private constructor(
                 }
             }
 
-            /*
-                TextFieldValue gives control over cursor.
-
-                This prevents the cursor from being placed
-                at the beginning of search term.
-             */
-            var searchInput by remember {
-                mutableStateOf( TextFieldValue( input ) )
-            }
             BasicTextField(
-                value = searchInput,
+                /**
+                 * [TextFieldValue] gives control over cursor.
+                 *
+                 * This prevents the cursor from being placed
+                 * at the beginning of search term.
+                 */
+                value = TextFieldValue( input, TextRange( input.length ) ),
                 onValueChange = {
-                    searchInput = it.copy(
-                        selection = TextRange( it.text.length )
-                    )
                     input = it.text
                 },
                 textStyle = typography().xs.semiBold,
@@ -210,9 +203,9 @@ class Search private constructor(
                 cursorBrush = SolidColor(colorPalette().text),
                 decorationBox = {
                     columnScope.DecorationBox( it ) {
-                        searchInput = searchInput.copy( text = "" )
                         input = ""
 
+                        // Regain focus in case keyboard is hidden
                         isFocused = true
                     }
                 },

--- a/composeApp/src/androidMain/kotlin/me/knighthat/component/Search.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/component/Search.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -180,15 +181,22 @@ class Search private constructor(
                 }
             }
 
+            /**
+             * [TextFieldValue] gives control over cursor.
+             *
+             * This prevents the cursor from being placed
+             * at the beginning of search term.
+             */
+            var searchTerm by remember { mutableStateOf(
+                TextFieldValue( input, TextRange( input.length ) )
+            )}
             BasicTextField(
-                /**
-                 * [TextFieldValue] gives control over cursor.
-                 *
-                 * This prevents the cursor from being placed
-                 * at the beginning of search term.
-                 */
-                value = TextFieldValue( input, TextRange( input.length ) ),
+                value = searchTerm,
                 onValueChange = {
+                    searchTerm = it.copy(
+                        text = it.text,
+                        selection = it.selection
+                    )
                     input = it.text
                 },
                 textStyle = typography().xs.semiBold,
@@ -203,6 +211,7 @@ class Search private constructor(
                 cursorBrush = SolidColor(colorPalette().text),
                 decorationBox = {
                     columnScope.DecorationBox( it ) {
+                        searchTerm = TextFieldValue( "" )
                         input = ""
 
                         // Regain focus in case keyboard is hidden

--- a/composeApp/src/androidMain/kotlin/me/knighthat/component/Search.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/component/Search.kt
@@ -88,11 +88,13 @@ class Search private constructor(
         }
 
     @Composable
-    private fun ColumnScope.DecorationBox(innerTextField: @Composable () -> Unit ) {
+    private fun ColumnScope.DecorationBox(
+        innerTextField: @Composable () -> Unit,
+        onBackClick: () -> Unit
+    ) {
         Box(
             contentAlignment = Alignment.CenterStart,
-            modifier = Modifier.weight(1f)
-                .padding(horizontal = 10.dp)
+            modifier = Modifier.padding( horizontal = 10.dp )
         ) {
             IconButton(
                 onClick = {},
@@ -128,6 +130,18 @@ class Search private constructor(
 
             // Actual text from user
             innerTextField()
+        }
+        Box(
+            contentAlignment = Alignment.CenterEnd,
+            modifier = Modifier.padding( start = 30.dp, end = 15.dp )
+        ) {
+            IconButton(
+                onClick = onBackClick,
+                icon = R.drawable.backspace_outline,
+                color = colorPalette().text.copy( alpha = .8f ), // A little dimmer to prevent eye-candy
+                modifier = Modifier.align( Alignment.CenterEnd )
+                                   .size( 16.dp )
+            )
         }
     }
 
@@ -198,7 +212,14 @@ class Search private constructor(
                     keyboardController?.hide()
                 }),
                 cursorBrush = SolidColor(colorPalette().text),
-                decorationBox = { columnScope.DecorationBox( it ) },
+                decorationBox = {
+                    columnScope.DecorationBox( it ) {
+                        searchInput = searchInput.copy( text = "" )
+                        input = ""
+
+                        isFocused = true
+                    }
+                },
                 modifier = Modifier.height( 30.dp )
                     .fillMaxWidth()
                     .focusRequester(focusRequester)

--- a/composeApp/src/androidMain/res/drawable/backspace_outline.xml
+++ b/composeApp/src/androidMain/res/drawable/backspace_outline.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="512dp"
+    android:height="512dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+  <path
+      android:pathData="M135.19,390.14a28.79,28.79 0,0 0,21.68 9.86h246.26A29,29 0,0 0,432 371.13V140.87A29,29 0,0 0,403.13 112H156.87a28.84,28.84 0,0 0,-21.67 9.84v0L46.33,256l88.86,134.11z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="32"
+      android:fillColor="#0000"
+      android:strokeColor="#000"/>
+  <path
+      android:pathData="M336.67,192.33L206.66,322.34M336.67,322.34L206.66,192.33M336.67,192.33L206.66,322.34M336.67,322.34L206.66,192.33"
+      android:strokeLineJoin="round"
+      android:strokeWidth="32"
+      android:fillColor="#0000"
+      android:strokeColor="#000"
+      android:strokeLineCap="round"/>
+</vector>


### PR DESCRIPTION
# New feature

A new button at the other end of search bar that clears search input instantly.

https://github.com/user-attachments/assets/a377284b-2556-43a3-a2ca-218c9eb2d03e

# Small adjustment (bug fix)

In last version, if you use keyboard that allows you to move the cursor around while holding "space" key, you were properly couldn't do that. But this update include a fix to that