### PR TITLE
improved visualizer thumbnail on error

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/extensions/nextvisualizer/NextVisualizer.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/extensions/nextvisualizer/NextVisualizer.kt
@@ -238,7 +238,8 @@ fun getVisualizers(): List<Painter> {
     val ampR = 3f
     val yR = 0.2f
     val color = colorPalette().text.hashCode()
-    var bitmapCover by remember { mutableStateOf(ContextCompat.getDrawable(context, R.drawable.app_logo)?.toBitmap()!!) }
+    var logoBitmapCover by remember { mutableStateOf(ContextCompat.getDrawable(context, R.drawable.app_logo)?.toBitmap()!!) }
+    var bitmapCover by remember { mutableStateOf(logoBitmapCover) }
     val binder = LocalPlayerServiceBinder.current
     val coroutineScope = rememberCoroutineScope()
     LaunchedEffect(Unit) {
@@ -276,6 +277,7 @@ fun getVisualizers(): List<Painter> {
                                 .resize(1200, 1200)
                         )
                     } catch (e: Exception) {
+                        bitmapCover = logoBitmapCover
                         Timber.e("Failed to get bitmap in NextVisualizer ${e.stackTraceToString()}")
                     }
                 }


### PR DESCRIPTION
- now it correctly shows the RiMusic-logo instead of the last successfully loaded thumbnail (for the wrong song)