### PR TITLE
Rotating thumbnail type now also applied for essential player

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Thumbnail.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Thumbnail.kt
@@ -271,8 +271,8 @@ fun Thumbnail(
                                             onDoubleTap = { onDoubleTap() }
                                         )
 
-                                    }
-
+                                    },
+                                type = coverThumbnailAnimation
                             )
                         else
                             Image (


### PR DESCRIPTION
Only Vinyl-type was possible in essential player because the type was not applied.

Fixes #4697.