### PR TITLE
Fixed repeat-problem (at least certain situations) 

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/MainActivity.kt
@@ -282,7 +282,6 @@ class MainActivity :
     private var currentAcceleration = 0f
     private var lastAcceleration = 0f
     private var shakeCounter = 0
-    private var appRunningInBackground: Boolean = false
 
     private var _monet: MonetCompat? by mutableStateOf(null)
     private val monet get() = _monet ?: throw MonetActivityAccessException()
@@ -1471,6 +1470,8 @@ class MainActivity :
 
 
 }
+
+var appRunningInBackground: Boolean = false
 
 val LocalPlayerServiceBinder = staticCompositionLocalOf<PlayerServiceModern.Binder?> { null }
 

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/MainActivity.kt
@@ -1,5 +1,6 @@
 package it.fast4x.rimusic
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.ActivityManager
 import android.content.ComponentName
@@ -411,6 +412,7 @@ class MainActivity :
         content()
     }
 
+    @SuppressLint("UnusedBoxWithConstraintsScope")
     @OptIn(
         ExperimentalTextApi::class,
         ExperimentalFoundationApi::class, ExperimentalAnimationApi::class,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/MainActivity.kt
@@ -1066,7 +1066,7 @@ class MainActivity :
                             )
 
                             checkIfAppIsRunningInBackground()
-                            if (appRunningInBackground) showPlayer = false
+                            // if (appRunningInBackground) showPlayer = false
 
 
                             val thumbnailRoundness by rememberPreference(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
@@ -44,6 +44,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.PagerDefaults
 import androidx.compose.foundation.pager.PagerSnapDistance
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -191,6 +192,7 @@ import dev.chrisbanes.haze.HazeDefaults
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.haze
 import dev.chrisbanes.haze.hazeChild
+import it.fast4x.rimusic.appRunningInBackground
 import it.fast4x.rimusic.enums.CarouselSize
 import it.fast4x.rimusic.enums.PlayerType
 import it.fast4x.rimusic.enums.QueueType
@@ -1176,9 +1178,8 @@ fun Player(
                                     snapPositionalThreshold = 0.15f,
                                     pagerSnapDistance = PagerSnapDistance.atMost(showsongs.number)
                                 )
-                                LaunchedEffect(binder.player.currentMediaItemIndex) {
-                                    pagerStateQueue.animateScrollToPage(binder.player.currentMediaItemIndex + 1)
-                                }
+                                pagerStateQueue.LaunchedEffectScrollToPage(binder.player.currentMediaItemIndex + 1)
+
                                 Row(
                                     modifier = Modifier
                                         .padding(vertical = 7.5.dp)
@@ -1195,7 +1196,11 @@ fun Player(
                                                 interactionSource = remember { MutableInteractionSource() },
                                                 onClick = {
                                                     scope.launch {
-                                                        pagerStateQueue.animateScrollToPage(binder.player.currentMediaItemIndex + 1)
+                                                        if (!appRunningInBackground) {
+                                                            pagerState.animateScrollToPage(binder.player.currentMediaItemIndex + 1)
+                                                        } else {
+                                                            pagerState.scrollToPage(binder.player.currentMediaItemIndex + 1)
+                                                        }
                                                     }
                                                 }
                                             ),
@@ -1708,10 +1713,7 @@ fun Player(
                      state = pagerState,
                      snapPositionalThreshold = 0.20f
                  )
-                 
-                 LaunchedEffect(binder.player.currentMediaItemIndex){
-                     pagerState.animateScrollToPage(binder.player.currentMediaItemIndex)
-                 }
+                 pagerState.LaunchedEffectScrollToPage(binder.player.currentMediaItemIndex)
 
                  LaunchedEffect(pagerState) {
                      var previousPage = pagerState.settledPage
@@ -1945,9 +1947,8 @@ fun Player(
                                  if ((!isShowingLyrics && !isShowingVisualizer) || (isShowingVisualizer && showvisthumbnail) || (isShowingLyrics && showlyricsthumbnail)) {
                                      val fling = PagerDefaults.flingBehavior(state = pagerState,snapPositionalThreshold = 0.25f)
                                      val pageSpacing = thumbnailSpacing.toInt()*0.01*(screenWidth) - (2.5*playerThumbnailSize.size.dp)
-                                     LaunchedEffect(binder.player.currentMediaItemIndex){
-                                         pagerState.animateScrollToPage(binder.player.currentMediaItemIndex)
-                                     }
+
+                                     pagerState.LaunchedEffectScrollToPage(binder.player.currentMediaItemIndex)
 
                                      LaunchedEffect(pagerState) {
                                          var previousPage = pagerState.settledPage
@@ -2153,9 +2154,7 @@ fun Player(
                         state = pagerState,
                         snapPositionalThreshold = 0.20f
                     )
-                    LaunchedEffect(binder.player.currentMediaItemIndex){
-                        pagerState.animateScrollToPage(binder.player.currentMediaItemIndex)
-                    }
+                   pagerState.LaunchedEffectScrollToPage(binder.player.currentMediaItemIndex)
 
                     LaunchedEffect(pagerState) {
                         var previousPage = pagerState.settledPage
@@ -2347,9 +2346,7 @@ fun Player(
                              if (playerType == PlayerType.Modern) {
                                  val fling = PagerDefaults.flingBehavior(state = pagerState,snapPositionalThreshold = 0.25f)
 
-                                 LaunchedEffect(binder.player.currentMediaItemIndex) {
-                                     pagerState.animateScrollToPage(binder.player.currentMediaItemIndex)
-                                 }
+                                 pagerState.LaunchedEffectScrollToPage(binder.player.currentMediaItemIndex)
 
                                  LaunchedEffect(pagerState) {
                                      var previousPage = pagerState.settledPage
@@ -2818,6 +2815,21 @@ fun Player(
 
     }
 
+}
+
+@Composable
+@androidx.annotation.OptIn(UnstableApi::class)
+private fun PagerState.LaunchedEffectScrollToPage(
+    index: Int
+) {
+    val pagerState = this
+    LaunchedEffect(pagerState, index) {
+        if (!appRunningInBackground) {
+            pagerState.animateScrollToPage(index)
+        } else {
+            pagerState.scrollToPage(index)
+        }
+    }
 }
 
 


### PR DESCRIPTION
- the repeat-problem can now be prevented in the case that player is set to "modern", player was opened and then app is put into background
=> disabled minimizing of player workaround when app is put into background
- `animateScrollToPage` seems to not complete in case the app is in background
=> pagerState is not updated properly
- created extension function `PagerState.LaunchedEffectScrollToPage`

If we are lucky, then this will solve **all** repeat problems.