### PR TITLE
Implemented an improved `cleanPrefix` method

### DIFF
--- a/composeApp/src/commonMain/kotlin/it/fast4x/rimusic/Utils.kt
+++ b/composeApp/src/commonMain/kotlin/it/fast4x/rimusic/Utils.kt
@@ -11,19 +11,22 @@ const val EXPLICIT_PREFIX = "e:"
 const val LOCAL_KEY_PREFIX = "local:"
 const val YTP_PREFIX = "account:"
 
+/**
+ * Assumption: all prefixes end with ":" and have at least 1 (other) character.
+ * Removes a "prefix of prefixes" including multiple times the same prefix (at different locations).
+ */
 fun cleanPrefix(text: String): String {
-    val cleanText = text.replace(PINNED_PREFIX, "", true)
-        .replace(MONTHLY_PREFIX, "", true)
-        .replace(PIPED_PREFIX, "", true)
-        .replace(EXPLICIT_PREFIX, "", true)
-        .replace(MODIFIED_PREFIX, "", true)
-        .replace(YTP_PREFIX, "", true)
-//    var cleanText = text.substringAfter(PINNED_PREFIX)
-//    cleanText = cleanText.substringAfter(MONTHLY_PREFIX)
-//    cleanText = cleanText.substringAfter(PIPED_PREFIX)
-//    cleanText = cleanText.substringAfter(EXPLICIT_PREFIX)
-//    cleanText = cleanText.substringAfter(MODIFIED_PREFIX)
-    return cleanText
+    val splitText = text.split(":")
+    var i = 0
+    while (i < splitText.size-1) {
+        if ("${splitText[i]}:" !in listOf(PINNED_PREFIX, MODIFIED_PREFIX, MONTHLY_PREFIX, PIPED_PREFIX,
+                EXPLICIT_PREFIX, YTP_PREFIX)) {
+            break
+        }
+        i++
+    }
+    if(i >= splitText.size) return ""
+    return splitText.subList(i, splitText.size).joinToString(":")
 }
 
 fun cleanString(text: String): String {

--- a/composeApp/src/commonMain/kotlin/it/fast4x/rimusic/Utils.kt
+++ b/composeApp/src/commonMain/kotlin/it/fast4x/rimusic/Utils.kt
@@ -20,7 +20,7 @@ fun cleanPrefix(text: String): String {
     var i = 0
     while (i < splitText.size-1) {
         if ("${splitText[i]}:" !in listOf(PINNED_PREFIX, MODIFIED_PREFIX, MONTHLY_PREFIX, PIPED_PREFIX,
-                EXPLICIT_PREFIX, YTP_PREFIX)) {
+                EXPLICIT_PREFIX, LOCAL_KEY_PREFIX, YTP_PREFIX)) {
             break
         }
         i++


### PR DESCRIPTION
- it **only** considers a prefix of prefixes, so if something breaks the "chain", following sub-strings will not be considered as prefix
- a prefix can still be included multiple times (feature?)
- only exact matches will be removed
- it can reconstruct texts with ":" in it
- examples:
    - "hi:e:" will not be changed
    - "e:e:" will be ""
    - "pinned:h:e:" will be "h:e:"
    - "e:e:e:e:g" will be "g"

My test has shown it is a bit slower than the old method (about 10-50%) but only if the "colon-to-other-characters" ratio is high. If it is low, it can be ~40% faster.

Note: my test was not very scientific.

A demo can be found [here](https://pl.kotl.in/5P_ogrnxN).

Fixes https://github.com/fast4x/RiMusic/issues/5568 (at least most of the problem including "e:")