### PR TITLE
would fix #5172 but maybe it is intentional

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPage.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/statistics/StatisticsPage.kt
@@ -184,9 +184,7 @@ fun StatisticsPage(
 
     var totalPlayTimes = 0L
     allSongs.forEach {
-        totalPlayTimes += it.durationText?.let { it1 ->
-            durationTextToMillis(it1)
-        }?.toLong() ?: 0
+        totalPlayTimes += it.totalPlayTimeMs
     }
 
     if (showStatsListeningTime) {


### PR DESCRIPTION
Currently it shows the added duration of the listened songs instead of the total listening time. I don't know if this is intentional, but it was noticed in #5172.

fixes #5172.