### PR TITLE
Fix volume resetting on automatic track change

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/PlayerServiceModern.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/service/modern/PlayerServiceModern.kt
@@ -957,7 +957,6 @@ class PlayerServiceModern : MediaLibraryService(),
             loudnessEnhancer?.release()
             loudnessEnhancer = null
             volumeNormalizationJob?.cancel()
-            player.volume = 1f
             return
         }
 


### PR DESCRIPTION
Turns out, `maybeNormalizeVolume()` is changing player's volume to 100% every time.

This PR fixes the last issue with the persistence of a "Playback volume" parameter