### PR TITLE
Fixup #4642

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/Database.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/Database.kt
@@ -236,124 +236,133 @@ interface Database {
     @RewriteQueriesToDropUnusedColumns
     fun songsEntityOnDevice(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY artistsText")
-    @RewriteQueriesToDropUnusedColumns
-    fun songsFavoritesByArtistAsc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE likedAt IS NOT NULL 
+        ORDER BY artistsText
+    """)
+    fun sortFavoriteSongsByArtist(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY artistsText DESC")
-    @RewriteQueriesToDropUnusedColumns
-    fun songsFavoritesByArtistDesc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE likedAt IS NOT NULL 
+        ORDER BY totalPlayTimeMs
+    """)
+    fun sortFavoriteSongsByPlayTime(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY totalPlayTimeMs")
-    @RewriteQueriesToDropUnusedColumns
-    fun songsFavoritesByPlayTimeAsc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE likedAt IS NOT NULL 
+        ORDER BY 
+            CASE
+                WHEN Song.title LIKE "$EXPLICIT_PREFIX%" THEN SUBSTR(Song.title, LENGTH('$EXPLICIT_PREFIX') + 1)
+                ELSE Song.title
+            END
+        COLLATE NOCASE
+    """)
+    fun sortFavoriteSongsByTitle(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY totalPlayTimeMs DESC")
-    @RewriteQueriesToDropUnusedColumns
-    fun songsFavoritesByPlayTimeDesc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE likedAt IS NOT NULL 
+        ORDER BY Song.ROWID
+    """)
+    fun sortFavoriteSongsByRowId(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY title COLLATE NOCASE ASC")
-    @RewriteQueriesToDropUnusedColumns
-    fun songsFavoritesByTitleAsc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE likedAt IS NOT NULL 
+        ORDER BY likedAt
+    """)
+    fun sortFavoriteSongsByLikedAt(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY title COLLATE NOCASE DESC")
-    @RewriteQueriesToDropUnusedColumns
-    fun songsFavoritesByTitleDesc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        LEFT JOIN Event E ON E.songId = Song.id 
+        WHERE likedAt IS NOT NULL 
+        ORDER BY E.timestamp
+    """)
+    fun sortFavoriteSongsByDatePlayed(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY ROWID")
-    @RewriteQueriesToDropUnusedColumns
-    fun songsFavoritesByRowIdAsc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE likedAt IS NOT NULL 
+        ORDER BY durationText
+    """)
+    fun sortFavoriteSongsByDuration(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY ROWID DESC")
-    @RewriteQueriesToDropUnusedColumns
-    fun songsFavoritesByRowIdDesc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE Song.likedAt IS NOT NULL
+        ORDER BY Album.title
+    """)
+    fun sortFavoriteSongsByAlbum(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY likedAt")
-    @RewriteQueriesToDropUnusedColumns
-    fun songsFavoritesByLikedAtAsc(): Flow<List<SongEntity>>
-
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY likedAt DESC")
-    @RewriteQueriesToDropUnusedColumns
-    fun songsFavoritesByLikedAtDesc(): Flow<List<SongEntity>>
-
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT DISTINCT S.* FROM Song S LEFT JOIN Event E ON E.songId=S.id " +
-            "WHERE likedAt IS NOT NULL " +
-            "ORDER BY E.timestamp DESC")
-    fun songsFavoritesByDatePlayedDesc(): Flow<List<SongEntity>>
-
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT DISTINCT S.* FROM Song S LEFT JOIN Event E ON E.songId=S.id " +
-            "WHERE likedAt IS NOT NULL " +
-            "ORDER BY E.timestamp")
-    fun songsFavoritesByDatePlayedAsc(): Flow<List<SongEntity>>
-
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY durationText")
-    @RewriteQueriesToDropUnusedColumns
-    fun songsFavoritesByDurationAsc(): Flow<List<SongEntity>>
-
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY durationText DESC")
-    @RewriteQueriesToDropUnusedColumns
-    fun songsFavoritesByDurationDesc(): Flow<List<SongEntity>>
-
-    fun songsFavorites(sortBy: SongSortBy, sortOrder: SortOrder): Flow<List<SongEntity>> {
-        return when (sortBy) {
-            SongSortBy.PlayTime -> when (sortOrder) {
-                SortOrder.Ascending -> songsFavoritesByPlayTimeAsc()
-                SortOrder.Descending -> songsFavoritesByPlayTimeDesc()
-            }
-            SongSortBy.Title, SongSortBy.AlbumName -> when (sortOrder) {
-                SortOrder.Ascending -> songsFavoritesByTitleAsc()
-                SortOrder.Descending -> songsFavoritesByTitleDesc()
-            }
-            SongSortBy.DateLiked -> when (sortOrder) {
-                SortOrder.Ascending -> songsFavoritesByLikedAtAsc()
-                SortOrder.Descending -> songsFavoritesByLikedAtDesc()
-            }
-            SongSortBy.DatePlayed -> when (sortOrder) {
-                SortOrder.Ascending -> songsFavoritesByDatePlayedAsc()
-                SortOrder.Descending -> songsFavoritesByDatePlayedDesc()
-            }
-            SongSortBy.DateAdded -> when (sortOrder) {
-                SortOrder.Ascending -> songsFavoritesByRowIdAsc()
-                SortOrder.Descending -> songsFavoritesByRowIdDesc()
-            }
-            SongSortBy.Artist -> when (sortOrder) {
-                SortOrder.Ascending -> songsFavoritesByArtistAsc()
-                SortOrder.Descending -> songsFavoritesByArtistDesc()
-            }
-            SongSortBy.Duration -> when (sortOrder) {
-                SortOrder.Ascending -> songsFavoritesByDurationAsc()
-                SortOrder.Descending -> songsFavoritesByDurationDesc()
-            }
-        }
-    }
+    /**
+     * Fetch all songs that are liked by the user
+     * from the database and sort them according to
+     * [sortBy] and [sortOrder].
+     *
+     * [sortBy] sorts all based on each song's property
+     * such as [SongSortBy.Title], [SongSortBy.PlayTime], etc.
+     * While [sortOrder] arranges order of sorted songs
+     * to follow alphabetical order A to Z, or numerical order 0 to 9, etc.
+     *
+     *
+     * @param sortBy which song's property is used to sort
+     * @param sortOrder what order should results be in
+     *
+     * @return a **SORTED** list of [SongEntity]'s that are continuously
+     * updated to reflect changes within the database - wrapped by [Flow]
+     *
+     * @see SongSortBy
+     * @see SortOrder
+     */
+    fun listFavoriteSongs(
+        sortBy: SongSortBy,
+        sortOrder: SortOrder
+    ): Flow<List<SongEntity>> = when (sortBy) {
+        SongSortBy.PlayTime -> sortFavoriteSongsByPlayTime()
+        SongSortBy.Title -> sortFavoriteSongsByTitle()
+        SongSortBy.DateAdded -> sortFavoriteSongsByRowId()
+        SongSortBy.DatePlayed -> sortFavoriteSongsByDatePlayed()
+        SongSortBy.DateLiked -> sortFavoriteSongsByLikedAt()
+        SongSortBy.Artist -> sortFavoriteSongsByArtist()
+        SongSortBy.Duration -> sortFavoriteSongsByDuration()
+        SongSortBy.AlbumName -> sortFavoriteSongsByAlbum()
+    }.map(sortOrder::applyTo)
 
     @Query("SELECT thumbnailUrl FROM Song WHERE likedAt IS NOT NULL AND id NOT LIKE '$LOCAL_KEY_PREFIX%'  LIMIT 4")
     fun preferitesThumbnailUrls(): Flow<List<String?>>

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/Database.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/Database.kt
@@ -552,31 +552,6 @@ interface Database {
         @MagicConstant(intValues = [-1, 0]) showHidden: Int
     ): Flow<List<SongEntity>>
 
