### PR TITLE
explicit indicator in queue and miniplayer

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/SongItem.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/items/SongItem.kt
@@ -41,44 +41,44 @@ import androidx.media3.exoplayer.offline.DownloadService
 import coil.compose.AsyncImage
 import it.fast4x.innertube.Innertube
 import it.fast4x.rimusic.Database
-import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.cleanPrefix
+import it.fast4x.rimusic.colorPalette
+import it.fast4x.rimusic.enums.ColorPaletteName
 import it.fast4x.rimusic.enums.DownloadedStateMedia
 import it.fast4x.rimusic.models.Song
 import it.fast4x.rimusic.service.MyDownloadService
 import it.fast4x.rimusic.service.isLocal
+import it.fast4x.rimusic.thumbnailShape
+import it.fast4x.rimusic.typography
 import it.fast4x.rimusic.ui.components.themed.HeaderIconButton
 import it.fast4x.rimusic.ui.components.themed.IconButton
+import it.fast4x.rimusic.ui.components.themed.NowPlayingSongIndicator
 import it.fast4x.rimusic.ui.components.themed.SmartMessage
 import it.fast4x.rimusic.ui.components.themed.TextPlaceholder
-import it.fast4x.rimusic.ui.styling.favoritesIcon
-import it.fast4x.rimusic.ui.styling.shimmer
-import it.fast4x.rimusic.ui.components.themed.NowPlayingSongIndicator
 import it.fast4x.rimusic.ui.styling.LocalAppearance
+import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.ui.styling.favoritesOverlay
+import it.fast4x.rimusic.ui.styling.shimmer
 import it.fast4x.rimusic.utils.asMediaItem
 import it.fast4x.rimusic.utils.asSong
+import it.fast4x.rimusic.utils.colorPaletteNameKey
 import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.downloadedStateMedia
 import it.fast4x.rimusic.utils.getLikeState
+import it.fast4x.rimusic.utils.isExplicit
 import it.fast4x.rimusic.utils.medium
 import it.fast4x.rimusic.utils.playlistindicatorKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.secondary
 import it.fast4x.rimusic.utils.semiBold
+import it.fast4x.rimusic.utils.shimmerEffect
 import it.fast4x.rimusic.utils.thumbnail
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import it.fast4x.rimusic.colorPalette
-import it.fast4x.rimusic.enums.ColorPaletteName
-import it.fast4x.rimusic.utils.shimmerEffect
-import it.fast4x.rimusic.thumbnailShape
-import it.fast4x.rimusic.typography
-import it.fast4x.rimusic.utils.colorPaletteNameKey
 
 
 @UnstableApi
