### PR TITLE
fixed modern queue lag

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/rimusic/ui/screens/player/Player.kt
@@ -2021,7 +2021,17 @@ fun Player(
 
         if (isLandscape) {
          Box(
-             modifier = Modifier.haze(state = hazeState, style = HazeDefaults.style(backgroundColor = Color.Transparent, tint = Color.Black.copy(0.5f),blurRadius = 8.dp))
+             modifier = Modifier
+                 .conditional(queueType == QueueType.Modern) {
+                     haze(
+                         state = hazeState,
+                         style = HazeDefaults.style(
+                             backgroundColor = Color.Transparent,
+                             tint = if (lightTheme) Color.White.copy(0.5f) else Color.Black.copy(0.5f),
+                             blurRadius = 8.dp
+                         )
+                     )
+                 }
          ){
              if (playerBackgroundColors == PlayerBackgroundColors.BlurredCoverColor && playerType == PlayerType.Modern && (!showthumbnail || albumCoverRotation)) {
                  val fling = PagerDefaults.flingBehavior(
@@ -2614,7 +2624,17 @@ fun Player(
          }
         } else {
            Box(
-               modifier = Modifier.haze(state = hazeState, style = HazeDefaults.style(backgroundColor = Color.Transparent, tint = Color.Black.copy(0.5f),blurRadius = 8.dp))
+               modifier = Modifier
+                   .conditional(queueType == QueueType.Modern) {
+                       haze(
+                           state = hazeState,
+                           style = HazeDefaults.style(
+                               backgroundColor = Color.Transparent,
+                               tint = if (lightTheme) Color.White.copy(0.5f) else Color.Black.copy(0.5f),
+                               blurRadius = 8.dp
+                           )
+                       )
+                   }
            ) {
                if (playerBackgroundColors == PlayerBackgroundColors.BlurredCoverColor && playerType == PlayerType.Modern && (!showthumbnail || albumCoverRotation)) {
                     val fling = PagerDefaults.flingBehavior(
@@ -3322,7 +3342,7 @@ fun Player(
             contentColor = if (queueType == QueueType.Modern) Color.Transparent else colorPalette().background2,
             modifier = Modifier
                 .fillMaxWidth()
-                .hazeChild(state = hazeState),
+                .conditional(queueType == QueueType.Modern) {hazeChild(state = hazeState)},
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
             dragHandle = {
                 Surface(
@@ -3352,7 +3372,7 @@ fun Player(
             contentColor = if (playerType == PlayerType.Modern) Color.Transparent else colorPalette().background2,
             modifier = Modifier
                 .fillMaxWidth()
-                .hazeChild(state = hazeState),
+                .conditional(queueType == QueueType.Modern) {hazeChild(state = hazeState)},
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
             dragHandle = {
                 Surface(


### PR DESCRIPTION
The player was always blurred when the queue was opened even when the essential queue was selected which resulted in queue lag.

now the player won't be blurred if you use the essential queue