-    @Transaction
-    @Query(
-        """
-        SELECT * FROM Song
-        WHERE id NOT LIKE '$LOCAL_KEY_PREFIX%'
-        ORDER BY totalPlayTimeMs DESC
-        LIMIT :limit
-        """
-    )
-    @RewriteQueriesToDropUnusedColumns
-    fun songsByPlayTimeWithLimitDesc(limit: Int = -1): Flow<List<Song>>
-
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query(
-        """
-        SELECT * FROM Song
-        WHERE id NOT LIKE '$LOCAL_KEY_PREFIX%'
-        ORDER BY totalPlayTimeMs DESC
-        LIMIT :limit
-        """
-    )
-    @RewriteQueriesToDropUnusedColumns
-    fun songsEntityByPlayTimeWithLimitDesc(limit: Int = -1): Flow<List<SongEntity>>
-
     @Query("""
         SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
         FROM Song 
@@ -710,6 +685,31 @@ interface Database {
     fun listAllSongs(
         @MagicConstant(intValues = [-1, 0]) showHidden: Int
     ): Flow<List<SongEntity>>
+
+    @Transaction
+    @Query(
+        """
+        SELECT * FROM Song
+        WHERE id NOT LIKE '$LOCAL_KEY_PREFIX%'
+        ORDER BY totalPlayTimeMs DESC
+        LIMIT :limit
+        """
+    )
+    @RewriteQueriesToDropUnusedColumns
+    fun songsByPlayTimeWithLimitDesc(limit: Int = -1): Flow<List<Song>>
+
+    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
+    @Transaction
+    @Query(
+        """
+        SELECT * FROM Song
+        WHERE id NOT LIKE '$LOCAL_KEY_PREFIX%'
+        ORDER BY totalPlayTimeMs DESC
+        LIMIT :limit
+        """
+    )
+    @RewriteQueriesToDropUnusedColumns
+    fun songsEntityByPlayTimeWithLimitDesc(limit: Int = -1): Flow<List<SongEntity>>
 
     @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
     @Transaction

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/Database.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/Database.kt
@@ -371,94 +371,139 @@ interface Database {
     @Query("SELECT Song.*, contentLength FROM Song LEFT JOIN Format ON id = songId WHERE songId = :songId")
     fun songCached(songId: String): Flow<SongWithContentLength?>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT Song.*, contentLength FROM Song INNER JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0 ORDER BY totalPlayTimeMs")
-    fun songsOfflineByPlayTimeAsc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE contentLength IS NOT NULL 
+            AND totalPlayTimeMs > 0 
+        ORDER BY totalPlayTimeMs
+    """)
+    fun sortOfflineSongsByPlayTime(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT Song.*, contentLength FROM Song INNER JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0 ORDER BY totalPlayTimeMs DESC")
-    fun songsOfflineByPlayTimeDesc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE contentLength IS NOT NULL 
+            AND totalPlayTimeMs > 0 
+        ORDER BY 
+            CASE
+                WHEN Song.title LIKE "$EXPLICIT_PREFIX%" THEN SUBSTR(Song.title, LENGTH('$EXPLICIT_PREFIX') + 1)
+                ELSE Song.title
+            END
+        COLLATE NOCASE
+    """)
+    fun sortOfflineSongsByTitle(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT Song.*, contentLength FROM Song INNER JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0 ORDER BY Song.title")
-    fun songsOfflineByTitleAsc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE contentLength IS NOT NULL 
+            AND totalPlayTimeMs > 0 
+        ORDER BY Song.ROWID
+    """)
+    fun sortOfflineSongsByRowId(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT Song.*, contentLength FROM Song INNER JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0 ORDER BY Song.title DESC")
-    fun songsOfflineByTitleDesc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE contentLength IS NOT NULL 
+        AND totalPlayTimeMs > 0 
+        ORDER BY Song.likedAt
+    """)
+    fun sortOfflineSongsByLikedAt(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT Song.*, contentLength FROM Song INNER JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0 ORDER BY Song.ROWID")
-    fun songsOfflineByRowIdAsc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE contentLength IS NOT NULL 
+            AND totalPlayTimeMs > 0 
+        ORDER BY Song.artistsText
+    """)
+    fun sortOfflineSongsByArtist(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT Song.*, contentLength FROM Song INNER JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0 ORDER BY Song.ROWID DESC")
-    fun songsOfflineByRowIdDesc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE contentLength IS NOT NULL 
+            AND totalPlayTimeMs > 0 
+        ORDER BY Song.durationText
+    """)
+    fun sortOfflineSongsByDuration(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT Song.*, contentLength FROM Song INNER JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0 ORDER BY Song.likedAt")
-    fun songsOfflineByLikedAtAsc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN Event E ON E.songId=Song.id 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE contentLength IS NOT NULL 
+            AND totalPlayTimeMs > 0 
+        ORDER BY E.timestamp
+    """)
+    fun sortOfflineSongsByDatePlayed(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT Song.*, contentLength FROM Song INNER JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0 ORDER BY Song.likedAt DESC")
-    fun songsOfflineByLikedAtDesc(): Flow<List<SongEntity>>
+    @Query("""
+        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        FROM Song 
+        LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
+        LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
+        LEFT JOIN Format ON Format.songId = Song.id
+        WHERE contentLength IS NOT NULL 
+            AND totalPlayTimeMs > 0 
+        ORDER BY Album.title COLLATE NOCASE
+    """)
+    fun sortOfflineSongsByAlbum(): Flow<List<SongEntity>>
 
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT Song.*, contentLength FROM Song INNER JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0 ORDER BY Song.artistsText")
-    fun songsOfflineByArtistAsc(): Flow<List<SongEntity>>
-
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT Song.*, contentLength FROM Song INNER JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0 ORDER BY Song.artistsText DESC")
-    fun songsOfflineByArtistDesc(): Flow<List<SongEntity>>
-
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT Song.*, contentLength FROM Song INNER JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0 ORDER BY Song.durationText")
-    fun songsOfflineByDurationAsc(): Flow<List<SongEntity>>
-
-    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
-    @Transaction
-    @Query("SELECT Song.*, contentLength FROM Song INNER JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0 ORDER BY Song.durationText DESC")
-    fun songsOfflineByDurationDesc(): Flow<List<SongEntity>>
-
-    fun songsOffline(sortBy: SongSortBy, sortOrder: SortOrder): Flow<List<SongEntity>> {
-        return when (sortBy) {
-            SongSortBy.PlayTime, SongSortBy.DatePlayed -> when (sortOrder) {
-                SortOrder.Ascending -> songsOfflineByPlayTimeAsc()
-                SortOrder.Descending -> songsOfflineByPlayTimeDesc()
-            }
-            SongSortBy.Title, SongSortBy.AlbumName -> when (sortOrder) {
-                SortOrder.Ascending -> songsOfflineByTitleAsc()
-                SortOrder.Descending -> songsOfflineByTitleDesc()
-            }
-            SongSortBy.DateAdded -> when (sortOrder) {
-                SortOrder.Ascending -> songsOfflineByRowIdAsc()
-                SortOrder.Descending -> songsOfflineByRowIdDesc()
-            }
-            SongSortBy.DateLiked -> when (sortOrder) {
-                SortOrder.Ascending -> songsOfflineByLikedAtAsc()
-                SortOrder.Descending -> songsOfflineByLikedAtDesc()
-            }
-            SongSortBy.Artist -> when (sortOrder) {
-                SortOrder.Ascending -> songsOfflineByArtistAsc()
-                SortOrder.Descending -> songsOfflineByArtistDesc()
-            }
-            SongSortBy.Duration -> when (sortOrder) {
-                SortOrder.Ascending -> songsOfflineByDurationAsc()
-                SortOrder.Descending -> songsOfflineByDurationDesc()
-            }
-        }
-    }
+    /**
+     * Fetch all songs from that are cached the database
+     * and sort them according to [sortBy] and [sortOrder].
+     *
+     * [sortBy] sorts all based on each song's property
+     * such as [SongSortBy.Title], [SongSortBy.PlayTime], etc.
+     * While [sortOrder] arranges order of sorted songs
+     * to follow alphabetical order A to Z, or numerical order 0 to 9, etc.
+     *
+     * @param sortBy which song's property is used to sort
+     * @param sortOrder what order should results be in
+     *
+     * @return a **SORTED** list of [SongEntity]'s that are continuously
+     * updated to reflect changes within the database - wrapped by [Flow]
+     *
+     * @see SongSortBy
+     * @see SortOrder
+     */
+    fun listOfflineSongs(
+        sortBy: SongSortBy,
+        sortOrder: SortOrder
+    ): Flow<List<SongEntity>> = when (sortBy) {
+        SongSortBy.PlayTime -> sortOfflineSongsByPlayTime()
+        SongSortBy.Title -> sortOfflineSongsByTitle()
+        SongSortBy.DateAdded -> sortOfflineSongsByRowId()
+        SongSortBy.DatePlayed -> sortOfflineSongsByDatePlayed()
+        SongSortBy.DateLiked -> sortOfflineSongsByLikedAt()
+        SongSortBy.Artist -> sortOfflineSongsByArtist()
+        SongSortBy.Duration -> sortOfflineSongsByDuration()
+        SongSortBy.AlbumName -> sortOfflineSongsByAlbum()
+    }.map( sortOrder::applyTo )
 
     @Query("SELECT thumbnailUrl FROM Song JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0  LIMIT 4")
     fun offlineThumbnailUrls(): Flow<List<String?>>

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/Database.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/Database.kt
@@ -237,7 +237,7 @@ interface Database {
     fun songsEntityOnDevice(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -248,7 +248,7 @@ interface Database {
     fun sortFavoriteSongsByArtist(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -259,7 +259,7 @@ interface Database {
     fun sortFavoriteSongsByPlayTime(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -275,7 +275,7 @@ interface Database {
     fun sortFavoriteSongsByTitle(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -286,7 +286,7 @@ interface Database {
     fun sortFavoriteSongsByRowId(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -297,7 +297,7 @@ interface Database {
     fun sortFavoriteSongsByLikedAt(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -309,7 +309,7 @@ interface Database {
     fun sortFavoriteSongsByDatePlayed(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -320,7 +320,7 @@ interface Database {
     fun sortFavoriteSongsByDuration(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -372,7 +372,7 @@ interface Database {
     fun songCached(songId: String): Flow<SongWithContentLength?>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -384,7 +384,7 @@ interface Database {
     fun sortOfflineSongsByPlayTime(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -401,7 +401,7 @@ interface Database {
     fun sortOfflineSongsByTitle(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -413,7 +413,7 @@ interface Database {
     fun sortOfflineSongsByRowId(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -425,7 +425,7 @@ interface Database {
     fun sortOfflineSongsByLikedAt(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -437,7 +437,7 @@ interface Database {
     fun sortOfflineSongsByArtist(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -449,7 +449,7 @@ interface Database {
     fun sortOfflineSongsByDuration(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN Event E ON E.songId=Song.id 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
@@ -462,7 +462,7 @@ interface Database {
     fun sortOfflineSongsByDatePlayed(): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -505,11 +505,8 @@ interface Database {
         SongSortBy.AlbumName -> sortOfflineSongsByAlbum()
     }.map( sortOrder::applyTo )
 
-    @Query("SELECT thumbnailUrl FROM Song JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0  LIMIT 4")
-    fun offlineThumbnailUrls(): Flow<List<String?>>
-
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -522,7 +519,7 @@ interface Database {
     ): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -540,7 +537,7 @@ interface Database {
     ): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -553,7 +550,7 @@ interface Database {
     ): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN Event E ON E.songId=Song.id 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
@@ -567,7 +564,7 @@ interface Database {
     ): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -580,7 +577,7 @@ interface Database {
     ): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -593,7 +590,7 @@ interface Database {
     ): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -606,7 +603,7 @@ interface Database {
     ): Flow<List<SongEntity>>
 
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -675,7 +672,7 @@ interface Database {
      * updated to reflect changes within the database - wrapped by [Flow]
      */
     @Query("""
-        SELECT DISTINCT Song.*, Album.title as albumTitle, Format.contentLength as contentLength
+        SELECT DISTINCT Song.*, Format.contentLength, Album.title
         FROM Song 
         LEFT JOIN SongAlbumMap ON Song.id = SongAlbumMap.songId 
         LEFT JOIN Album ON Album.id = SongAlbumMap.albumId 
@@ -719,7 +716,8 @@ interface Database {
     @RewriteQueriesToDropUnusedColumns
     fun songsWithAlbumByPlayTimeDesc(showHiddenSongs: Int = 0): Flow<List<SongEntity>>
 
-
+    @Query("SELECT thumbnailUrl FROM Song JOIN Format ON id = songId WHERE contentLength IS NOT NULL AND totalPlayTimeMs > 0  LIMIT 4")
+    fun offlineThumbnailUrls(): Flow<List<String?>>
 
     @Transaction
     @Query("SELECT * FROM Song WHERE likedAt IS NOT NULL ORDER BY likedAt DESC")

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/enums/SortOrder.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/enums/SortOrder.kt
@@ -1,5 +1,7 @@
 package it.fast4x.rimusic.enums
 
+import org.jetbrains.annotations.Contract
+
 enum class SortOrder( val rotationZ: Float ) {
     Ascending( 0f ),
     Descending( 180f );
@@ -8,4 +10,25 @@ enum class SortOrder( val rotationZ: Float ) {
         Ascending -> Descending
         Descending -> Ascending
     }
+
+    /**
+     * Attempt to apply sort order based on selected value.
+     *
+     * The provided list [items] is always assumed to be sorted
+     * in ascending order. Therefore, it only get reversed
+     * when [Descending] is selected.
+     *
+     * Return list is always a new list to prevent unwanted results
+     *
+     * @return a new list regardless selected value
+     */
+    @Contract(
+        value = "_->new",
+        pure = true
+    )
+    fun <T> applyTo( items: List<T> ): List<T> =
+        when( this ) {
+            Descending -> items.reversed()
+            Ascending -> items.toList()
+        }
 }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/PlayerMediaBrowserService.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/PlayerMediaBrowserService.kt
@@ -157,8 +157,9 @@ class PlayerMediaBrowserService : MediaBrowserServiceCompat(), ServiceConnection
                     )
 
                     MediaId.songs -> Database
-                        .songsByPlayTimeDesc()
+                        .sortAllSongsByPlayTime( 0 )
                         .first()
+                        .reversed()
                         .take(500)
                         .also { lastSongs = it.map { it.song } }
                         .map { it.song.asBrowserMediaItem }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/PlayerMediaBrowserService.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/PlayerMediaBrowserService.kt
@@ -23,15 +23,16 @@ import it.fast4x.innertube.models.bodies.SearchBody
 import it.fast4x.innertube.requests.searchPage
 import it.fast4x.innertube.utils.from
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.MONTHLY_PREFIX
+import it.fast4x.rimusic.PINNED_PREFIX
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.MaxTopPlaylistItems
 import it.fast4x.rimusic.models.Album
 import it.fast4x.rimusic.models.Artist
 import it.fast4x.rimusic.models.PlaylistPreview
 import it.fast4x.rimusic.models.Song
+import it.fast4x.rimusic.models.SongEntity
 import it.fast4x.rimusic.models.SongWithContentLength
-import it.fast4x.rimusic.PINNED_PREFIX
-import it.fast4x.rimusic.MONTHLY_PREFIX
 import it.fast4x.rimusic.utils.MaxTopPlaylistItemsKey
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.asSong
@@ -465,10 +466,12 @@ class PlayerMediaBrowserService : MediaBrowserServiceCompat(), ServiceConnection
 
                     MediaId.downloaded -> {
                         val downloads = MyDownloadHelper.downloads.value
-                        Database.listAllSongs()
-                             .filter {
-                                    downloads[it.id]?.state == Download.STATE_COMPLETED
-                             }
+                        Database.listAllSongs( -1 )
+                                .first()
+                                .map( SongEntity::song )
+                                .filter {
+                                       downloads[it.id]?.state == Download.STATE_COMPLETED
+                                }
                     }
 
                     MediaId.top -> {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/MediaLibrarySessionCallback.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/MediaLibrarySessionCallback.kt
@@ -313,7 +313,7 @@ class MediaLibrarySessionCallback @Inject constructor(
 
                         when (val playlistId =
                             parentId.removePrefix("${PlayerServiceModern.PLAYLIST}/")) {
-                            ID_FAVORITES -> database.songsFavoritesByRowIdAsc().map { list ->
+                            ID_FAVORITES -> database.sortFavoriteSongsByRowId().map { list ->
                                 list.map { it.song }
                             }
                             ID_CACHED -> database.songsOfflineByPlayTimeDesc().map { list ->
@@ -434,7 +434,7 @@ class MediaLibrarySessionCallback @Inject constructor(
                 val songId = path.getOrNull(2) ?: return@future defaultResult
                 val playlistId = path.getOrNull(1) ?: return@future defaultResult
                 val songs = when (playlistId) {
-                    ID_FAVORITES -> database.songsFavoritesByRowIdDesc()
+                    ID_FAVORITES -> database.sortFavoriteSongsByRowId().map{ it.reversed() }
                     ID_CACHED -> database.songsOfflineByPlayTimeDesc()
                     ID_TOP -> database.trendingSongEntity(
                         context.preferences.getEnum(MaxTopPlaylistItemsKey,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/MediaLibrarySessionCallback.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/MediaLibrarySessionCallback.kt
@@ -213,7 +213,7 @@ class MediaLibrarySessionCallback @Inject constructor(
                     )
                 )
 
-                PlayerServiceModern.SONG -> database.songsByRowIdAsc().first()
+                PlayerServiceModern.SONG -> database.sortAllSongsByRowId( 0 ).first()
                     .map { it.song.toMediaItem(parentId) }
 
                 PlayerServiceModern.ARTIST -> database.artistsByRowIdAsc().first().map { artist ->

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/MediaLibrarySessionCallback.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/MediaLibrarySessionCallback.kt
@@ -316,8 +316,8 @@ class MediaLibrarySessionCallback @Inject constructor(
                             ID_FAVORITES -> database.sortFavoriteSongsByRowId().map { list ->
                                 list.map { it.song }
                             }
-                            ID_CACHED -> database.songsOfflineByPlayTimeDesc().map { list ->
-                                list.map { it.song }
+                            ID_CACHED -> database.sortOfflineSongsByPlayTime().map { list ->
+                                list.reversed().map { it.song }
                             }
                             ID_TOP -> database.trending(
                                 context.preferences.getEnum(MaxTopPlaylistItemsKey,
@@ -435,7 +435,7 @@ class MediaLibrarySessionCallback @Inject constructor(
                 val playlistId = path.getOrNull(1) ?: return@future defaultResult
                 val songs = when (playlistId) {
                     ID_FAVORITES -> database.sortFavoriteSongsByRowId().map{ it.reversed() }
-                    ID_CACHED -> database.songsOfflineByPlayTimeDesc()
+                    ID_CACHED -> database.sortOfflineSongsByPlayTime().map{ it.reversed() }
                     ID_TOP -> database.trendingSongEntity(
                         context.preferences.getEnum(MaxTopPlaylistItemsKey,
                             MaxTopPlaylistItems.`10`).number.toInt()

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/MediaLibrarySessionCallback.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/MediaLibrarySessionCallback.kt
@@ -328,14 +328,14 @@ class MediaLibrarySessionCallback @Inject constructor(
                             }
                             ID_DOWNLOADED -> {
                                 val downloads = downloadHelper.downloads.value
-                                database.listAllSongsAsFlow()
-                                    .flowOn(Dispatchers.IO)
-                                    .map { list ->
-                                        list.map { it.song }
-                                            .filter {
-                                                downloads[it.id]?.state == Download.STATE_COMPLETED
-                                            }
-                                    }
+                                database.listAllSongs( -1 )
+                                        .flowOn( Dispatchers.IO )
+                                        .map { list ->
+                                            list.map { it.song }
+                                                .filter {
+                                                    downloads[it.id]?.state == Download.STATE_COMPLETED
+                                                }
+                                        }
                             }
 
                             else -> database.sortSongsFromPlaylistByRowId( playlistId.toLong() )
@@ -398,7 +398,7 @@ class MediaLibrarySessionCallback @Inject constructor(
 
             PlayerServiceModern.SONG -> {
                 val songId = path.getOrNull(1) ?: return@future defaultResult
-                val allSongs = database.listAllSongsAsFlow().first()
+                val allSongs = database.listAllSongs( -1 ).first()
                 MediaSession.MediaItemsWithStartPosition(
                     allSongs.map { it.song.toMediaItem() },
                     allSongs.indexOfFirst { it.song.id == songId }.takeIf { it != -1 } ?: 0,
@@ -443,18 +443,18 @@ class MediaLibrarySessionCallback @Inject constructor(
                     ID_ONDEVICE -> database.songsEntityOnDevice()
                     ID_DOWNLOADED -> {
                         val downloads = downloadHelper.downloads.value
-                        database.listAllSongsAsFlow()
-                            .flowOn(Dispatchers.IO)
-                            .map { songs ->
-                                songs.filter {
-                                    downloads[it.song.id]?.state == Download.STATE_COMPLETED
+                        database.listAllSongs( -1 )
+                                .flowOn( Dispatchers.IO )
+                                .map { songs ->
+                                    songs.filter {
+                                        downloads[it.song.id]?.state == Download.STATE_COMPLETED
+                                    }
                                 }
-                            }
-                            .map { songs ->
-                                songs.map { it to downloads[it.song.id] }
-                                    .sortedBy { it.second?.updateTimeMs ?: 0L }
-                                    .map { it.first }
-                            }
+                                .map { songs ->
+                                    songs.map { it to downloads[it.song.id] }
+                                        .sortedBy { it.second?.updateTimeMs ?: 0L }
+                                        .map { it.first }
+                                }
                     }
 
                     else -> database.sortSongsFromPlaylistByRowId( playlistId.toLong() )

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
@@ -132,6 +132,7 @@ import it.fast4x.rimusic.utils.songSortByKey
 import it.fast4x.rimusic.utils.songSortOrderKey
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
@@ -391,7 +392,21 @@ fun HomeSongs(
             }
             BuiltInPlaylist.OnDevice -> flowOf()
 
-        }.flowOn( Dispatchers.IO ).distinctUntilChanged().collect { items = it }
+        }.flowOn( Dispatchers.IO ).distinctUntilChanged().collect {
+             /*
+                 When [builtInPlaylist] goes from [BuiltInPlaylist.All] to [BuiltInPlaylist.Downloaded]
+                 or vice versa, the list refuses to update because new list and [items] contain
+                 the same items.
+                 To counter this, we need to manually clear the list and update it
+                 with a new one (with a little delay in between to prevent race condition)
+             */
+            if( it.containsAll( items ) ) {
+                items = emptyList()
+                delay( 100 )
+            }
+
+            items = it
+        }
     }
 
     var songsDevice by remember {

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
@@ -379,7 +379,7 @@ fun HomeSongs(
 
                 Database.listAllSongs( songSort.sortBy, songSort.sortOrder, showHidden )
             }
-            BuiltInPlaylist.Favorites -> Database.songsFavorites( songSort.sortBy, songSort.sortOrder )
+            BuiltInPlaylist.Favorites -> Database.listFavoriteSongs( songSort.sortBy, songSort.sortOrder )
             BuiltInPlaylist.Offline -> Database.songsOffline( songSort.sortBy, songSort.sortOrder )
             BuiltInPlaylist.Top -> {
                 if (topPlaylists.period.duration == Duration.INFINITE)

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/home/HomeSongs.kt
@@ -380,7 +380,7 @@ fun HomeSongs(
                 Database.listAllSongs( songSort.sortBy, songSort.sortOrder, showHidden )
             }
             BuiltInPlaylist.Favorites -> Database.listFavoriteSongs( songSort.sortBy, songSort.sortOrder )
-            BuiltInPlaylist.Offline -> Database.songsOffline( songSort.sortBy, songSort.sortOrder )
+            BuiltInPlaylist.Offline -> Database.listOfflineSongs( songSort.sortBy, songSort.sortOrder )
             BuiltInPlaylist.Top -> {
                 if (topPlaylists.period.duration == Duration.INFINITE)
                     Database.songsEntityByPlayTimeWithLimitDesc(limit = maxTopPlaylistItems.number.toInt())


### PR DESCRIPTION
Last time I stashed current work on HomeSongs to implement `contentLength` and forgot to unstash it (then I deleted it LOL)

This PR is similar to #4642, I added a `CASE` to sort by title so `e:` wouldn't count and both `albumTitle` & `contentLength` are present to prevent `RoomWarnings.QUERY_MISMATCH` . I added `DISTINCT` to make sure no duplicated items allowed.

EDIT: Don't forget the document I added

> Let me know if you need adjustment