@@ -345,7 +345,6 @@ fun SongItem(
     downloadedStateMedia = if (!mediaItem.isLocal) downloadedStateMedia(mediaItem.mediaId)
     else DownloadedStateMedia.DOWNLOADED
 
-    val isExplicit = mediaItem.mediaMetadata.title?.startsWith(EXPLICIT_PREFIX) == true
     val title = mediaItem.mediaMetadata.title.toString()
     val authors = mediaItem.mediaMetadata.artist.toString()
     val duration = mediaItem.mediaMetadata.extras?.getString("durationText")
@@ -357,6 +356,7 @@ fun SongItem(
     val colorPaletteName by rememberPreference(colorPaletteNameKey, ColorPaletteName.Dynamic)
 
     // TODO improve playlist indicator without recompose
+    // There's no need, turning this into Flow is much more efficient
     if (playlistindicator)
         LaunchedEffect(Unit, forceRecompose) {
             withContext(Dispatchers.IO) {
@@ -464,7 +464,7 @@ fun SongItem(
                         Spacer(modifier = Modifier.padding(horizontal = 3.dp))
                     }
 
-                    if (isExplicit)
+                    if ( mediaItem.isExplicit )
                         IconButton(
                             icon = R.drawable.explicit,
                             color = colorPalette().text,
@@ -522,7 +522,7 @@ fun SongItem(
                                 .size(18.dp)
                         )
 
-                    if (isExplicit)
+                    if ( mediaItem.isExplicit )
                         IconButton(
                             icon = R.drawable.explicit,
                             color = colorPalette().text,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Controls.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Controls.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -42,7 +41,6 @@ import it.fast4x.rimusic.enums.PlayerControlsType
 import it.fast4x.rimusic.enums.PlayerInfoType
 import it.fast4x.rimusic.enums.PlayerPlayButtonType
 import it.fast4x.rimusic.enums.PlayerTimelineSize
-import it.fast4x.rimusic.enums.PlayerTimelineType
 import it.fast4x.rimusic.enums.PlayerType
 import it.fast4x.rimusic.models.Info
 import it.fast4x.rimusic.models.Song
@@ -54,7 +52,6 @@ import it.fast4x.rimusic.utils.GetSeekBar
 import it.fast4x.rimusic.utils.buttonzoomoutKey
 import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.disableScrollingTextKey
-import it.fast4x.rimusic.utils.effectRotationKey
 import it.fast4x.rimusic.utils.isCompositionLaunched
 import it.fast4x.rimusic.utils.isDownloadedSong
 import it.fast4x.rimusic.utils.isLandscape
@@ -63,7 +60,6 @@ import it.fast4x.rimusic.utils.playerInfoTypeKey
 import it.fast4x.rimusic.utils.playerPlayButtonTypeKey
 import it.fast4x.rimusic.utils.playerSwapControlsWithTimelineKey
 import it.fast4x.rimusic.utils.playerTimelineSizeKey
-import it.fast4x.rimusic.utils.playerTimelineTypeKey
 import it.fast4x.rimusic.utils.playerTypeKey
 import it.fast4x.rimusic.utils.rememberPreference
 import it.fast4x.rimusic.utils.showlyricsthumbnailKey
@@ -97,6 +93,7 @@ fun Controls(
     shouldBePlaying: Boolean,
     position: Long,
     duration: Long,
+    isExplicit: Boolean,
     modifier: Modifier = Modifier
 ) {
     val binder = LocalPlayerServiceBinder.current
@@ -247,6 +244,7 @@ fun Controls(
                             disableScrollingText = disableScrollingText,
                             artist = artist,
                             artistIds = artistIds,
+                            isExplicit = isExplicit
                         )
 
                     if (playerInfoType == PlayerInfoType.Essential)
@@ -262,6 +260,7 @@ fun Controls(
                             disableScrollingText = disableScrollingText,
                             artist = artist,
                             artistIds = artistIds,
+                            isExplicit = isExplicit
                         )
                     Spacer(
                         modifier = Modifier
@@ -323,6 +322,7 @@ fun Controls(
                         disableScrollingText = disableScrollingText,
                         artist = artist,
                         artistIds = artistIds,
+                        isExplicit = isExplicit
                     )
 
                 if (playerInfoType == PlayerInfoType.Essential)
@@ -338,6 +338,7 @@ fun Controls(
                         disableScrollingText = disableScrollingText,
                         artist = artist,
                         artistIds = artistIds,
+                        isExplicit = isExplicit
                     )
 
                 Spacer(
@@ -418,6 +419,7 @@ fun Controls(
                     disableScrollingText = disableScrollingText,
                     artist = artist,
                     artistIds = artistIds,
+                    isExplicit = isExplicit
                 )
 
             if (playerInfoType == PlayerInfoType.Essential)
@@ -433,6 +435,7 @@ fun Controls(
                     disableScrollingText = disableScrollingText,
                     artist = artist,
                     artistIds = artistIds,
+                    isExplicit = isExplicit
                 )
 
             Spacer(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/MiniPlayer.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/MiniPlayer.kt
@@ -64,20 +64,22 @@ import coil.compose.AsyncImage
 import it.fast4x.rimusic.Database
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
+import it.fast4x.rimusic.cleanPrefix
+import it.fast4x.rimusic.colorPalette
 import it.fast4x.rimusic.enums.BackgroundProgress
 import it.fast4x.rimusic.enums.MiniPlayerType
 import it.fast4x.rimusic.enums.NavRoutes
+import it.fast4x.rimusic.service.modern.PlayerServiceModern
+import it.fast4x.rimusic.thumbnailShape
+import it.fast4x.rimusic.typography
+import it.fast4x.rimusic.ui.components.themed.NowPlayingSongIndicator
 import it.fast4x.rimusic.ui.components.themed.SmartMessage
-import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.favoritesIcon
 import it.fast4x.rimusic.ui.styling.favoritesOverlay
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.DisposableListener
 import it.fast4x.rimusic.utils.backgroundProgressKey
-import it.fast4x.rimusic.cleanPrefix
-import it.fast4x.rimusic.service.modern.PlayerServiceModern
-import it.fast4x.rimusic.ui.components.themed.NowPlayingSongIndicator
 import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.disableClosingPlayerSwipingDownKey
 import it.fast4x.rimusic.utils.disableScrollingTextKey
@@ -85,6 +87,7 @@ import it.fast4x.rimusic.utils.effectRotationKey
 import it.fast4x.rimusic.utils.getLikedIcon
 import it.fast4x.rimusic.utils.getUnlikedIcon
 import it.fast4x.rimusic.utils.intent
+import it.fast4x.rimusic.utils.isExplicit
 import it.fast4x.rimusic.utils.mediaItemToggleLike
 import it.fast4x.rimusic.utils.miniPlayerTypeKey
 import it.fast4x.rimusic.utils.playNext
@@ -95,9 +98,6 @@ import it.fast4x.rimusic.utils.semiBold
 import it.fast4x.rimusic.utils.shouldBePlaying
 import it.fast4x.rimusic.utils.thumbnail
 import kotlinx.coroutines.flow.distinctUntilChanged
-import it.fast4x.rimusic.colorPalette
-import it.fast4x.rimusic.thumbnailShape
-import it.fast4x.rimusic.typography
 import kotlin.math.absoluteValue
 
 @androidx.annotation.OptIn(UnstableApi::class)
@@ -340,7 +340,7 @@ fun MiniPlayer(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    if (mediaItem.mediaMetadata.title?.startsWith(EXPLICIT_PREFIX) == true)
+                    if ( mediaItem.isExplicit )
                         it.fast4x.rimusic.ui.components.themed.IconButton(
                             icon = R.drawable.explicit,
                             color = colorPalette().text,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
@@ -52,10 +52,10 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -84,7 +84,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.LinearGradientShader
 import androidx.compose.ui.graphics.StrokeJoin
-import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.toArgb
@@ -98,99 +97,24 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-import androidx.media3.common.MediaItem
-import androidx.media3.common.Player
-import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.offline.Download
-import androidx.navigation.NavController
-import coil.compose.AsyncImage
-import coil.compose.rememberAsyncImagePainter
-import coil.request.ImageRequest
-import it.fast4x.rimusic.Database
-import it.fast4x.rimusic.LocalPlayerServiceBinder
-import it.fast4x.rimusic.R
-import it.fast4x.rimusic.enums.BackgroundProgress
-import it.fast4x.rimusic.enums.ColorPaletteMode
-import it.fast4x.rimusic.enums.NavRoutes
-import it.fast4x.rimusic.enums.PlayerBackgroundColors
-import it.fast4x.rimusic.enums.PlayerThumbnailSize
-import it.fast4x.rimusic.enums.PopupType
-import it.fast4x.rimusic.models.Info
-import it.fast4x.rimusic.models.Song
-import it.fast4x.rimusic.models.ui.toUiMedia
-import it.fast4x.rimusic.ui.components.CustomModalBottomSheet
-import it.fast4x.rimusic.ui.components.LocalMenuState
-import it.fast4x.rimusic.ui.components.themed.BlurParamsDialog
-import it.fast4x.rimusic.ui.components.themed.ThumbnailOffsetDialog
-import it.fast4x.rimusic.ui.components.themed.CircularSlider
-import it.fast4x.rimusic.ui.components.themed.ConfirmationDialog
-import it.fast4x.rimusic.ui.components.themed.DefaultDialog
-import it.fast4x.rimusic.ui.components.themed.DownloadStateIconButton
-import it.fast4x.rimusic.ui.components.themed.IconButton
-import it.fast4x.rimusic.ui.components.themed.MiniPlayerMenu
-import it.fast4x.rimusic.ui.components.themed.PlayerMenu
-import it.fast4x.rimusic.ui.components.themed.SecondaryTextButton
-import it.fast4x.rimusic.ui.components.themed.animateBrushRotation
-import it.fast4x.rimusic.ui.styling.Dimensions
-import it.fast4x.rimusic.ui.styling.collapsedPlayerProgressBar
-import it.fast4x.rimusic.ui.styling.dynamicColorPaletteOf
-import it.fast4x.rimusic.ui.styling.favoritesOverlay
-import it.fast4x.rimusic.ui.styling.px
-import it.fast4x.rimusic.utils.BlurTransformation
-import it.fast4x.rimusic.utils.DisposableListener
-import it.fast4x.rimusic.utils.backgroundProgressKey
-import it.fast4x.rimusic.utils.blurDarkenFactorKey
-import it.fast4x.rimusic.utils.blurStrengthKey
-import it.fast4x.rimusic.utils.colorPaletteModeKey
-import it.fast4x.rimusic.utils.currentWindow
-import it.fast4x.rimusic.utils.disablePlayerHorizontalSwipeKey
-import it.fast4x.rimusic.utils.durationTextToMillis
-import it.fast4x.rimusic.utils.effectRotationKey
-import it.fast4x.rimusic.utils.formatAsDuration
-import it.fast4x.rimusic.utils.formatAsTime
-import it.fast4x.rimusic.utils.getBitmapFromUrl
-import it.fast4x.rimusic.utils.getDownloadState
-import it.fast4x.rimusic.utils.isLandscape
-import it.fast4x.rimusic.utils.manageDownload
-import it.fast4x.rimusic.utils.mediaItems
-import it.fast4x.rimusic.utils.playerBackgroundColorsKey
-import it.fast4x.rimusic.utils.playerThumbnailSizeKey
-import it.fast4x.rimusic.utils.positionAndDurationState
-import it.fast4x.rimusic.utils.rememberPreference
-import it.fast4x.rimusic.utils.semiBold
-import it.fast4x.rimusic.utils.shouldBePlaying
-import it.fast4x.rimusic.utils.showButtonPlayerAddToPlaylistKey
-import it.fast4x.rimusic.utils.showButtonPlayerArrowKey
-import it.fast4x.rimusic.utils.showButtonPlayerDownloadKey
-import it.fast4x.rimusic.utils.showButtonPlayerLoopKey
-import it.fast4x.rimusic.utils.showButtonPlayerLyricsKey
-import it.fast4x.rimusic.utils.showButtonPlayerMenuKey
-import it.fast4x.rimusic.utils.showButtonPlayerShuffleKey
-import it.fast4x.rimusic.utils.showButtonPlayerSleepTimerKey
-import it.fast4x.rimusic.utils.showButtonPlayerSystemEqualizerKey
-import it.fast4x.rimusic.utils.showNextSongsInPlayerKey
-import it.fast4x.rimusic.utils.showTopActionsBarKey
-import it.fast4x.rimusic.utils.showTotalTimeQueueKey
-import it.fast4x.rimusic.utils.shuffleQueue
-import it.fast4x.rimusic.utils.thumbnail
-import it.fast4x.rimusic.utils.thumbnailTapEnabledKey
-import it.fast4x.rimusic.utils.transparentBackgroundPlayerActionBarKey
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import kotlin.math.absoluteValue
 import androidx.compose.ui.unit.times
 import androidx.compose.ui.util.lerp
 import androidx.compose.ui.zIndex
 import androidx.core.graphics.ColorUtils.colorToHSL
+import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
 import androidx.media3.common.Timeline
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.offline.Download
+import androidx.navigation.NavController
 import androidx.palette.graphics.Palette
+import coil.compose.AsyncImage
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
 import com.mikepenz.hypnoticcanvas.shaderBackground
 import com.mikepenz.hypnoticcanvas.shaders.BlackCherryCosmos
 import com.mikepenz.hypnoticcanvas.shaders.GlossyGradients
@@ -208,89 +132,164 @@ import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.haze
 import dev.chrisbanes.haze.hazeChild
 import it.fast4x.innertube.models.NavigationEndpoint
+import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.LocalPlayerServiceBinder
+import it.fast4x.rimusic.R
 import it.fast4x.rimusic.appRunningInBackground
+import it.fast4x.rimusic.cleanPrefix
+import it.fast4x.rimusic.colorPalette
+import it.fast4x.rimusic.enums.AnimatedGradient
+import it.fast4x.rimusic.enums.BackgroundProgress
 import it.fast4x.rimusic.enums.CarouselSize
+import it.fast4x.rimusic.enums.ColorPaletteMode
+import it.fast4x.rimusic.enums.ColorPaletteName
+import it.fast4x.rimusic.enums.NavRoutes
+import it.fast4x.rimusic.enums.PlayerBackgroundColors
+import it.fast4x.rimusic.enums.PlayerThumbnailSize
 import it.fast4x.rimusic.enums.PlayerType
+import it.fast4x.rimusic.enums.PopupType
+import it.fast4x.rimusic.enums.QueueLoopType
 import it.fast4x.rimusic.enums.QueueType
 import it.fast4x.rimusic.enums.SongsNumber
+import it.fast4x.rimusic.enums.ThumbnailCoverType
 import it.fast4x.rimusic.enums.ThumbnailRoundness
 import it.fast4x.rimusic.enums.ThumbnailType
-import it.fast4x.rimusic.ui.components.themed.SmartMessage
-import it.fast4x.rimusic.utils.SearchYoutubeEntity
-import it.fast4x.rimusic.utils.actionspacedevenlyKey
-import it.fast4x.rimusic.utils.addNext
-import it.fast4x.rimusic.utils.expandedplayerKey
-import it.fast4x.rimusic.utils.expandedplayertoggleKey
-import it.fast4x.rimusic.utils.showthumbnailKey
-import it.fast4x.rimusic.utils.showlyricsthumbnailKey
-import it.fast4x.rimusic.utils.blackgradientKey
-import it.fast4x.rimusic.utils.visualizerEnabledKey
-import it.fast4x.rimusic.utils.bottomgradientKey
-import it.fast4x.rimusic.utils.carouselKey
-import it.fast4x.rimusic.utils.carouselSizeKey
-import it.fast4x.rimusic.cleanPrefix
-import it.fast4x.rimusic.enums.QueueLoopType
-import it.fast4x.rimusic.enums.ThumbnailCoverType
+import it.fast4x.rimusic.models.Info
+import it.fast4x.rimusic.models.Song
+import it.fast4x.rimusic.models.ui.toUiMedia
+import it.fast4x.rimusic.thumbnailShape
+import it.fast4x.rimusic.typography
+import it.fast4x.rimusic.ui.components.CustomModalBottomSheet
+import it.fast4x.rimusic.ui.components.LocalMenuState
+import it.fast4x.rimusic.ui.components.themed.BlurParamsDialog
+import it.fast4x.rimusic.ui.components.themed.CircularSlider
+import it.fast4x.rimusic.ui.components.themed.ConfirmationDialog
+import it.fast4x.rimusic.ui.components.themed.DefaultDialog
+import it.fast4x.rimusic.ui.components.themed.DownloadStateIconButton
+import it.fast4x.rimusic.ui.components.themed.IconButton
+import it.fast4x.rimusic.ui.components.themed.MiniPlayerMenu
 import it.fast4x.rimusic.ui.components.themed.NowPlayingSongIndicator
+import it.fast4x.rimusic.ui.components.themed.PlayerMenu
 import it.fast4x.rimusic.ui.components.themed.RotateThumbnailCoverAnimationModern
+import it.fast4x.rimusic.ui.components.themed.SecondaryTextButton
+import it.fast4x.rimusic.ui.components.themed.SmartMessage
+import it.fast4x.rimusic.ui.components.themed.ThumbnailOffsetDialog
+import it.fast4x.rimusic.ui.components.themed.animateBrushRotation
+import it.fast4x.rimusic.ui.styling.Dimensions
+import it.fast4x.rimusic.ui.styling.collapsedPlayerProgressBar
+import it.fast4x.rimusic.ui.styling.dynamicColorPaletteOf
+import it.fast4x.rimusic.ui.styling.favoritesOverlay
+import it.fast4x.rimusic.ui.styling.px
+import it.fast4x.rimusic.utils.BlurTransformation
+import it.fast4x.rimusic.utils.DisposableListener
+import it.fast4x.rimusic.utils.SearchYoutubeEntity
 import it.fast4x.rimusic.utils.VerticalfadingEdge2
 import it.fast4x.rimusic.utils.VinylSizeKey
 import it.fast4x.rimusic.utils.actionExpandedKey
-import it.fast4x.rimusic.utils.textoutlineKey
-import kotlin.Float.Companion.POSITIVE_INFINITY
+import it.fast4x.rimusic.utils.actionspacedevenlyKey
+import it.fast4x.rimusic.utils.addNext
+import it.fast4x.rimusic.utils.animatedGradientKey
+import it.fast4x.rimusic.utils.backgroundProgressKey
+import it.fast4x.rimusic.utils.blackgradientKey
+import it.fast4x.rimusic.utils.blurDarkenFactorKey
+import it.fast4x.rimusic.utils.blurStrengthKey
+import it.fast4x.rimusic.utils.bottomgradientKey
+import it.fast4x.rimusic.utils.carouselKey
+import it.fast4x.rimusic.utils.carouselSizeKey
 import it.fast4x.rimusic.utils.clickOnLyricsTextKey
-import it.fast4x.rimusic.utils.conditional
+import it.fast4x.rimusic.utils.colorPaletteModeKey
+import it.fast4x.rimusic.utils.colorPaletteNameKey
 import it.fast4x.rimusic.utils.controlsExpandedKey
 import it.fast4x.rimusic.utils.coverThumbnailAnimationKey
+import it.fast4x.rimusic.utils.currentWindow
+import it.fast4x.rimusic.utils.disablePlayerHorizontalSwipeKey
 import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.discoverKey
 import it.fast4x.rimusic.utils.doubleShadowDrop
+import it.fast4x.rimusic.utils.durationTextToMillis
+import it.fast4x.rimusic.utils.effectRotationKey
+import it.fast4x.rimusic.utils.expandedplayerKey
+import it.fast4x.rimusic.utils.expandedplayertoggleKey
 import it.fast4x.rimusic.utils.extraspaceKey
 import it.fast4x.rimusic.utils.fadingedgeKey
+import it.fast4x.rimusic.utils.formatAsDuration
+import it.fast4x.rimusic.utils.formatAsTime
+import it.fast4x.rimusic.utils.getBitmapFromUrl
+import it.fast4x.rimusic.utils.getDownloadState
+import it.fast4x.rimusic.utils.getIconQueueLoopState
 import it.fast4x.rimusic.utils.horizontalFadingEdge
+import it.fast4x.rimusic.utils.isDownloadedSong
+import it.fast4x.rimusic.utils.isExplicit
+import it.fast4x.rimusic.utils.isLandscape
+import it.fast4x.rimusic.utils.manageDownload
+import it.fast4x.rimusic.utils.mediaItems
 import it.fast4x.rimusic.utils.miniQueueExpandedKey
 import it.fast4x.rimusic.utils.noblurKey
-import it.fast4x.rimusic.utils.playerTypeKey
-import it.fast4x.rimusic.utils.playlistindicatorKey
-import it.fast4x.rimusic.utils.queueDurationExpandedKey
-import it.fast4x.rimusic.utils.queueLoopTypeKey
-import it.fast4x.rimusic.utils.queueTypeKey
-import it.fast4x.rimusic.utils.resize
-import it.fast4x.rimusic.utils.setQueueLoopState
-import it.fast4x.rimusic.utils.showButtonPlayerDiscoverKey
-import it.fast4x.rimusic.utils.showButtonPlayerVideoKey
-import it.fast4x.rimusic.utils.showalbumcoverKey
-import it.fast4x.rimusic.utils.showsongsKey
-import it.fast4x.rimusic.utils.showvisthumbnailKey
-import it.fast4x.rimusic.utils.statsfornerdsKey
-import it.fast4x.rimusic.utils.swipeUpQueueKey
-import it.fast4x.rimusic.utils.tapqueueKey
-import it.fast4x.rimusic.utils.thumbnailRoundnessKey
-import it.fast4x.rimusic.utils.thumbnailSpacingKey
-import it.fast4x.rimusic.utils.thumbnailTypeKey
-import it.fast4x.rimusic.utils.timelineExpandedKey
-import it.fast4x.rimusic.utils.titleExpandedKey
-import it.fast4x.rimusic.utils.getIconQueueLoopState
-import it.fast4x.rimusic.utils.isDownloadedSong
 import it.fast4x.rimusic.utils.playAtIndex
 import it.fast4x.rimusic.utils.playNext
 import it.fast4x.rimusic.utils.playPrevious
-import it.fast4x.rimusic.utils.showButtonPlayerStartRadioKey
-import it.fast4x.rimusic.utils.showCoverThumbnailAnimationKey
-import it.fast4x.rimusic.utils.statsExpandedKey
-import it.fast4x.rimusic.utils.thumbnailFadeKey
-import it.fast4x.rimusic.colorPalette
-import it.fast4x.rimusic.enums.AnimatedGradient
-import it.fast4x.rimusic.enums.ColorPaletteName
-import it.fast4x.rimusic.thumbnailShape
-import it.fast4x.rimusic.typography
-import it.fast4x.rimusic.utils.animatedGradientKey
-import it.fast4x.rimusic.utils.colorPaletteNameKey
+import it.fast4x.rimusic.utils.playerBackgroundColorsKey
+import it.fast4x.rimusic.utils.playerThumbnailSizeKey
 import it.fast4x.rimusic.utils.playerThumbnailSizeLKey
+import it.fast4x.rimusic.utils.playerTypeKey
+import it.fast4x.rimusic.utils.playlistindicatorKey
+import it.fast4x.rimusic.utils.positionAndDurationState
+import it.fast4x.rimusic.utils.queueDurationExpandedKey
+import it.fast4x.rimusic.utils.queueLoopTypeKey
+import it.fast4x.rimusic.utils.queueTypeKey
+import it.fast4x.rimusic.utils.rememberPreference
+import it.fast4x.rimusic.utils.resize
 import it.fast4x.rimusic.utils.seamlessPlay
+import it.fast4x.rimusic.utils.semiBold
+import it.fast4x.rimusic.utils.setQueueLoopState
+import it.fast4x.rimusic.utils.shouldBePlaying
+import it.fast4x.rimusic.utils.showButtonPlayerAddToPlaylistKey
+import it.fast4x.rimusic.utils.showButtonPlayerArrowKey
+import it.fast4x.rimusic.utils.showButtonPlayerDiscoverKey
+import it.fast4x.rimusic.utils.showButtonPlayerDownloadKey
+import it.fast4x.rimusic.utils.showButtonPlayerLoopKey
+import it.fast4x.rimusic.utils.showButtonPlayerLyricsKey
+import it.fast4x.rimusic.utils.showButtonPlayerMenuKey
+import it.fast4x.rimusic.utils.showButtonPlayerShuffleKey
+import it.fast4x.rimusic.utils.showButtonPlayerSleepTimerKey
+import it.fast4x.rimusic.utils.showButtonPlayerStartRadioKey
+import it.fast4x.rimusic.utils.showButtonPlayerSystemEqualizerKey
+import it.fast4x.rimusic.utils.showButtonPlayerVideoKey
+import it.fast4x.rimusic.utils.showCoverThumbnailAnimationKey
+import it.fast4x.rimusic.utils.showNextSongsInPlayerKey
+import it.fast4x.rimusic.utils.showTopActionsBarKey
+import it.fast4x.rimusic.utils.showTotalTimeQueueKey
+import it.fast4x.rimusic.utils.showalbumcoverKey
+import it.fast4x.rimusic.utils.showlyricsthumbnailKey
+import it.fast4x.rimusic.utils.showsongsKey
+import it.fast4x.rimusic.utils.showthumbnailKey
+import it.fast4x.rimusic.utils.showvisthumbnailKey
+import it.fast4x.rimusic.utils.shuffleQueue
+import it.fast4x.rimusic.utils.statsExpandedKey
+import it.fast4x.rimusic.utils.statsfornerdsKey
+import it.fast4x.rimusic.utils.swipeUpQueueKey
+import it.fast4x.rimusic.utils.tapqueueKey
+import it.fast4x.rimusic.utils.textoutlineKey
+import it.fast4x.rimusic.utils.thumbnail
 import it.fast4x.rimusic.utils.thumbnailFadeExKey
+import it.fast4x.rimusic.utils.thumbnailFadeKey
+import it.fast4x.rimusic.utils.thumbnailRoundnessKey
+import it.fast4x.rimusic.utils.thumbnailSpacingKey
 import it.fast4x.rimusic.utils.thumbnailSpacingLKey
+import it.fast4x.rimusic.utils.thumbnailTapEnabledKey
+import it.fast4x.rimusic.utils.thumbnailTypeKey
+import it.fast4x.rimusic.utils.timelineExpandedKey
+import it.fast4x.rimusic.utils.titleExpandedKey
 import it.fast4x.rimusic.utils.topPaddingKey
+import it.fast4x.rimusic.utils.transparentBackgroundPlayerActionBarKey
+import it.fast4x.rimusic.utils.visualizerEnabledKey
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.Float.Companion.POSITIVE_INFINITY
+import kotlin.math.absoluteValue
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -1305,7 +1304,8 @@ fun Player(
             position = positionAndDuration.first,
             duration = positionAndDuration.second,
             modifier = modifierValue,
-            onBlurScaleChange = { blurStrength = it }
+            onBlurScaleChange = { blurStrength = it },
+            isExplicit = mediaItem.isExplicit
         )
     }
     val textoutline by rememberPreference(textoutlineKey, false)
@@ -2477,7 +2477,8 @@ fun Player(
                                     duration = positionAndDuration.second,
                                     modifier = Modifier
                                         .padding(vertical = 8.dp),
-                                    onBlurScaleChange = { blurStrength = it }
+                                    onBlurScaleChange = { blurStrength = it },
+                                    isExplicit = mediaItem.isExplicit
                                 )
 
                     }
@@ -3008,7 +3009,8 @@ fun Player(
                                         .padding(vertical = 4.dp)
                                         .fillMaxWidth(),
                                             //.weight(1f),
-                                        onBlurScaleChange = { blurStrength = it }
+                                        onBlurScaleChange = { blurStrength = it },
+                                    isExplicit = mediaItem.isExplicit
                                 )
 
                     }

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Essential.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Essential.kt
@@ -52,7 +52,10 @@ import androidx.navigation.NavController
 import it.fast4x.rimusic.Database
 import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.R
+import it.fast4x.rimusic.appContext
 import it.fast4x.rimusic.cleanPrefix
+import it.fast4x.rimusic.colorPalette
+import it.fast4x.rimusic.context
 import it.fast4x.rimusic.enums.ButtonState
 import it.fast4x.rimusic.enums.ColorPaletteMode
 import it.fast4x.rimusic.enums.ColorPaletteName
@@ -64,15 +67,19 @@ import it.fast4x.rimusic.enums.QueueLoopType
 import it.fast4x.rimusic.models.Info
 import it.fast4x.rimusic.models.Song
 import it.fast4x.rimusic.models.ui.UiMedia
+import it.fast4x.rimusic.service.MyDownloadHelper
 import it.fast4x.rimusic.service.modern.PlayerServiceModern
+import it.fast4x.rimusic.typography
 import it.fast4x.rimusic.ui.components.themed.IconButton
 import it.fast4x.rimusic.ui.components.themed.SelectorArtistsDialog
 import it.fast4x.rimusic.ui.screens.player.bounceClick
 import it.fast4x.rimusic.ui.styling.favoritesIcon
+import it.fast4x.rimusic.utils.HorizontalfadingEdge2
 import it.fast4x.rimusic.utils.bold
 import it.fast4x.rimusic.utils.buttonStateKey
 import it.fast4x.rimusic.utils.colorPaletteModeKey
 import it.fast4x.rimusic.utils.colorPaletteNameKey
+import it.fast4x.rimusic.utils.conditional
 import it.fast4x.rimusic.utils.effectRotationKey
 import it.fast4x.rimusic.utils.getIconQueueLoopState
 import it.fast4x.rimusic.utils.getLikeState
@@ -90,13 +97,6 @@ import it.fast4x.rimusic.utils.setQueueLoopState
 import it.fast4x.rimusic.utils.showthumbnailKey
 import it.fast4x.rimusic.utils.textCopyToClipboard
 import it.fast4x.rimusic.utils.textoutlineKey
-import it.fast4x.rimusic.appContext
-import it.fast4x.rimusic.colorPalette
-import it.fast4x.rimusic.context
-import it.fast4x.rimusic.service.MyDownloadHelper
-import it.fast4x.rimusic.typography
-import it.fast4x.rimusic.utils.HorizontalfadingEdge2
-import it.fast4x.rimusic.utils.conditional
 
 
 @UnstableApi
@@ -112,6 +112,7 @@ fun InfoAlbumAndArtistEssential(
     likedAt: Long?,
     artistIds: List<Info>?,
     artist: String?,
+    isExplicit: Boolean,
     onCollapse: () -> Unit,
     disableScrollingText: Boolean = false
 ) {
@@ -157,23 +158,19 @@ fun InfoAlbumAndArtistEssential(
 
             if (!disableScrollingText) modifierTitle = modifierTitle.basicMarquee()
 
-            if (title?.startsWith(EXPLICIT_PREFIX) == true || playerControlsType == PlayerControlsType.Modern) {
-                Box(
-                    modifier = Modifier.weight(0.1f)
-                ) {
-                    if (title?.startsWith(EXPLICIT_PREFIX) == true) {
-                        if (title.startsWith(EXPLICIT_PREFIX))
-                            IconButton(
-                                icon = R.drawable.explicit,
-                                color = colorPalette().text,
-                                enabled = true,
-                                onClick = {},
-                                modifier = Modifier
-                                    .size(18.dp)
-                                    .align(Alignment.Center)
-                            )
-                    }
-                }
+            Box(
+                modifier = Modifier.weight(0.1f)
+            ) {
+                if ( isExplicit || playerControlsType == PlayerControlsType.Modern )
+                    IconButton(
+                        icon = R.drawable.explicit,
+                        color = colorPalette().text,
+                        enabled = true,
+                        onClick = {},
+                        modifier = Modifier
+                            .size(18.dp)
+                            .align(Alignment.Center)
+                    )
             }
 
             BoxWithConstraints(

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/components/controls/Modern.kt
@@ -47,9 +47,11 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.navigation.NavController
 import it.fast4x.rimusic.Database
-import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.R
+import it.fast4x.rimusic.appContext
 import it.fast4x.rimusic.cleanPrefix
+import it.fast4x.rimusic.colorPalette
+import it.fast4x.rimusic.context
 import it.fast4x.rimusic.enums.ColorPaletteMode
 import it.fast4x.rimusic.enums.NavRoutes
 import it.fast4x.rimusic.enums.PlayerBackgroundColors
@@ -58,7 +60,9 @@ import it.fast4x.rimusic.enums.PlayerPlayButtonType
 import it.fast4x.rimusic.models.Info
 import it.fast4x.rimusic.models.Song
 import it.fast4x.rimusic.models.ui.UiMedia
+import it.fast4x.rimusic.service.MyDownloadHelper
 import it.fast4x.rimusic.service.modern.PlayerServiceModern
+import it.fast4x.rimusic.typography
 import it.fast4x.rimusic.ui.components.themed.CustomElevatedButton
 import it.fast4x.rimusic.ui.components.themed.IconButton
 import it.fast4x.rimusic.ui.components.themed.SelectorArtistsDialog
@@ -83,11 +87,6 @@ import it.fast4x.rimusic.utils.setLikeState
 import it.fast4x.rimusic.utils.showthumbnailKey
 import it.fast4x.rimusic.utils.textCopyToClipboard
 import it.fast4x.rimusic.utils.textoutlineKey
-import it.fast4x.rimusic.appContext
-import it.fast4x.rimusic.colorPalette
-import it.fast4x.rimusic.context
-import it.fast4x.rimusic.service.MyDownloadHelper
-import it.fast4x.rimusic.typography
 
 
 @UnstableApi
@@ -102,6 +101,7 @@ fun InfoAlbumAndArtistModern(
     title: String?,
     likedAt: Long?,
     artistIds: List<Info>?,
+    isExplicit: Boolean,
     artist: String?,
     onCollapse: () -> Unit,
     disableScrollingText: Boolean = false
@@ -177,7 +177,7 @@ fun InfoAlbumAndArtistModern(
                 modifier = Modifier
                  .weight(1f)
             ) {
-                if (title?.startsWith(EXPLICIT_PREFIX) == true)
+                if ( isExplicit )
                     IconButton(
                         icon = R.drawable.explicit,
                         color = colorPalette().text,

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/searchresult/SearchResultScreen.kt
@@ -35,17 +35,18 @@ import it.fast4x.innertube.requests.albumPage
 import it.fast4x.innertube.requests.searchPage
 import it.fast4x.innertube.utils.from
 import it.fast4x.rimusic.Database
-import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.LocalPlayerServiceBinder
 import it.fast4x.rimusic.R
 import it.fast4x.rimusic.enums.NavRoutes
 import it.fast4x.rimusic.models.Album
 import it.fast4x.rimusic.models.SongAlbumMap
 import it.fast4x.rimusic.ui.components.LocalMenuState
+import it.fast4x.rimusic.ui.components.Skeleton
 import it.fast4x.rimusic.ui.components.SwipeableAlbumItem
 import it.fast4x.rimusic.ui.components.SwipeablePlaylistItem
 import it.fast4x.rimusic.ui.components.themed.NonQueuedMediaItemMenu
 import it.fast4x.rimusic.ui.components.themed.NowPlayingSongIndicator
+import it.fast4x.rimusic.ui.components.themed.SmartMessage
 import it.fast4x.rimusic.ui.components.themed.Title
 import it.fast4x.rimusic.ui.items.AlbumItem
 import it.fast4x.rimusic.ui.items.AlbumItemPlaceholder
@@ -61,7 +62,6 @@ import it.fast4x.rimusic.ui.styling.Dimensions
 import it.fast4x.rimusic.ui.styling.px
 import it.fast4x.rimusic.utils.addNext
 import it.fast4x.rimusic.utils.asMediaItem
-import it.fast4x.rimusic.utils.asSong
 import it.fast4x.rimusic.utils.disableScrollingTextKey
 import it.fast4x.rimusic.utils.enqueue
 import it.fast4x.rimusic.utils.forcePlay
@@ -80,8 +80,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import it.fast4x.rimusic.ui.components.Skeleton
-import it.fast4x.rimusic.ui.components.themed.SmartMessage
 
 @ExperimentalMaterialApi
 @ExperimentalTextApi
@@ -201,7 +199,7 @@ fun SearchResultScreen(
                                 headerContent = headerContent,
                                 itemContent = { song ->
                                     //Log.d("mediaItem",song.toString())
-                                    if (parentalControlEnabled && song.asSong.title.startsWith(EXPLICIT_PREFIX))
+                                    if (parentalControlEnabled && song.explicit)
                                         return@ItemsPage
 
                                     downloadState = getDownloadState(song.asMediaItem.mediaId)

--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Utils.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/utils/Utils.kt
@@ -28,6 +28,7 @@ import it.fast4x.innertube.requests.playlistPage
 import it.fast4x.innertube.utils.ProxyPreferences
 import it.fast4x.innertube.utils.getProxy
 import it.fast4x.rimusic.Database
+import it.fast4x.rimusic.EXPLICIT_PREFIX
 import it.fast4x.rimusic.cleanPrefix
 import it.fast4x.rimusic.models.Album
 import it.fast4x.rimusic.models.Song
@@ -43,6 +44,7 @@ import java.util.Date
 import java.util.GregorianCalendar
 import kotlin.time.Duration.Companion.minutes
 
+const val EXPLICIT_BUNDLE_TAG = "is_explicit"
 
 fun getDateTimeAsFormattedString(dateAsLongInMs: Long): String? {
     try {
@@ -168,6 +170,7 @@ val Innertube.SongItem.asMediaItem: MediaItem
                         "artistNames" to authors?.filter { it.endpoint != null }
                             ?.mapNotNull { it.name },
                         "artistIds" to authors?.mapNotNull { it.endpoint?.browseId },
+                        EXPLICIT_BUNDLE_TAG to explicit
                     )
                 )
                 .build()
@@ -223,7 +226,8 @@ val Song.asMediaItem: MediaItem
                 .setArtworkUri(thumbnailUrl?.toUri())
                 .setExtras(
                     bundleOf(
-                        "durationText" to durationText
+                        "durationText" to durationText,
+                        EXPLICIT_BUNDLE_TAG to title.startsWith( EXPLICIT_PREFIX, true )
                     )
                 )
                 .build()
@@ -249,7 +253,8 @@ val SongEntity.asMediaItem: MediaItem
                 .setArtworkUri(song.thumbnailUrl?.toUri())
                 .setExtras(
                     bundleOf(
-                        "durationText" to song.durationText
+                        "durationText" to song.durationText,
+                        EXPLICIT_BUNDLE_TAG to song.title.startsWith( EXPLICIT_PREFIX, true )
                     )
                 )
                 .build()
@@ -297,6 +302,14 @@ val MediaItem.cleaned: MediaItem
 
 val MediaItem.isVideo: Boolean
     get() = mediaMetadata.extras?.getBoolean("isVideo") == true
+
+val MediaItem.isExplicit: Boolean
+    get() {
+        val isTitleContain = mediaMetadata.title?.startsWith( EXPLICIT_PREFIX, true )
+        val isBundleContain = mediaMetadata.extras?.getBoolean( EXPLICIT_BUNDLE_TAG )
+
+        return isTitleContain == true || isBundleContain == true
+    }
 
 fun String.resize(
     width: Int? = null,

--- a/extensions/innertube/src/main/kotlin/it/fast4x/innertube/Innertube.kt
+++ b/extensions/innertube/src/main/kotlin/it/fast4x/innertube/Innertube.kt
@@ -141,7 +141,7 @@ object Innertube {
     internal const val searchSuggestions = "/youtubei/v1/music/get_search_suggestions"
     internal const val accountMenu = "/youtubei/v1/account/account_menu"
 
-    internal const val musicResponsiveListItemRendererMask = "musicResponsiveListItemRenderer(flexColumns,fixedColumns,thumbnail,navigationEndpoint)"
+    internal const val musicResponsiveListItemRendererMask = "musicResponsiveListItemRenderer(flexColumns,fixedColumns,thumbnail,navigationEndpoint,badges)"
     internal const val musicTwoRowItemRendererMask = "musicTwoRowItemRenderer(thumbnailRenderer,title,subtitle,navigationEndpoint)"
     const val playlistPanelVideoRendererMask = "playlistPanelVideoRenderer(title,navigationEndpoint,longBylineText,shortBylineText,thumbnail,lengthText)"
 

--- a/extensions/innertube/src/main/kotlin/it/fast4x/innertube/utils/FromMusicShelfRendererContent.kt
+++ b/extensions/innertube/src/main/kotlin/it/fast4x/innertube/utils/FromMusicShelfRendererContent.kt
@@ -24,6 +24,12 @@ fun Innertube.SongItem.Companion.from(content: MusicShelfRenderer.Content): Inne
         }
         ?.let(Innertube::Info)
 
+    val isExplicit = content.musicResponsiveListItemRenderer
+                                      ?.badges
+                                      ?.any {
+                                          it.musicInlineBadgeRenderer?.icon?.iconType == "MUSIC_EXPLICIT_BADGE"
+                                      } ?: false
+
     return Innertube.SongItem(
         info = mainRuns
             .firstOrNull()
@@ -36,7 +42,8 @@ fun Innertube.SongItem.Companion.from(content: MusicShelfRenderer.Content): Inne
             .lastOrNull()
             ?.firstOrNull()?.text,
         thumbnail = content
-            .thumbnail
+            .thumbnail,
+        explicit = isExplicit
     ).takeIf { it.info?.endpoint?.videoId != null }
 }
 


### PR DESCRIPTION
I couldn't find where the title located in Player due to my limited free time.

But if you want to here's the formula:

> Extract `is_explicit` boolean from bundle (extra) if it's `MediaItem`

```kotlin
val isExplicit = MediaItem#mediaMetadata.extras?.getBoolean("is_explicit") == true
```

> Use `EXPLICIT_PREFIX` for other cases

```kotlin
val isExplicit = String#startsWith(EXPLICIT_PREFIX, true)
```