### PR TITLE
fixed centering for (landscape) rectangular thumbnails in visualizer

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/extensions/nextvisualizer/painters/misc/Icon.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/extensions/nextvisualizer/painters/misc/Icon.kt
@@ -37,7 +37,7 @@ class Icon(
             val radius = shortest * radiusR
             matrix.apply {
                 postScale(radius / this@bitmap.width, radius / this@bitmap.width)
-                postTranslate(-radius / 2f, -radius / 2f)
+                postTranslate(-radius / 2f, -radius / 2f + (this@bitmap.width-this@bitmap.height)/2)
             }
             drawHelper(canvas, "a", .5f, .5f) {
                 canvas.drawBitmap(this, matrix, paint)


### PR DESCRIPTION
- does not fix the case if the thumbnail is in portrait orientation (but did not yet find an example of that)