### PR TITLE
fixed library artists-/... shuffling (database update related)

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/tab/toolbar/SongsShuffle.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/components/tab/toolbar/SongsShuffle.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import it.fast4x.rimusic.appContext
+import kotlinx.coroutines.CancellationException
 
 @UnstableApi
 class SongsShuffle private constructor(
@@ -37,6 +38,7 @@ class SongsShuffle private constructor(
         CoroutineScope( Dispatchers.IO ).launch {
             songs().collect {
                 playShuffledSongs( it, appContext(), binder )
+                throw CancellationException()
             }
         }
     }


### PR DESCRIPTION
- an database update would reload the queue if it was started by library artists-/... shuffle
- "broke" the connection to the database