### PR TITLE
fixed (multi-select) "play next" when applied on empty queue

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Player.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Player.kt
@@ -162,7 +162,8 @@ fun Player.addNext(mediaItems: List<MediaItem>, context: Context? = null) {
     }
 
     if (playbackState == Player.STATE_IDLE || playbackState == Player.STATE_ENDED) {
-        forcePlay(filteredMediaItems.first())
+        setMediaItems(filteredMediaItems.map { it.cleaned })
+        play()
     } else {
         addMediaItems(currentMediaItemIndex + 1, filteredMediaItems.map { it.cleaned })
     }


### PR DESCRIPTION
- fixed "play next" when applied on empty queue for multiple selected songs
- was only adding the first selected song