### PR TITLE
disabled filter for dynamic color palette

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/styling/ColorPalette.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/styling/ColorPalette.kt
@@ -125,7 +125,7 @@ fun dynamicColorPaletteOf(bitmap: Bitmap, isDark: Boolean): ColorPalette? {
     val palette = Palette
         .from(bitmap)
         .maximumColorCount(8)
-        .addFilter(if (isDark) ({ _, hsl -> hsl[0] !in 36f..100f }) else null)
+        //.addFilter(if (isDark) ({ _, hsl -> hsl[0] !in 36f..100f }) else null)
         .generate()
 
 


### PR DESCRIPTION
- it breaks `match song cover` for colors like yellow in app dark mode