### PR TITLE
fixed minimizing of player when spamming control buttons #4786

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
@@ -257,6 +257,7 @@ import it.fast4x.rimusic.utils.timelineExpandedKey
 import it.fast4x.rimusic.utils.titleExpandedKey
 import it.fast4x.rimusic.utils.getIconQueueLoopState
 import it.fast4x.rimusic.utils.isDownloadedSong
+import it.fast4x.rimusic.utils.playAtIndex
 import it.fast4x.rimusic.utils.playNext
 import it.fast4x.rimusic.utils.playPrevious
 import it.fast4x.rimusic.utils.playbackPitchKey
@@ -2355,7 +2356,7 @@ fun Player(
                                      var previousPage = pagerState.settledPage
                                      snapshotFlow { pagerState.settledPage }.distinctUntilChanged().collect {
                                          if (previousPage != it) {
-                                             if (it != binder.player.currentMediaItemIndex) binder.player.forcePlayAtIndex(mediaItems,it)
+                                             if (it != binder.player.currentMediaItemIndex) binder.player.playAtIndex(it)
                                          }
                                          previousPage = it
                                      }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Player.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Player.kt
@@ -82,6 +82,12 @@ fun Player.playVideo(mediaItem: MediaItem) {
     pause()
 }
 
+fun Player.playAtIndex(mediaItemIndex: Int) {
+    seekTo(mediaItemIndex, 0)
+    prepare()
+    playWhenReady = true
+}
+
 @SuppressLint("Range")
 @UnstableApi
 fun Player.forcePlayAtIndex(mediaItems: List<MediaItem>, mediaItemIndex: Int) {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Player.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Player.kt
@@ -83,7 +83,7 @@ fun Player.playVideo(mediaItem: MediaItem) {
 }
 
 fun Player.playAtIndex(mediaItemIndex: Int) {
-    seekTo(mediaItemIndex, 0)
+    seekTo(mediaItemIndex, C.TIME_UNSET)
     prepare()
     playWhenReady = true
 }


### PR DESCRIPTION
If the "forward" or "backward" button is spammed, the player is minimized if `Keep minimized` is enabled.

Fixes #4786.