### PR TITLE
Bug in custom thumbnail for playlist in 0.6.61

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/localplaylist/LocalPlaylistSongs.kt
@@ -427,12 +427,6 @@ fun LocalPlaylistSongs(
                 .flowOn( Dispatchers.IO )
                 .distinctUntilChanged()
                 .collect { playlistPreview = it }
-
-        val thumbnailName = "thumbnail/playlist_${playlistId}"
-        val presentThumbnailUrl: String? = checkFileExists(context, thumbnailName)
-        if (presentThumbnailUrl != null) {
-            thumbnailUrl.value = presentThumbnailUrl
-        }
     }
     LaunchedEffect( playlistPreview?.playlist?.name ) {
         renameDialog.playlistName = playlistPreview?.playlist?.name?.let { name ->
@@ -442,6 +436,12 @@ fun LocalPlaylistSongs(
                 name.substringAfter( PINNED_PREFIX )
                     .substringAfter( PIPED_PREFIX )
         } ?: "Unknown"
+
+        val thumbnailName = "thumbnail/playlist_${playlistId}"
+        val presentThumbnailUrl: String? = checkFileExists(context, thumbnailName)
+        if (presentThumbnailUrl != null) {
+            thumbnailUrl.value = presentThumbnailUrl
+        }
     }
 
     //**** SMART RECOMMENDATION

--- a/composeApp/src/androidMain/kotlin/me/knighthat/component/MenuComponent.kt
+++ b/composeApp/src/androidMain/kotlin/me/knighthat/component/MenuComponent.kt
@@ -187,7 +187,7 @@ fun ResetThumbnail(
 
     val menuState: MenuState = LocalMenuState.current
     override val iconId: Int = R.drawable.image
-    override val messageId: Int = R.string.edit_thumbnail
+    override val messageId: Int = R.string.reset_thumbnail
     override val menuIconTitle: String
         @Composable
         get() = stringResource( messageId )


### PR DESCRIPTION
This bug was created only in 0.6.62

1. Custom thumbnail not visible in single playlist page
2. Reset Thumbnail options is wrongly labelled as edit thumbnail